### PR TITLE
Sneedergy Tweaks

### DIFF
--- a/maps/synergy.dmm
+++ b/maps/synergy.dmm
@@ -1387,11 +1387,14 @@
 /area/maintenance/fpmaint2)
 "acQ" = (
 /obj/item/weapon/stock_parts/manipulator,
-/obj/item/device/mining_scanner,
 /obj/structure/closet/crate{
 	icon_state = "crateopen";
 	opened = 1
 	},
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/stock_parts/micro_laser,
+/obj/item/weapon/stock_parts/scanning_module,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
 "acR" = (
@@ -2475,6 +2478,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/mannequin/corgi,
+/obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
 "afh" = (
@@ -3085,7 +3090,7 @@
 	tag = "icon-warning (EAST)"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2)
+/area/security/medical)
 "agm" = (
 /turf/simulated/wall/r_wall,
 /area/security/range{
@@ -3398,7 +3403,7 @@
 	req_access_txt = "1"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2)
+/area/hallway/secondary/exit)
 "agS" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3416,7 +3421,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
 "agU" = (
-/obj/machinery/space_heater/air_conditioner,
+/obj/effect/decal/cleanable/vomit/pre_dry,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
 "agV" = (
@@ -6176,6 +6181,12 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint3)
@@ -9216,8 +9227,8 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -9988,13 +9999,9 @@
 	},
 /area/storage/tools)
 "arX" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/storage/tools)
+/obj/item/device/flashlight,
+/turf/space,
+/area)
 "arY" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/mineral/plastic{
@@ -10191,9 +10198,12 @@
 /turf/simulated/floor,
 /area/janitor)
 "aso" = (
-/obj/structure/ore_box,
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/item/toy/balloon/glove,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2)
+/area/maintenance/fsmaint2)
 "asp" = (
 /obj/structure/closet,
 /obj/item/device/flash,
@@ -12242,6 +12252,7 @@
 	dir = 4
 	},
 /obj/machinery/light/small,
+/obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint3)
 "avY" = (
@@ -12351,9 +12362,7 @@
 	},
 /area/storage/tools)
 "awi" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	name = "Air Vent (2)"
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor{
 	icon_state = "neutral"
 	},
@@ -12365,11 +12374,7 @@
 /turf/simulated/floor,
 /area/storage/tools)
 "awk" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
 	icon_state = "neutral"
 	},
@@ -13234,16 +13239,17 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor/plating,
 /area/storage/tools)
 "axy" = (
 /obj/machinery/door/airlock/glass{
 	name = "Auxiliary Tool Storage"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor/border_only{
 	name = "Firelock South"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor,
 /area/storage/tools)
 "axz" = (
@@ -13256,11 +13262,7 @@
 	dir = 1;
 	pixel_y = 1
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor/plating,
 /area/storage/tools)
 "axA" = (
@@ -13995,26 +13997,19 @@
 /turf/simulated/floor,
 /area/hallway/primary/port)
 "ayJ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
 	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
 "ayK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/simulated/floor,
 /area/hallway/primary/port)
 "ayL" = (
@@ -14688,13 +14683,11 @@
 /turf/simulated/floor,
 /area/hallway/primary/port)
 "aAb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/firedoor/border_only{
+	name = "Firelock South"
 	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
@@ -15462,18 +15455,11 @@
 /turf/simulated/floor,
 /area/hallway/primary/port)
 "aBB" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/closet/emcloset,
+/turf/simulated/floor{
+	icon_state = "dark vault full"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
-/area/hallway/primary/port)
+/area/hallway/secondary/exit)
 "aBC" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -17086,6 +17072,10 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced,
+/obj/structure/sign/poster{
+	icon_state = "vgposter2";
+	pixel_x = -32
+	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -22458,6 +22448,12 @@
 	icon_state = "warning";
 	tag = "icon-warning (WEST)"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "brown"
@@ -22797,6 +22793,9 @@
 	d2 = 2;
 	icon_state = "1-2";
 	tag = ""
+	},
+/obj/machinery/door/firedoor/border_only{
+	name = "Firelock South"
 	},
 /turf/simulated/floor,
 /area/hallway/primary/central)
@@ -23257,19 +23256,24 @@
 	codes_txt = "patrol;next_patrol=Chap1";
 	location = "ZooN2"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
 "aOB" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
@@ -23848,6 +23852,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/structure/closet/wardrobe/pjs,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "aPp" = (
@@ -24399,12 +24404,6 @@
 	},
 /area/hallway/primary/port)
 "aQn" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /obj/structure/disposalpipe/sortjunction/HoP{
 	dir = 1
 	},
@@ -25400,12 +25399,6 @@
 "aRL" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /obj/machinery/status_display{
 	pixel_x = 32;
 	pixel_y = -32
@@ -26147,12 +26140,6 @@
 /area/hallway/primary/port)
 "aTh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
 	dir = 8;
@@ -27029,12 +27016,6 @@
 "aUO" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	name = "_East Fire Alarm";
@@ -27249,16 +27230,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "aVm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fsmaint2)
+/area/maintenance/starboard)
 "aVn" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -27857,12 +27836,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
 "aWp" = (
@@ -28037,19 +28010,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
 	},
 /turf/simulated/floor,
 /area/hallway/primary/central)
@@ -28154,12 +28122,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "aWP" = (
-/obj/structure/grille/broken,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/structure/falsewall/closed,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "aWQ" = (
@@ -28727,12 +28690,6 @@
 /turf/simulated/floor,
 /area/hallway/primary/port)
 "aXN" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
@@ -29094,7 +29051,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fsmaint2)
+/area/crew_quarters/courtroom)
 "aYs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -29104,6 +29061,12 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -29122,17 +29085,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "aYv" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
-/area/maintenance/fsmaint2)
+/area/maintenance/fpmaint2)
 "aYw" = (
 /obj/machinery/shower{
 	dir = 8
 	},
+/obj/item/weapon/soap/deluxe,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "aYx" = (
@@ -29840,13 +29800,19 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/courtroom)
 "aZG" = (
-/obj/machinery/power/apc{
-	name = "_South APC";
-	pixel_y = -24
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/fsmaint2)
+/area/maintenance/fpmaint3)
 "aZH" = (
 /turf/simulated/wall,
 /area/supply/storage)
@@ -31137,12 +31103,6 @@
 /area/engineering/break_room)
 "bbI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /obj/structure/disposalpipe/sortjunction/Atmos{
 	dir = 1;
 	icon_state = "pipe-j2s"
@@ -31316,12 +31276,6 @@
 /turf/simulated/floor,
 /area/hallway/primary/central)
 "bcb" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /obj/machinery/door/firedoor/border_only{
 	name = "Firelock South"
 	},
@@ -31366,6 +31320,12 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Office Maintenance";
 	req_access_txt = "31"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -31847,12 +31807,6 @@
 /area/engineering/break_room)
 "bcV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /obj/structure/disposalpipe/sortjunction/Engineering{
 	dir = 1;
 	icon_state = "pipe-j2s"
@@ -32067,12 +32021,6 @@
 	},
 /area/hallway/primary/central)
 "bdo" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
-	},
 /obj/machinery/status_display{
 	pixel_x = 32;
 	pixel_y = 32
@@ -32082,11 +32030,6 @@
 "bdp" = (
 /obj/machinery/camera{
 	name = "Central Primary Hallway 2"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/hallway/primary/central)
@@ -32099,12 +32042,6 @@
 /turf/simulated/floor,
 /area/hallway/primary/central)
 "bdr" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -32193,11 +32130,11 @@
 	name = "_North APC";
 	pixel_y = 24
 	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/structure/filingcabinet/filingcabinet,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor,
 /area/supply/office)
 "bdA" = (
@@ -32205,6 +32142,17 @@
 	dir = 8;
 	name = "Air Alarm (8)";
 	pixel_x = 24
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor,
 /area/supply/office)
@@ -32787,12 +32735,6 @@
 /area/engineering/break_room)
 "beu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
 	dir = 4
@@ -33115,13 +33057,8 @@
 /turf/simulated/floor,
 /area/supply/office)
 "beU" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/supply/office)
+/turf/simulated/floor/glass/airless,
+/area/maintenance/port)
 "beV" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -33940,6 +33877,12 @@
 /area/supply/office)
 "bgj" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor,
 /area/supply/office)
 "bgk" = (
@@ -34561,18 +34504,16 @@
 /turf/simulated/floor,
 /area/supply/office)
 "bhq" = (
+/turf/simulated/wall,
+/area/maintenance/apmaint)
+"bhr" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "1-2";
+	tag = ""
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/supply/office)
-"bhr" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/simulated/floor,
 /area/supply/office)
 "bhs" = (
@@ -34919,13 +34860,17 @@
 	},
 /area/engineering/atmos)
 "bhX" = (
-/obj/item/device/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -28
-	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "_West APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -35005,12 +34950,6 @@
 /turf/simulated/floor,
 /area/hallway/primary/port)
 "bif" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -35360,8 +35299,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -35370,40 +35308,40 @@
 	},
 /area/hallway/primary/central)
 "biH" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
 	},
 /turf/simulated/floor,
 /area/hallway/primary/central)
 "biI" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/sortjunction/QM/mirrored,
-/turf/simulated/floor,
-/area/hallway/primary/central)
-"biJ" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/turf/simulated/floor,
+/area/hallway/primary/central)
+"biJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/hallway/primary/central)
@@ -35411,11 +35349,6 @@
 /obj/machinery/door/airlock/glass_mining{
 	name = "Cargo Office";
 	req_access_txt = "31"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -35427,28 +35360,28 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/supply/office)
-"biL" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/turf/simulated/floor,
+/area/supply/office)
+"biL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/supply/office)
-"biM" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/turf/simulated/floor,
+/area/supply/office)
+"biM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -35456,45 +35389,49 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/supply/office)
-"biN" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/turf/simulated/floor,
+/area/supply/office)
+"biN" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/supply/office)
 "biO" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
 	},
 /turf/simulated/floor,
 /area/supply/office)
@@ -35848,17 +35785,19 @@
 /turf/simulated/wall/r_wall,
 /area/engineering/atmos)
 "bjn" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "_West APC";
-	pixel_x = -25
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -35866,11 +35805,6 @@
 /area/engineering/break_room)
 "bjo" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -35889,11 +35823,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4;
 	name = "Firelock East"
@@ -35903,56 +35832,33 @@
 	},
 /area/engineering/break_room)
 "bjq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/hallway/primary/port)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/port)
 "bjr" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
 "bjs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/sign/poster{
+	icon_state = "poster4";
+	pixel_y = -32
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/turf/simulated/floor{
+	icon_state = "white"
 	},
-/turf/simulated/floor,
-/area/hallway/primary/port)
+/area/science/hallway)
 "bjt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/item/device/radio/intercom{
 	broadcasting = 1;
 	dir = 8;
 	listening = 0;
 	name = "Station Intercom (General)";
 	pixel_x = 28
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
@@ -36528,11 +36434,6 @@
 "bks" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
 "bkt" = (
@@ -36858,6 +36759,12 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -36926,6 +36833,7 @@
 /area/engineering/break_room)
 "blh" = (
 /obj/machinery/light,
+/obj/structure/closet/emcloset,
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "brown"
@@ -37343,15 +37251,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard2)
 "blW" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
-	},
-/obj/abstract/map/spawner/assistant/materials,
-/obj/abstract/map/spawner/assistant/materials,
-/obj/abstract/map/spawner/assistant/materials,
-/obj/item/clothing/head/hardhat/red,
-/obj/item/clothing/glasses/scanner/meson,
+/obj/structure/ore_box,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard2)
 "blX" = (
@@ -37378,7 +37278,10 @@
 /obj/item/device/assembly/voice,
 /obj/item/tool/weldingtool/hugetank,
 /obj/structure/grille/broken,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg1";
+	tag = "icon-platingdmg1"
+	},
 /area/maintenance/starboard2)
 "bmd" = (
 /obj/structure/grille,
@@ -37506,10 +37409,16 @@
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "11;24"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/maintenance/port)
+/area/engineering/break_room)
 "bms" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -37530,19 +37439,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
+	d1 = 2;
 	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
-	d1 = 1;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "2-8";
+	tag = ""
 	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
@@ -38221,7 +38126,7 @@
 	req_access_txt = "31"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/starboard2)
+/area/supply/storage)
 "bnO" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -38308,7 +38213,7 @@
 	dir = 5;
 	icon_state = "vault"
 	},
-/area/maintenance/port)
+/area/engineering/atmos)
 "bnW" = (
 /turf/simulated/wall,
 /area/maintenance/port)
@@ -38524,6 +38429,9 @@
 	icon_state = "1-2";
 	tag = ""
 	},
+/obj/machinery/door/firedoor/border_only{
+	name = "Firelock South"
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "yellowsiding";
@@ -38540,6 +38448,9 @@
 	icon_state = "1-2";
 	tag = ""
 	},
+/obj/machinery/door/firedoor/border_only{
+	name = "Firelock South"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "yellowsiding";
@@ -38552,6 +38463,9 @@
 	dir = 4;
 	name = "_East Fire Alarm";
 	pixel_x = 26
+	},
+/obj/machinery/door/firedoor/border_only{
+	name = "Firelock South"
 	},
 /turf/simulated/floor,
 /area/hallway/primary/central)
@@ -38794,6 +38708,9 @@
 	dir = 8;
 	name = "Air Vent (8)"
 	},
+/obj/machinery/door/firedoor/border_only{
+	name = "Firelock South"
+	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
 "boW" = (
@@ -38804,6 +38721,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor/border_only{
+	name = "Firelock South"
+	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
 "boX" = (
@@ -39093,9 +39013,7 @@
 	},
 /area/hallway/primary/starboard)
 "bpy" = (
-/obj/machinery/atm{
-	pixel_x = 32
-	},
+/obj/structure/closet/emcloset,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -39507,6 +39425,10 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	name = "Firelock East"
+	},
 /turf/simulated/floor,
 /area/hallway/primary/aft)
 "bqb" = (
@@ -39566,12 +39488,12 @@
 /obj/machinery/door/airlock/glass{
 	name = "Central Access"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	name = "Firelock East"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8;
+	name = "Firelock West"
 	},
 /turf/simulated/floor,
 /area/hallway/primary/central)
@@ -39805,6 +39727,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/atm{
+	pixel_x = 32
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -39818,7 +39743,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor/plating,
-/area/maintenance/starboard2)
+/area/crew_quarters/fitness)
 "bqG" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -40060,6 +39985,10 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	name = "Air Vent (2)"
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	name = "Firelock East"
+	},
 /turf/simulated/floor,
 /area/hallway/primary/aft)
 "bre" = (
@@ -40098,8 +40027,8 @@
 	name = "Central Access"
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	name = "Firelock East"
+	dir = 8;
+	name = "Firelock West"
 	},
 /turf/simulated/floor,
 /area/hallway/primary/central)
@@ -40147,12 +40076,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1;
 	name = "Air Scrubber (1)"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
 	},
 /turf/simulated/floor,
 /area/hallway/primary/central)
@@ -40717,12 +40640,12 @@
 /obj/machinery/door/airlock/glass{
 	name = "Central Access"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	name = "Firelock East"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8;
+	name = "Firelock West"
 	},
 /turf/simulated/floor,
 /area/hallway/primary/central)
@@ -40732,16 +40655,18 @@
 /turf/simulated/floor,
 /area/hallway/primary/central)
 "bst" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/firedoor/border_only{
+	dir = 8;
+	name = "Firelock West"
 	},
 /turf/simulated/floor,
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "bsu" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/simulated/floor,
@@ -41239,11 +41164,6 @@
 	dir = 1;
 	name = "Firelock North"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "btx" = (
@@ -41740,16 +41660,6 @@
 /obj/machinery/camera{
 	name = "Kitchen North"
 	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "_East APC";
-	pixel_x = 27;
-	pixel_y = 2
-	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -41790,13 +41700,9 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "buH" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/bar)
+/obj/machinery/portable_atmospherics/pump,
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint2)
 "buI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor/carpet,
@@ -42377,17 +42283,13 @@
 	},
 /area/crew_quarters/kitchen)
 "bvL" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+/obj/structure/sign/poster{
+	icon_state = "poster3";
+	pixel_y = 32
 	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/kitchen)
+/obj/structure/closet/boxinggloves,
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint2)
 "bvM" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -42428,48 +42330,30 @@
 "bvR" = (
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4";
+	d2 = 2;
+	icon_state = "1-2";
 	tag = ""
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint3)
 "bvS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	name = "Firelock East"
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
+/turf/simulated/floor{
+	icon_state = "purple"
+	},
+/area/hallway/primary/aft)
 "bvT" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint2)
 "bvU" = (
 /obj/machinery/camera{
 	dir = 8;
 	name = "Bar North East"
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "_East APC";
-	pixel_x = 27;
-	pixel_y = 2
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -42708,7 +42592,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor/plating,
-/area/maintenance/starboard2)
+/area/crew_quarters/fitness)
 "bwp" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -42855,9 +42739,8 @@
 /turf/simulated/floor/glass/plasma,
 /area/science/hallway)
 "bwI" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/item/weapon/stool,
+/obj/abstract/map/spawner/floorpill,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bwJ" = (
@@ -43104,12 +42987,6 @@
 "bxg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -43744,12 +43621,6 @@
 	},
 /area/crew_quarters/kitchen)
 "bys" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor{
 	dir = 5;
@@ -43795,12 +43666,6 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "byy" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -44266,12 +44131,6 @@
 /area/crew_quarters/kitchen)
 "bzy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -44531,7 +44390,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor/plating,
-/area/maintenance/starboard2)
+/area/security/checkpoint2)
 "bzY" = (
 /turf/simulated/wall,
 /area/security/checkpoint2)
@@ -44962,12 +44821,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
-	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -44982,11 +44835,6 @@
 	dir = 4;
 	name = "Firelock East"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/light_switch{
 	name = "_South light switch";
 	pixel_y = -27
@@ -45000,53 +44848,25 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bAR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
+/obj/machinery/power/treadmill,
+/turf/simulated/floor/plating,
+/area/maintenance/port)
 "bAS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
-	d1 = 4;
+	d1 = 1;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
+/turf/simulated/floor/plating,
+/area/maintenance/port)
 "bAT" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
-	},
 /turf/simulated/floor/wood{
 	broken = 1;
 	icon_state = "wood-broken6"
@@ -45066,8 +44886,11 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bAW" = (
-/obj/machinery/space_heater,
 /obj/abstract/map/spawner/floorpill,
+/obj/item/firedoor_frame,
+/obj/item/firedoor_frame,
+/obj/item/firedoor_frame,
+/obj/structure/rack,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
 "bAX" = (
@@ -45553,7 +45376,6 @@
 	icon_state = "warning";
 	tag = "icon-warning (EAST)"
 	},
-/obj/structure/closet/emcloset,
 /turf/simulated/floor,
 /area/hallway/secondary/entry)
 "bBP" = (
@@ -45902,12 +45724,6 @@
 "bCA" = (
 /obj/item/weapon/stool/bar,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -46558,12 +46374,6 @@
 "bDL" = (
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	icon_state = "grimy"
@@ -47348,12 +47158,6 @@
 /area/crew_quarters/bar)
 "bFr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	icon_state = "grimy"
@@ -47890,11 +47694,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
 "bGx" = (
@@ -47910,11 +47709,6 @@
 "bGy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/gateway)
@@ -48434,7 +48228,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/bed/chair,
+/obj/structure/closet/emcloset,
 /turf/simulated/floor,
 /area/hallway/secondary/entry)
 "bHA" = (
@@ -48577,6 +48371,9 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/door/firedoor/border_only{
+	name = "Firelock South"
+	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
 "bHS" = (
@@ -48589,6 +48386,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/door/firedoor/border_only{
+	name = "Firelock South"
 	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
@@ -48609,6 +48409,12 @@
 "bHU" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	name = "Air Vent (2)"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
 	},
 /turf/simulated/floor,
 /area/gateway)
@@ -48863,12 +48669,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	icon_state = "grimy"
@@ -49078,7 +48878,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "bIO" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
@@ -49164,13 +48964,15 @@
 /area/hallway/secondary/exit)
 "bIY" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "_North APC";
-	pixel_y = 24
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -49191,6 +48993,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/closet/emcloset,
 /turf/simulated/floor,
 /area/hallway/secondary/entry)
 "bJc" = (
@@ -49269,21 +49072,11 @@
 /turf/simulated/floor/glass/plasma,
 /area/science/hallway)
 "bJk" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor,
-/area/hallway/primary/port)
+/obj/item/device/flashlight/flare/ever_bright,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/ash,
+/turf/simulated/floor/plating,
+/area/maintenance/port)
 "bJl" = (
 /obj/machinery/light{
 	dir = 1
@@ -49320,6 +49113,11 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
@@ -49361,6 +49159,12 @@
 	req_access_txt = "62"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor,
 /area/gateway)
 "bJr" = (
@@ -49879,22 +49683,12 @@
 	icon_state = "1-8";
 	tag = ""
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/simulated/floor,
 /area/hallway/primary/starboard)
 "bKo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Med2";
@@ -50076,11 +49870,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -50115,6 +49904,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
 	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
@@ -50159,7 +49954,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/port)
+/area/hallway/primary/port)
 "bKP" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -50171,6 +49966,12 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -50185,6 +49986,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -50291,19 +50097,9 @@
 /area/hallway/primary/aft)
 "bKZ" = (
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/hallway/primary/aft)
@@ -50317,60 +50113,48 @@
 	dir = 4;
 	tag = ""
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/hydroponics)
 "bLb" = (
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
 	},
 /turf/simulated/floor,
-/area/hydroponics)
+/area/supply/office)
 "bLc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/simulated/floor,
-/area/hydroponics)
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/maintenance/port)
 "bLd" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8";
+	tag = ""
 	},
-/turf/simulated/floor,
-/area/hydroponics)
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint3)
 "bLe" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/closet/crate{
+	icon_state = "crateopen";
+	opened = 1
 	},
-/turf/simulated/floor,
-/area/hydroponics)
+/obj/abstract/map/spawner/assistant/materials,
+/obj/abstract/map/spawner/assistant/materials,
+/obj/abstract/map/spawner/assistant/materials,
+/obj/item/clothing/glasses/scanner/meson,
+/turf/simulated/floor/plating,
+/area/maintenance/port)
 "bLf" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "_East APC";
-	pixel_x = 27;
-	pixel_y = 2
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "green"
@@ -50647,20 +50431,11 @@
 /turf/simulated/floor,
 /area/hallway/primary/starboard)
 "bLI" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
-	},
-/turf/simulated/floor,
-/area/hallway/primary/starboard)
+/obj/structure/table/woodentable,
+/obj/item/device/paicard,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "bLJ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/light,
 /turf/simulated/floor,
 /area/hallway/primary/starboard)
@@ -50677,11 +50452,6 @@
 	dir = 8;
 	name = "Firelock West"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor,
 /area/hallway/primary/starboard)
 "bLL" = (
@@ -50689,24 +50459,17 @@
 	dir = 1;
 	name = "Arrivals Checkpoint"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/hallway/primary/starboard)
-"bLM" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	name = "_South APC";
-	pixel_y = -24
-	},
 /turf/simulated/floor,
 /area/hallway/secondary/entry)
+"bLM" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/port)
 "bLN" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -50826,14 +50589,12 @@
 /turf/simulated/floor,
 /area/hallway/primary/port)
 "bMd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	name = "Firelock East"
 	},
 /turf/simulated/floor,
-/area/hallway/primary/port)
+/area/hallway/secondary/entry)
 "bMe" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4;
@@ -50905,16 +50666,17 @@
 /turf/simulated/floor,
 /area/hallway/primary/aft)
 "bMm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "1-2";
+	tag = ""
 	},
-/turf/simulated/floor,
-/area/hallway/primary/aft)
+/turf/simulated/floor/plating,
+/area/storage/tools)
 "bMn" = (
 /obj/machinery/door/airlock/glass{
 	name = "Hydroponics";
@@ -50969,12 +50731,22 @@
 	name = "Kitchen Delivery";
 	req_access_txt = "28"
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
 /area/crew_quarters/kitchen)
 "bMu" = (
 /obj/machinery/light,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -50993,6 +50765,16 @@
 /obj/item/weapon/soap,
 /obj/item/device/radio/headset/headset_service,
 /obj/item/tool/wrench,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "_East APC";
+	pixel_x = 27;
+	pixel_y = 2
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -51454,12 +51236,6 @@
 	name = "Chapel"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1;
 	name = "Firelock North"
@@ -51506,6 +51282,12 @@
 	name = "Firelock North"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/carpet,
 /area/chapel/main)
 "bNy" = (
@@ -51671,6 +51453,12 @@
 	freq = 1400;
 	location = "Kitchen"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/kitchen)
 "bNO" = (
@@ -51683,7 +51471,7 @@
 /turf/simulated/floor{
 	icon_state = "dark vault full"
 	},
-/area/maintenance/apmaint)
+/area/crew_quarters/kitchen)
 "bNP" = (
 /obj/structure/closet/secure_closet/bar,
 /turf/simulated/floor/wood,
@@ -51697,12 +51485,6 @@
 /area/crew_quarters/bar)
 "bNR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -52324,11 +52106,6 @@
 /turf/simulated/floor,
 /area/hallway/primary/port)
 "bOX" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/light_switch{
 	name = "_North light switch";
 	pixel_y = 27
@@ -52342,74 +52119,67 @@
 	},
 /area/chapel/main)
 "bOY" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/turf/simulated/floor/carpet,
-/area/chapel/main)
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	name = "Firelock East"
+	},
+/turf/simulated/floor,
+/area/hallway/secondary/entry)
 "bOZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4";
+	d2 = 2;
+	icon_state = "1-2";
 	tag = ""
 	},
-/turf/simulated/floor/carpet,
-/area/chapel/main)
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint3)
 "bPa" = (
-/obj/structure/bed/chair/wood/pew/right,
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "chapel"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
 	},
-/area/chapel/main)
+/turf/simulated/floor/plating,
+/area/maintenance/port)
 "bPb" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/bed/chair/wood/pew/mid,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "dark"
 	},
 /area/chapel/main)
 "bPc" = (
-/obj/structure/bed/chair/wood/pew/left,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning";
+	tag = "icon-warning"
 	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "chapel"
-	},
-/area/chapel/main)
+/turf/simulated/floor/glass/airless,
+/area/maintenance/port)
 "bPd" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
+	},
 /turf/simulated/floor/carpet,
 /area/chapel/main)
 "bPe" = (
@@ -52442,6 +52212,8 @@
 /obj/item/weapon/extinguisher,
 /obj/item/clothing/suit/fire/firefighter,
 /obj/item/clothing/head/hardhat/red,
+/obj/item/weapon/tank/oxygen,
+/obj/item/clothing/glasses/scanner/meson,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bPh" = (
@@ -52602,6 +52374,12 @@
 	name = "_West light switch";
 	pixel_x = -27
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor{
 	icon_state = "dark vault full"
 	},
@@ -52641,7 +52419,7 @@
 /turf/simulated/floor{
 	icon_state = "dark vault full"
 	},
-/area/maintenance/apmaint)
+/area/crew_quarters/bar)
 "bPB" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	name = "Air Vent (2)"
@@ -52696,7 +52474,7 @@
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
-/area/maintenance/aft)
+/area/medical/morgue)
 "bPG" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -53250,11 +53028,6 @@
 	dir = 8;
 	name = "Aft South Hallway"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor,
 /area/hallway/primary/aft)
 "bQO" = (
@@ -53311,6 +53084,12 @@
 	dir = 4;
 	name = "Air Vent (4)"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
+	},
 /turf/simulated/floor{
 	icon_state = "dark vault full"
 	},
@@ -53320,6 +53099,17 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
 /turf/simulated/floor{
 	icon_state = "dark vault full"
 	},
@@ -53331,10 +53121,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "dark vault full"
@@ -53344,13 +53133,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "dark vault full"
@@ -53359,11 +53148,6 @@
 "bQY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53376,15 +53160,15 @@
 	freq = 1400;
 	location = "Bar"
 	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/bar)
-"bQZ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/bar)
+"bQZ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -53396,10 +53180,18 @@
 	name = "Bar Delivery";
 	req_access_txt = "25"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bRa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -53407,23 +53199,25 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bRb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "_East APC";
+	pixel_x = 27;
+	pixel_y = 2
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -53952,12 +53746,6 @@
 /area/chapel/main)
 "bSc" = (
 /obj/structure/bed/chair/wood/normal,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "chapel"
@@ -53996,8 +53784,11 @@
 "bSh" = (
 /obj/abstract/map/spawner/maint/lowchance,
 /obj/structure/rack,
-/obj/item/weapon/tank/oxygen,
-/turf/simulated/floor/plating,
+/obj/abstract/map/spawner/maint,
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg3";
+	tag = "icon-platingdmg3"
+	},
 /area/maintenance/port)
 "bSi" = (
 /turf/simulated/floor{
@@ -54157,32 +53948,18 @@
 /area/hallway/primary/aft)
 "bSs" = (
 /obj/machinery/light,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor,
 /area/hallway/primary/aft)
 "bSt" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "bSu" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/obj/structure/closet/walllocker/emerglocker/west,
+/turf/simulated/floor/engine,
+/area/maintenance/port)
 "bSv" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -54222,17 +53999,18 @@
 "bSy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor{
 	icon_state = "dark vault full"
 	},
 /area/maintenance/apmaint)
 "bSz" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor{
 	icon_state = "dark vault full"
 	},
@@ -54690,13 +54468,19 @@
 	},
 /area/science/hallway)
 "bTu" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/rack,
+/obj/item/clothing/mask/gas,
+/obj/item/weapon/extinguisher,
+/obj/item/clothing/suit/fire/firefighter,
+/obj/item/clothing/head/hardhat/red,
+/obj/item/weapon/tank/oxygen,
+/obj/item/clothing/glasses/scanner/meson,
+/obj/machinery/light/small{
+	dir = 1
 	},
+/obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/fpmaint2)
 "bTv" = (
 /obj/abstract/map/spawner/floorpill,
 /obj/structure/reagent_dispensers/fueltank,
@@ -54708,6 +54492,15 @@
 /obj/item/weapon/pickaxe/shovel/spade,
 /obj/item/weapon/reagent_containers/glass/bucket,
 /obj/item/tool/wirecutters/clippers,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "_West APC";
+	pixel_x = -25
+	},
 /turf/simulated/floor{
 	icon_state = "hydrofloor"
 	},
@@ -54720,6 +54513,11 @@
 /obj/item/tool/wirecutters/clippers,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "hydrofloor"
@@ -54734,6 +54532,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	icon_state = "hydrofloor"
 	},
@@ -54743,6 +54546,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/hydroponics)
 "bTA" = (
@@ -54759,6 +54567,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 6;
@@ -54777,11 +54590,21 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/hydroponics)
 "bTC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "dark vault full"
@@ -54793,6 +54616,18 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
 /turf/simulated/floor{
 	icon_state = "dark vault full"
 	},
@@ -54802,11 +54637,6 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor{
 	icon_state = "dark vault full"
 	},
@@ -54834,6 +54664,7 @@
 	dir = 8;
 	flickering = 1
 	},
+/obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "bTJ" = (
@@ -55304,6 +55135,12 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "bUx" = (
@@ -55393,17 +55230,16 @@
 	},
 /area/chapel/main)
 "bUF" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -11
 	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "chapel"
+/obj/structure/mirror{
+	pixel_x = -28
 	},
-/area/chapel/main)
+/obj/item/toy/gasha/skub,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2)
 "bUG" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -55433,6 +55269,7 @@
 /area/chapel/main)
 "bUL" = (
 /obj/effect/decal/mecha_wreckage/ripley/firefighter,
+/obj/effect/decal/cleanable/ash,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bUM" = (
@@ -55602,7 +55439,7 @@
 /turf/simulated/floor{
 	icon_state = "dark vault full"
 	},
-/area/maintenance/apmaint)
+/area/hydroponics)
 "bVc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -55621,6 +55458,17 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor{
 	icon_state = "dark vault full"
 	},
@@ -55628,10 +55476,9 @@
 "bVe" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "dark vault full"
@@ -56186,12 +56033,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "chapel"
@@ -56454,22 +56295,28 @@
 "bWG" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall,
-/area/maintenance/aft)
+/area/maintenance/apmaint)
 "bWH" = (
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "12;25;28;35"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"bWI" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /obj/structure/plasticflaps{
 	opacity = 1
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/apmaint)
+"bWI" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;25;28;35"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/apmaint)
 "bWJ" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "12;35"
@@ -56869,12 +56716,6 @@
 /area/chapel/main)
 "bXz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "chapel"
@@ -57002,6 +56843,12 @@
 "bXN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "bXO" = (
@@ -57350,12 +57197,6 @@
 /area/chapel/main)
 "bYz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1;
 	name = "Firelock North"
@@ -57408,9 +57249,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bYG" = (
-/obj/machinery/recharge_station,
-/turf/simulated/floor/plating,
-/area/science/lab)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	name = "Firelock East"
+	},
+/turf/simulated/floor,
+/area/hallway/secondary/entry)
 "bYH" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -57528,19 +57375,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "bYP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "1-2";
+	tag = ""
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/fsmaint2)
 "bYQ" = (
 /obj/item/weapon/light/tube/broken,
 /obj/structure/disposalpipe/segment{
@@ -57590,7 +57432,12 @@
 	icon_state = "2-4";
 	tag = ""
 	},
-/mob/living/simple_animal/mouse/common,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "bYV" = (
@@ -58002,6 +57849,7 @@
 /area/crew_quarters/sleep)
 "bZI" = (
 /obj/machinery/recharge_station,
+/obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "bZJ" = (
@@ -58037,6 +57885,7 @@
 /area/maintenance/port)
 "bZP" = (
 /obj/item/weapon/stool,
+/obj/effect/decal/cleanable/crumbs,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bZQ" = (
@@ -58066,12 +57915,6 @@
 /area/chapel/main)
 "bZT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -58132,11 +57975,6 @@
 	name = "Research Division Maintenance";
 	req_access_txt = "47"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -58144,13 +57982,23 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/port)
+/area/science/hallway)
 "cab" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -58255,18 +58103,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "caj" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/structure/bed/chair,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	name = "Firelock East"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/turf/simulated/floor,
+/area/hallway/secondary/entry)
 "cak" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -58545,6 +58388,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "caQ" = (
@@ -58612,20 +58456,10 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	tag = ""
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall,
 /area/maintenance/port)
 "caX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -59091,15 +58925,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "cbZ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/item/stack/rods{
+	amount = 3
+	},
+/obj/item/weapon/shard{
+	icon_state = "small";
+	pixel_x = 5;
+	pixel_y = -5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -59143,12 +58978,6 @@
 /area/chapel/main)
 "cce" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -59161,11 +58990,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8;
 	name = "Firelock West"
@@ -59175,12 +58999,6 @@
 	},
 /area/chapel/office)
 "ccg" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8;
 	name = "Air Scrubber (8)"
@@ -59229,8 +59047,22 @@
 	},
 /area/chapel/office)
 "ccl" = (
-/turf/simulated/wall/r_wall,
-/area/maintenance/port)
+/obj/effect/decal/warning_stripes{
+	dir = 8;
+	icon_state = "warning";
+	tag = "icon-warning (WEST)"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "brown"
+	},
+/area/hallway/primary/port)
 "ccm" = (
 /turf/simulated/wall/r_wall,
 /area/science/rd)
@@ -59759,13 +59591,16 @@
 	name = "_South APC";
 	pixel_y = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
 /obj/machinery/light_switch{
 	name = "_West light switch";
 	pixel_x = -27
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor{
 	icon_state = "grimy"
@@ -59774,6 +59609,11 @@
 "cdp" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -59786,6 +59626,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -59793,6 +59638,12 @@
 "cdr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
 	},
 /turf/simulated/floor{
 	icon_state = "grimy"
@@ -59830,7 +59681,7 @@
 	req_access_txt = "27"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/port)
+/area/chapel/office)
 "cdw" = (
 /obj/structure/table,
 /obj/item/weapon/hatchet,
@@ -60387,13 +60238,19 @@
 "ceB" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/starboard)
 "ceC" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Chapel Maintenance";
 	req_access_txt = "22"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/plating,
 /area/chapel/office)
 "ceD" = (
@@ -60787,7 +60644,7 @@
 "cfB" = (
 /mob/living/simple_animal/mouse,
 /turf/simulated/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/starboard)
 "cfC" = (
 /obj/effect/decal/cleanable/vomit,
 /obj/structure/disposalpipe/segment{
@@ -60868,7 +60725,7 @@
 /obj/item/robot_parts/l_arm,
 /obj/item/device/assembly/signaler,
 /obj/structure/closet,
-/obj/item/clothing/glasses/scanner/meson,
+/obj/item/weapon/storage/box/smokebombs,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "cfL" = (
@@ -61372,7 +61229,7 @@
 "cgB" = (
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/starboard)
 "cgC" = (
 /obj/item/weapon/storage/box/cups,
 /obj/structure/closet/crate{
@@ -61443,7 +61300,10 @@
 /area/chapel/main)
 "cgK" = (
 /obj/structure/grille/broken,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg1";
+	tag = "icon-platingdmg1"
+	},
 /area/maintenance/port)
 "cgL" = (
 /obj/structure/grille,
@@ -61980,7 +61840,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/area/medical/break_room)
 "chw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62115,8 +61975,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "chL" = (
-/turf/simulated/floor/plating,
-/area/maintenance/disposal)
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/wall,
+/area/maintenance/port)
 "chM" = (
 /obj/item/tool/wrench,
 /obj/item/tool/weldingtool,
@@ -62139,7 +62004,7 @@
 	req_access_txt = "12"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/port)
+/area/chapel/main)
 "chP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/maintenance{
@@ -62929,7 +62794,7 @@
 /area/maintenance/port)
 "cjr" = (
 /obj/structure/rack,
-/obj/item/device/paicard,
+/obj/abstract/map/spawner/assistant/tools,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "cjs" = (
@@ -62946,9 +62811,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "cju" = (
-/obj/item/weapon/bananapeel,
-/turf/space,
-/area)
+/obj/structure/closet/toolcloset,
+/obj/structure/sign/poster{
+	icon_state = "poster9";
+	pixel_x = -32
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutral"
+	},
+/area/storage/tools)
 "cjv" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -63504,12 +63376,6 @@
 /area/science/hallway)
 "ckz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/small{
 	dir = 4
@@ -98704,12 +98570,34 @@
 /obj/effect/landmark/map_element/salvage_shuttle_cockroaches,
 /turf/space,
 /area)
-"eyG" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"dZQ" = (
+/obj/structure/window/reinforced{
+	dir = 1
 	},
+/obj/item/weapon/shard,
+/obj/item/weapon/shard{
+	icon_state = "medium"
+	},
+/obj/item/stack/rods{
+	amount = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/port)
+"ecG" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/port)
+"eyG" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor,
 /area/hydroponics)
@@ -98733,6 +98621,20 @@
 	},
 /turf/simulated/floor,
 /area/hallway/secondary/exit)
+"fei" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	name = "_South APC";
+	pixel_y = -24
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2)
 "fme" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor{
@@ -98816,6 +98718,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/perma)
+"gnY" = (
+/obj/structure/closet/emcloset,
+/turf/simulated/floor,
+/area/hallway/secondary/entry)
 "gCK" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plating,
@@ -98932,12 +98838,6 @@
 	},
 /area/medical/medbay)
 "itQ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
@@ -98955,6 +98855,21 @@
 /obj/item/mounted/poster,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
+"iSL" = (
+/obj/structure/closet/wardrobe/black,
+/turf/simulated/floor/plating,
+/area/maintenance/port)
+"iVQ" = (
+/obj/machinery/power/apc{
+	name = "_South APC";
+	pixel_y = -24
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor,
+/area/hallway/secondary/entry)
 "iWf" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/bed/chair/vehicle/wheelchair{
@@ -99017,6 +98932,18 @@
 /obj/docking_port/destination/pod3/shuttle,
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/escape/centcom)
+"knr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	icon_state = "freezerfloor"
+	},
+/area/crew_quarters/kitchen)
 "kom" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -99058,6 +98985,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = -28
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -99068,6 +99006,11 @@
 	icon_state = "dark"
 	},
 /area/chapel/main)
+"kTk" = (
+/obj/machinery/power/treadmill,
+/obj/machinery/power/treadmill,
+/turf/simulated/floor/plating,
+/area/maintenance/port)
 "lrb" = (
 /obj/machinery/light_construct/small{
 	dir = 1
@@ -99087,6 +99030,18 @@
 	icon_state = "whitepurple"
 	},
 /area/science/hallway)
+"lBv" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "lVg" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -99104,6 +99059,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"nla" = (
+/obj/structure/closet/emcloset,
+/turf/simulated/floor,
+/area/hallway/secondary/exit)
+"nlk" = (
+/obj/effect/decal/cleanable/vomit/pre_dry,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2)
 "nGG" = (
 /obj/structure/table/woodentable,
 /obj/machinery/disk_duplicator,
@@ -99208,6 +99171,14 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
+"oXL" = (
+/obj/machinery/power/apc{
+	name = "_South APC";
+	pixel_y = -24
+	},
+/obj/structure/cable,
+/turf/simulated/floor/plating,
+/area/maintenance/port)
 "pcW" = (
 /obj/machinery/light_construct/small,
 /turf/simulated/floor/plating,
@@ -99243,10 +99214,28 @@
 /obj/machinery/researcharchive,
 /turf/simulated/floor/wood,
 /area/library)
+"pEX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only{
+	name = "Firelock South"
+	},
+/turf/simulated/floor,
+/area/hallway/primary/central)
 "pLQ" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain)
+"pMX" = (
+/obj/abstract/map/spawner/floorpill,
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/maintenance/port)
+"pXz" = (
+/obj/structure/punching_bag/clown,
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint2)
 "qbi" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -99275,9 +99264,32 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "qiT" = (
-/obj/item/inflatable/wall,
-/obj/item/inflatable/wall,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/plating,
+/area/maintenance/port)
+"qme" = (
+/obj/machinery/light,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8;
+	name = "Firelock West"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8;
+	name = "Firelock West"
+	},
+/turf/simulated/floor,
+/area/hallway/primary/port)
+"qEt" = (
+/obj/abstract/map/spawner/floorpill,
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg1";
+	tag = "icon-platingdmg1"
+	},
 /area/maintenance/port)
 "qFn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -99294,6 +99306,10 @@
 /mob/living/simple_animal/mouse/common,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"qXU" = (
+/obj/structure/largecrate/skele_stand,
+/turf/simulated/floor/plating,
+/area/maintenance/port)
 "rfu" = (
 /obj/machinery/electric_loom,
 /turf/simulated/floor/plating,
@@ -99341,6 +99357,19 @@
 /area/science/breakroom{
 	name = "\improper Research Storage Room"
 	})
+"rPD" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint3)
+"rPX" = (
+/obj/structure/girder,
+/turf/simulated/floor/plating,
+/area/maintenance/port)
 "rUj" = (
 /obj/machinery/door/airlock/glass_research{
 	name = "Research Archive";
@@ -99414,6 +99443,25 @@
 	},
 /turf/simulated/floor,
 /area/medical/exam_room)
+"tvj" = (
+/obj/structure/closet/emcloset/vox,
+/turf/simulated/floor,
+/area/hallway/primary/starboard)
+"tCs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8;
+	name = "Firelock West"
+	},
+/turf/simulated/floor,
+/area/hallway/primary/port)
 "tIQ" = (
 /turf/simulated/wall,
 /area/mine/explored)
@@ -99427,12 +99475,28 @@
 	icon_state = "whitepurple"
 	},
 /area/science/hallway)
-"ueC" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"ubc" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor,
+/area/hallway/primary/port)
+"ucO" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
+	},
+/turf/simulated/floor,
+/area/storage/tools)
+"ueC" = (
 /obj/machinery/firealarm{
 	name = "_North Fire Alarm";
 	pixel_y = 26
@@ -99442,11 +99506,6 @@
 "umG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	name = "_East Fire Alarm";
@@ -99454,6 +99513,24 @@
 	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
+"uIl" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/glass/airless,
+/area/maintenance/port)
+"vbp" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/grille/broken,
+/obj/item/weapon/shard{
+	icon_state = "medium"
+	},
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg3";
+	tag = "icon-platingdmg3"
+	},
+/area/maintenance/port)
 "viK" = (
 /obj/structure/shuttle/diag_wall/smooth{
 	dir = 8
@@ -99483,6 +99560,20 @@
 /obj/item/weapon/stamp/judge,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
+"vtV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor/border_only{
+	name = "Firelock South"
+	},
+/turf/simulated/floor,
+/area/hallway/primary/central)
+"vDH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor/border_only{
+	name = "Firelock South"
+	},
+/turf/simulated/floor,
+/area/hallway/primary/central)
 "vDL" = (
 /obj/item/weapon/stool,
 /obj/machinery/firealarm{
@@ -99492,6 +99583,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"vQb" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/simulated/floor,
+/area/hallway/secondary/entry)
 "vZL" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -99537,6 +99637,13 @@
 /obj/item/weapon/storage/belt/utility,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"wpX" = (
+/obj/structure/bed/chair/wood/normal,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "chapel"
+	},
+/area/chapel/main)
 "wtA" = (
 /obj/structure/bookcase/manuals/research_and_development,
 /obj/machinery/newscaster{
@@ -99559,23 +99666,38 @@
 /obj/structure/window/full/reinforced/plasma,
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/trade/start)
+"wAS" = (
+/obj/structure/largecrate/showers,
+/turf/simulated/floor/plating,
+/area/maintenance/port)
 "wBP" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor,
 /area/storage/eva)
+"wVC" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	name = "Air Vent (2)"
+	},
+/turf/simulated/floor,
+/area/storage/tools)
 "xji" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
 	},
 /turf/simulated/floor,
 /area/gateway)
+"xwy" = (
+/obj/effect/decal/cleanable/crayon/fuckyou,
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint2)
 "xwD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -99590,6 +99712,12 @@
 	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
+"xAa" = (
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg3";
+	tag = "icon-platingdmg3"
+	},
+/area/maintenance/port)
 "xBz" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
@@ -99600,6 +99728,22 @@
 	},
 /turf/space,
 /area/shuttle/mining/station)
+"xGU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	name = "Firelock South"
+	},
+/turf/simulated/floor,
+/area/hallway/primary/port)
+"xXQ" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/simulated/floor/plating,
+/area/science/podbay)
 
 (1,1,1) = {"
 aaa
@@ -190734,7 +190878,7 @@ bnW
 bxT
 bnW
 boS
-bnn
+bjq
 bnn
 bEB
 bnW
@@ -191738,25 +191882,25 @@ bwD
 bxU
 bnn
 bnn
-bnn
-bnn
-bnn
-bnn
-bnn
-bnn
-bnn
-bnn
-bNl
+bjq
+beU
+beU
+beU
+beU
+beU
+beU
+beU
+bPc
 bOK
 bQq
-bRR
+bSu
 bTa
 bUA
 bWa
 bnn
 bnn
 bnn
-caU
+bnW
 aaa
 abP
 aaa
@@ -192241,14 +192385,14 @@ bnn
 bnn
 bnn
 bnn
-bnn
-bnn
-bnn
-bnn
-bnn
-bnn
-bnn
-bNl
+beU
+uIl
+beU
+beU
+beU
+beU
+beU
+bPc
 bOL
 bQr
 bRR
@@ -192257,8 +192401,8 @@ bQr
 bWa
 bXu
 bnn
-bZP
-caV
+bnn
+bnW
 aaa
 abR
 aaa
@@ -192757,10 +192901,10 @@ bRS
 bOM
 bQs
 bNm
-bwE
+wAS
 bnn
 bnn
-caV
+caU
 aaa
 abR
 aaa
@@ -193259,9 +193403,9 @@ bRT
 bTb
 bUB
 bNm
-bXv
+qXU
 bnn
-bZP
+bwI
 caV
 aaa
 abP
@@ -193760,11 +193904,11 @@ bOO
 bRU
 bOO
 bOO
-bNm
-bXw
+xXQ
+bnn
 bnn
 bZP
-caV
+chL
 aaa
 abR
 aaa
@@ -194265,7 +194409,7 @@ bOP
 bNm
 bNm
 bnn
-bnn
+bwI
 caW
 aai
 cdg
@@ -194768,7 +194912,7 @@ bWb
 bNm
 bnn
 bnn
-bnW
+chL
 aaa
 aai
 aaa
@@ -195248,7 +195392,7 @@ aUs
 aUs
 aaa
 bnW
-bwI
+bWq
 bnn
 bnW
 bAm
@@ -195270,8 +195414,8 @@ bWc
 bNm
 bnn
 bnn
-bnW
-cbZ
+bLc
+cdh
 cdh
 cdh
 cfF
@@ -195750,7 +195894,7 @@ aaa
 aaa
 aaa
 bnW
-bnn
+bXv
 bnn
 bnW
 bAn
@@ -196252,7 +196396,7 @@ bnW
 bnW
 bnW
 bnW
-boS
+bXw
 bnn
 bno
 bkr
@@ -196282,7 +196426,7 @@ cfG
 cgF
 bNr
 bnn
-bnn
+iSL
 bnW
 aaa
 aaa
@@ -196747,14 +196891,14 @@ blb
 aUs
 bnm
 bnn
-boS
+qEt
 bnn
 bnn
 bnn
 bnn
 bnn
 bnn
-bnn
+xAa
 bnn
 bnW
 bAo
@@ -196784,7 +196928,7 @@ cfH
 cgG
 bNr
 bnn
-bnn
+bLe
 bnW
 aaa
 aaa
@@ -197723,7 +197867,7 @@ anw
 anw
 anw
 anw
-anw
+aZG
 anw
 anw
 anw
@@ -197749,16 +197893,16 @@ bjn
 kMD
 blc
 bmr
-bnn
+bLM
 bnn
 boT
 bpF
 bqN
 brX
-boU
+bnW
 btZ
 bvn
-boU
+bnW
 bnn
 bnW
 bAp
@@ -197780,7 +197924,7 @@ bWg
 bNr
 cfR
 bNr
-bSb
+kQz
 bXB
 bXB
 bXB
@@ -198225,7 +198369,7 @@ axp
 axp
 axp
 axp
-aeV
+alH
 aFO
 aFO
 aFO
@@ -198251,7 +198395,7 @@ aXE
 bhY
 bld
 aTf
-bnn
+lVg
 bnn
 boU
 boU
@@ -198727,7 +198871,7 @@ ayw
 azO
 aBp
 axp
-aeV
+alH
 aFO
 aHq
 aIA
@@ -198754,7 +198898,7 @@ bkn
 bld
 aTf
 bIY
-bnn
+oXL
 boU
 bpG
 bqO
@@ -198771,9 +198915,9 @@ bzi
 bzi
 bzi
 bzi
-bJi
-bKH
-bLY
+tCs
+bst
+qme
 bNr
 bNr
 bQy
@@ -199229,7 +199373,7 @@ ayx
 azP
 aBq
 axp
-aeV
+alH
 aFO
 aHr
 aIA
@@ -199280,8 +199424,8 @@ bNr
 bOX
 bQz
 bSc
-bQz
-bUF
+wpX
+bXA
 bWh
 bXz
 bYz
@@ -199731,7 +199875,7 @@ ayy
 azQ
 aBr
 axp
-aeV
+alH
 aFO
 aHs
 aIB
@@ -199779,7 +199923,7 @@ bJi
 bKH
 bMc
 bNs
-bOY
+bQA
 bQA
 bQA
 bQA
@@ -200233,7 +200377,7 @@ ayz
 azR
 aBs
 axp
-aeV
+alH
 aFO
 aFO
 aFO
@@ -200260,7 +200404,7 @@ bko
 ble
 aTf
 lVg
-bnn
+bAR
 boU
 bpJ
 bqP
@@ -200277,11 +200421,11 @@ bDn
 bEI
 bGq
 bzi
-bJk
+bJm
 bKI
-bMd
+bvu
 bNt
-bOZ
+bQB
 bQB
 bQB
 bQB
@@ -200735,7 +200879,7 @@ ayA
 azS
 aBt
 ayG
-aeV
+alH
 aFP
 aHt
 aIC
@@ -200762,7 +200906,7 @@ aZc
 blf
 aTf
 lVg
-bnn
+bAR
 boU
 bpK
 bqP
@@ -200783,7 +200927,7 @@ xwD
 bKH
 bkr
 bNu
-bPa
+bSd
 bQC
 bSd
 bQC
@@ -201237,10 +201381,10 @@ ayB
 azT
 aBu
 ayG
-aeV
-aeV
-aeV
-aeV
+bLd
+bvR
+bvR
+rPD
 aFO
 aLA
 aNp
@@ -201259,12 +201403,12 @@ bes
 bfB
 bgK
 bib
-aXE
+bcP
 bkp
 blg
 aTf
 lVg
-bnn
+kTk
 boU
 bpL
 bqQ
@@ -201742,7 +201886,7 @@ ayG
 ayG
 ayG
 ayG
-aeV
+alH
 aFO
 aFO
 aNq
@@ -201787,7 +201931,7 @@ bJl
 bKH
 bkr
 bNw
-bPc
+bSe
 bQE
 bSe
 bQE
@@ -201800,7 +201944,7 @@ cbb
 ccj
 cdr
 ceC
-bnn
+bLM
 bnn
 bnW
 aaa
@@ -202244,7 +202388,7 @@ aCU
 aEj
 aFQ
 ayG
-aeV
+alH
 aeV
 agA
 aNr
@@ -202263,7 +202407,7 @@ aTf
 bfF
 bgL
 bid
-bjq
+aAc
 aTg
 blh
 aTf
@@ -202289,7 +202433,7 @@ bJm
 bKK
 bMe
 bNs
-bOY
+bQA
 bQA
 bQA
 bQA
@@ -202302,11 +202446,11 @@ cbc
 caZ
 cds
 bYA
-bnn
+lVg
 bnn
 bnW
-aad
-aad
+aaa
+aaa
 cka
 cka
 cka
@@ -202746,11 +202890,11 @@ aCV
 aEk
 aFR
 ayG
-aeV
-aeV
-aeW
+bLd
+bvR
+bOZ
 aNs
-aOz
+ccl
 aOz
 aOz
 bTJ
@@ -202771,7 +202915,7 @@ bli
 bms
 aBz
 bnX
-aWn
+aAb
 bpO
 bqT
 bse
@@ -202789,7 +202933,7 @@ bGv
 bHR
 bJn
 bKL
-aEo
+ubc
 bNx
 bPd
 bQF
@@ -202804,7 +202948,7 @@ bYA
 cck
 bYA
 bYA
-bnn
+lVg
 bnn
 bnW
 aaa
@@ -203267,7 +203411,7 @@ aIF
 aIF
 aIF
 aCZ
-bjs
+aNw
 bkr
 bkr
 aBC
@@ -203288,7 +203432,7 @@ aIF
 aBz
 aEo
 aCZ
-ayI
+xGU
 bJo
 bKM
 bMf
@@ -203306,11 +203450,11 @@ cbd
 cbd
 cdt
 bYA
-bnn
+lVg
 cgK
 bnW
 aaa
-cju
+aaa
 cka
 ckJ
 ckJ
@@ -203761,13 +203905,13 @@ aTh
 aUO
 aWo
 aXN
-aIE
-aIE
+bks
+bks
 bbI
 bcV
 beu
-aIE
-aIE
+bks
+bks
 bif
 bjt
 umG
@@ -203801,18 +203945,18 @@ bSg
 bSb
 bSb
 bQH
-kQz
+bSb
 bYA
 bZZ
 cbe
 hxS
 cdu
 bYA
-bnn
+lVg
 cgL
 bnW
 aaa
-aaa
+arX
 cka
 ckK
 clF
@@ -204242,7 +204386,7 @@ apy
 aqD
 arW
 atv
-atv
+cju
 awh
 axw
 ayH
@@ -204303,16 +204447,16 @@ bNr
 bNr
 bNr
 bNr
-bNr
+chO
 bYA
 bYA
 bYA
 bYA
 cdv
 bYA
-bnn
+lVg
 cgM
-bnW
+cjY
 aaa
 aaa
 cka
@@ -204744,7 +204888,7 @@ apy
 aqE
 aqF
 aqF
-aqF
+wVC
 awi
 axx
 ayI
@@ -204797,24 +204941,24 @@ bGy
 bHT
 bye
 bKP
+qiT
+qiT
+qiT
+qiT
+qiT
+qiT
+qiT
+qiT
+qiT
+qiT
+ecG
+qiT
+qiT
+bPa
+qiT
+bAS
 bnn
-bnn
-bnn
-bnn
-bnn
-bnn
-bnn
-bnn
-bnn
-bnn
-bnn
-bnn
-bnn
-bnn
-bnn
-bnn
-bnn
-bnW
+caV
 aaa
 aaa
 cka
@@ -205239,15 +205383,15 @@ aiE
 ajH
 akH
 alJ
-aeV
-aeV
-aeV
-aeW
+bvR
+bvR
+bvR
+bMm
+ucO
 aqF
 aqF
 aqF
 aqF
-awj
 axy
 ayJ
 aAa
@@ -205303,20 +205447,20 @@ bnn
 bnn
 bnn
 bnn
-qiT
+bnn
 gCK
 boS
 bnn
 bnn
 bnn
-bnn
+lVg
 bnn
 bnn
 bnn
 bnn
 bnn
 cgN
-bnW
+caV
 aaa
 aaa
 cka
@@ -205746,14 +205890,14 @@ anz
 aoD
 apy
 aqG
-arX
-arX
-arX
+aqF
+aqF
+awj
 awk
 axz
 ayK
-aAb
-aBB
+aAc
+aBC
 aDb
 aEq
 aFV
@@ -205802,23 +205946,23 @@ bHV
 bye
 bKR
 bnn
+rPX
+dZQ
+cbZ
+vbp
 bnW
 bnW
-bno
-bnW
-bnW
-bno
-bnW
+rPX
 bnW
 bYE
-bnn
+lVg
 bnn
 bnW
 bnW
 ceD
 bnW
 cgO
-bnW
+cjZ
 aaa
 aaa
 cka
@@ -206303,17 +206447,17 @@ bGz
 bHW
 bye
 bKS
-boS
-bnW
+pMX
+rPX
 bPg
-bnn
+bnl
 bSh
 bnW
 bUL
-bWq
+bJk
 bnW
 bYF
-bnn
+lVg
 bnn
 bnW
 cdw
@@ -206814,8 +206958,8 @@ bMh
 bMh
 bMh
 bMh
-bYG
-bnn
+boT
+lVg
 bnn
 bnW
 cdx
@@ -207317,7 +207461,7 @@ bUM
 bWr
 bMh
 bMh
-bnn
+lVg
 cbf
 bnW
 cdy
@@ -207819,9 +207963,9 @@ bTj
 bWs
 bXF
 bMh
-bnn
+lVg
 cbg
-ccl
+bnW
 cdz
 ceF
 ccm
@@ -208321,7 +208465,7 @@ bUN
 bWt
 bXG
 bMh
-bnn
+lVg
 bwE
 ccm
 ccm
@@ -208823,7 +208967,7 @@ bUO
 bWu
 bXH
 bMh
-bnn
+lVg
 bWq
 ccn
 cdA
@@ -211308,7 +211452,7 @@ bog
 bph
 bqa
 brd
-bsl
+bvS
 bte
 bte
 bte
@@ -213261,8 +213405,8 @@ aaa
 aaa
 aaa
 acD
-ade
-aea
+aBB
+nla
 aea
 aea
 aea
@@ -213331,9 +213475,9 @@ bFc
 bFc
 bFc
 bKZ
-bMm
-bsh
-bsh
+bqe
+bra
+bra
 bQN
 bSs
 bTr
@@ -214339,13 +214483,13 @@ bMo
 bFj
 bPp
 bDC
-bSu
-bTu
-bTu
-bTu
-bTu
-bYP
-caj
+bMz
+bMz
+bMz
+bMz
+bMz
+bYS
+cak
 cbn
 ccu
 cdL
@@ -214836,7 +214980,7 @@ bFf
 bGL
 bIi
 bIi
-bLc
+bIi
 bMp
 bIi
 bPq
@@ -215338,7 +215482,7 @@ bFg
 bGM
 bIj
 bJw
-bLd
+bNK
 bMq
 bIj
 bPr
@@ -215367,7 +215511,7 @@ bUW
 bUW
 cpy
 bUW
-bUW
+bjs
 crE
 csi
 csx
@@ -215840,7 +215984,7 @@ bFh
 bFj
 bIj
 bFj
-bLe
+bIj
 bMo
 bIj
 bPs
@@ -216342,7 +216486,7 @@ bFi
 bFj
 bIj
 bFj
-bLe
+bIj
 bMr
 bNK
 bPt
@@ -216844,7 +216988,7 @@ bFj
 bFj
 bIj
 bFj
-bLe
+bIj
 bMo
 bIj
 bPr
@@ -217346,7 +217490,7 @@ bFi
 bFj
 bFj
 bJy
-bLb
+bFj
 bMs
 bNL
 bPu
@@ -218834,15 +218978,15 @@ bkw
 aDr
 aDr
 bnD
-aDr
+vtV
 aDr
 bqi
 bdq
 aAp
 btq
 buB
-bvL
-bvL
+bwW
+bwW
 bys
 bzy
 bAO
@@ -219336,7 +219480,7 @@ aBZ
 aBZ
 aBZ
 aBZ
-aBZ
+vDH
 aBZ
 bqj
 brj
@@ -219802,7 +219946,7 @@ adv
 acP
 apG
 aqT
-aso
+adv
 atN
 adv
 adv
@@ -219849,7 +219993,7 @@ bvN
 bxb
 byu
 byu
-bvT
+bvQ
 bCw
 bto
 bFn
@@ -219857,7 +220001,7 @@ bGQ
 bIn
 bIn
 bLi
-bIn
+knr
 bNO
 bPy
 bQW
@@ -220366,7 +220510,7 @@ bQX
 bSA
 bTF
 bVf
-bTG
+bhq
 bMz
 qFn
 cam
@@ -220853,7 +220997,7 @@ bvP
 bxd
 buD
 buD
-bAR
+bAU
 bCy
 bto
 bto
@@ -221350,12 +221494,12 @@ bqm
 bdq
 aAp
 btu
-buF
+bLI
 bvQ
 bxe
 byw
 buF
-bAR
+bAU
 bCx
 bts
 bFp
@@ -221857,7 +222001,7 @@ bvQ
 bxf
 byx
 byx
-bAS
+bAV
 bTh
 bDK
 bFq
@@ -222327,7 +222471,7 @@ aHO
 aGp
 aGp
 aMd
-aGp
+bbZ
 aOZ
 aQM
 aGp
@@ -222352,10 +222496,10 @@ aai
 bhi
 bqn
 brl
-bst
+aAp
 btw
-buH
-bvR
+bCB
+bvQ
 bxg
 itQ
 byy
@@ -222829,7 +222973,7 @@ aHP
 aJa
 aKw
 aKw
-aKw
+pEX
 aPa
 aQN
 aKw
@@ -222857,7 +223001,7 @@ bri
 aAq
 btx
 buI
-bvS
+bCz
 bxh
 buD
 buD
@@ -223338,9 +223482,9 @@ aDs
 aTA
 aVf
 aWF
-aDs
-aDs
-aDs
+aBX
+aBX
+aBX
 bcb
 bdo
 aBX
@@ -223359,7 +223503,7 @@ brm
 bsu
 btt
 buJ
-bvT
+bvQ
 bxi
 byz
 bzz
@@ -223861,7 +224005,7 @@ bdq
 aAp
 bty
 buK
-bvT
+bvQ
 buL
 buL
 bzA
@@ -224363,7 +224507,7 @@ bdq
 aAp
 btz
 buF
-bvT
+bvQ
 bvQ
 bvQ
 bzB
@@ -224848,7 +224992,7 @@ aYl
 aYl
 baO
 bcc
-bdq
+aBX
 azh
 bgc
 bhg
@@ -224865,7 +225009,7 @@ bdq
 aAp
 btu
 buL
-bvT
+bvQ
 bvQ
 byA
 bzC
@@ -225350,7 +225494,7 @@ aQR
 aQR
 baP
 bcd
-bdq
+aBX
 azh
 bgd
 bhk
@@ -226364,7 +226508,7 @@ aDr
 aDr
 aDr
 aDr
-aDr
+vtV
 aDr
 bqp
 bdq
@@ -227316,7 +227460,7 @@ aaa
 aaa
 aaa
 acr
-adv
+aYv
 ads
 aem
 aem
@@ -227818,7 +227962,7 @@ aaa
 aaa
 aaa
 acr
-adv
+bvT
 acP
 adv
 adv
@@ -228320,7 +228464,7 @@ aaa
 aaa
 aaa
 acr
-adv
+buH
 acP
 aen
 aen
@@ -228821,7 +228965,7 @@ aaa
 aaa
 aaa
 aaa
-acr
+ahQ
 adv
 acP
 aen
@@ -229323,7 +229467,7 @@ aaa
 aaa
 aaa
 aaa
-acr
+ahR
 adv
 acP
 aen
@@ -229825,7 +229969,7 @@ aai
 aaa
 aaa
 aaa
-acr
+ahS
 adv
 acP
 aen
@@ -229869,9 +230013,9 @@ aNM
 aNM
 aNO
 bdz
-beU
-beU
-bhq
+beT
+beT
+bho
 biN
 bjO
 bkD
@@ -230328,7 +230472,7 @@ aaa
 aaa
 aaa
 acr
-adv
+xwy
 acP
 aen
 afi
@@ -230367,11 +230511,11 @@ aTL
 aVk
 aWO
 aYs
-aPq
-aPq
+bYP
+bYP
 bcf
 bdA
-beT
+bLb
 bgj
 bhr
 biO
@@ -230830,7 +230974,7 @@ aaa
 aaa
 aaa
 acr
-adv
+pXz
 acP
 aen
 afk
@@ -231332,7 +231476,7 @@ aaa
 aaa
 aaa
 acr
-adv
+bvL
 acP
 aen
 afl
@@ -231870,9 +232014,9 @@ ajg
 aQW
 ajg
 aPs
-aVl
+fei
 aPs
-aYu
+bUF
 aYu
 aZH
 bcg
@@ -232372,10 +232516,10 @@ aPo
 aQX
 aPq
 aTM
-aVm
+aQZ
 aWP
-aYv
-aZG
+aPq
+nlk
 aZH
 bch
 aZL
@@ -232877,7 +233021,7 @@ aSf
 aQX
 aPs
 aYw
-aYw
+aso
 aZH
 bci
 aZL
@@ -233340,7 +233484,7 @@ abQ
 aai
 aaa
 acr
-afg
+bTu
 acN
 aeo
 ady
@@ -236886,8 +237030,8 @@ aJt
 aKG
 aMt
 aJA
-aPs
 aPr
+aPs
 aSg
 aTU
 aVt
@@ -240417,7 +240561,7 @@ aaa
 aaa
 aaa
 bkM
-blX
+blW
 bng
 bnP
 boD
@@ -247451,7 +247595,7 @@ bkM
 boH
 blX
 blX
-blX
+blY
 blX
 blX
 blX
@@ -247969,7 +248113,7 @@ bHt
 bIK
 bKn
 brz
-bNa
+tvj
 bOu
 bQc
 bRI
@@ -247982,8 +248126,8 @@ bNc
 caP
 cbX
 ccR
-bNf
-bNf
+cez
+cez
 cez
 chI
 cgz
@@ -248470,7 +248614,7 @@ bzY
 brz
 bqx
 bKo
-bLI
+brz
 bNc
 bNc
 bNc
@@ -249975,7 +250119,7 @@ bEr
 bGa
 bHw
 bIN
-bsz
+bKr
 bLL
 bNc
 bNc
@@ -250478,7 +250622,7 @@ bGb
 bHx
 bIO
 bKq
-bLM
+bwx
 bNc
 bOz
 bQf
@@ -250997,8 +251141,8 @@ ccR
 ceB
 cfB
 cgB
-chL
-cez
+bOD
+bNf
 aaa
 aai
 aaa
@@ -253490,7 +253634,7 @@ bGf
 bHC
 bKy
 bMb
-bwx
+iVQ
 bNd
 bNd
 bNd
@@ -253992,12 +254136,12 @@ bGg
 bHD
 bKz
 bOU
-bwx
-bNe
-bOD
-bOD
-bOD
-bOD
+vQb
+lBv
+aVm
+aVm
+aVm
+aVm
 bUw
 bVZ
 bVZ
@@ -259511,10 +259655,10 @@ aVx
 bxK
 bxK
 bGf
-bHB
-bIQ
-bKr
-bwx
+caj
+bYG
+bOY
+bMd
 bvm
 aaa
 aaa
@@ -260005,7 +260149,7 @@ aaa
 aaa
 aaa
 bvm
-bwx
+gnY
 bxL
 bzc
 bzc

--- a/maps/synergy.dmm
+++ b/maps/synergy.dmm
@@ -48313,7 +48313,8 @@
 /turf/simulated/floor,
 /area/hallway/secondary/entry)
 "bHJ" = (
-/obj/machinery/computer/merch,
+/obj/structure/table,
+/obj/item/weapon/storage/box/donkpockets/random_amount,
 /turf/simulated/floor,
 /area/hallway/secondary/entry)
 "bHK" = (
@@ -48994,7 +48995,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/closet/emcloset,
+/obj/machinery/computer/merch,
 /turf/simulated/floor,
 /area/hallway/secondary/entry)
 "bJc" = (
@@ -49766,7 +49767,6 @@
 	},
 /area/hallway/secondary/entry)
 "bKx" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -99204,6 +99204,21 @@
 	},
 /turf/simulated/wall,
 /area/crew_quarters/fitness)
+"olu" = (
+/obj/structure/window/full/plasma,
+/obj/structure/grille,
+/obj/structure/window/reinforced/plasma,
+/obj/structure/window/reinforced/plasma{
+	dir = 1
+	},
+/obj/structure/window/reinforced/plasma{
+	dir = 8
+	},
+/obj/structure/window/reinforced/plasma{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/bridge)
 "olS" = (
 /obj/item/clothing/accessory/storage/bandolier,
 /obj/item/weapon/gun/projectile/shotgun/doublebarrel,
@@ -211613,7 +211628,7 @@ aEz
 aTk
 aUP
 aWr
-aDc
+olu
 aaa
 baz
 bbL

--- a/maps/synergy.dmm
+++ b/maps/synergy.dmm
@@ -98704,6 +98704,15 @@
 	icon_state = "dark"
 	},
 /area/storage/tech)
+"fzj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/turf/simulated/floor,
+/area/hallway/primary/fore)
 "fCB" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -218615,7 +218624,7 @@ atL
 avf
 awB
 aqR
-ayY
+fzj
 aAe
 aBR
 aDn

--- a/maps/synergy.dmm
+++ b/maps/synergy.dmm
@@ -13239,7 +13239,6 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor/plating,
 /area/storage/tools)
 "axy" = (
@@ -40272,6 +40271,10 @@
 	dir = 8;
 	name = "Air Scrubber (8)"
 	},
+/obj/machinery/light_switch{
+	name = "_North light switch";
+	pixel_y = 27
+	},
 /turf/simulated/floor,
 /area/crew_quarters/fitness)
 "brE" = (
@@ -40785,17 +40788,15 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/fitness)
 "bsI" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "_West APC";
-	pixel_x = -25
+/obj/structure/window/reinforced/tinted,
+/obj/structure/window/reinforced/tinted{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/structure/window/reinforced/tinted{
+	dir = 8
 	},
-/turf/simulated/floor,
+/obj/structure/grille,
+/turf/simulated/floor/plating,
 /area/crew_quarters/fitness)
 "bsJ" = (
 /turf/simulated/floor,
@@ -41314,16 +41315,7 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/fitness)
 "btT" = (
-/obj/machinery/light_switch{
-	name = "_West light switch";
-	pixel_x = -27
-	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor,
 /area/crew_quarters/fitness)
 "btU" = (
@@ -41905,13 +41897,13 @@
 /area/medical/paramedics)
 "bvb" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/crew_quarters/fitness)
@@ -41919,6 +41911,14 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8;
 	name = "Air Vent (8)"
+	},
+/obj/machinery/power/apc{
+	name = "_South APC";
+	pixel_y = -24
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor,
 /area/crew_quarters/fitness)
@@ -42739,8 +42739,7 @@
 /turf/simulated/floor/glass/plasma,
 /area/science/hallway)
 "bwI" = (
-/obj/item/weapon/stool,
-/obj/abstract/map/spawner/floorpill,
+/obj/structure/largecrate/skele_stand,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bwJ" = (
@@ -45154,10 +45153,6 @@
 	},
 /area/storage/primary)
 "bBr" = (
-/obj/machinery/alarm{
-	name = "Air Alarm (2)";
-	pixel_y = 24
-	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "neutral"
@@ -45165,6 +45160,10 @@
 /area/storage/primary)
 "bBs" = (
 /obj/structure/reagent_dispensers/silicate,
+/obj/machinery/alarm{
+	name = "Air Alarm (2)";
+	pixel_y = 24
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "neutral"
@@ -45173,19 +45172,25 @@
 "bBt" = (
 /obj/structure/table,
 /obj/item/clothing/head/ushanka,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "_West APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor{
 	icon_state = "neutral"
 	},
 /area/crew_quarters/locker)
 "bBu" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "_North APC";
-	pixel_y = 24
-	},
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
 	},
 /turf/simulated/floor,
 /area/crew_quarters/locker)
@@ -45209,10 +45214,6 @@
 "bBx" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/item/clothing/gloves/fyellow,
-/obj/machinery/firealarm{
-	name = "_North Fire Alarm";
-	pixel_y = 26
-	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "neutral"
@@ -57885,7 +57886,7 @@
 /area/maintenance/port)
 "bZP" = (
 /obj/item/weapon/stool,
-/obj/effect/decal/cleanable/crumbs,
+/obj/abstract/map/spawner/floorpill,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bZQ" = (
@@ -58456,7 +58457,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/wall,
+/turf/simulated/floor/plating,
 /area/maintenance/port)
 "caX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -61976,12 +61977,12 @@
 /area/maintenance/disposal)
 "chL" = (
 /obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
+/obj/structure/window/reinforced/tinted{
 	dir = 1
 	},
-/turf/simulated/wall,
-/area/maintenance/port)
+/obj/structure/window/reinforced/tinted,
+/turf/simulated/floor/plating,
+/area/crew_quarters/fitness)
 "chM" = (
 /obj/item/tool/wrench,
 /obj/item/tool/weldingtool,
@@ -98570,6 +98571,17 @@
 /obj/effect/landmark/map_element/salvage_shuttle_cockroaches,
 /turf/space,
 /area)
+"dSW" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/structure/window/reinforced/tinted,
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/fitness)
 "dZQ" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -98601,6 +98613,16 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor,
 /area/hydroponics)
+"eWs" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/crew_quarters/fitness)
 "fbp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -98641,6 +98663,16 @@
 	icon_state = "dark"
 	},
 /area/engineering/engine)
+"fnO" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/fitness)
 "ftn" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
@@ -98722,6 +98754,19 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor,
 /area/hallway/secondary/entry)
+"gtk" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/crew_quarters/fitness)
 "gCK" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plating,
@@ -98774,6 +98819,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/virology_maint)
+"htt" = (
+/obj/item/weapon/stool,
+/obj/effect/decal/cleanable/crumbs,
+/turf/simulated/floor/plating,
+/area/maintenance/port)
 "hxS" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -98951,6 +99001,12 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor,
 /area/hallway/primary/central)
+"krQ" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/simulated/floor/plating,
+/area/science/podbay)
 "kvT" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -98961,6 +99017,14 @@
 	},
 /turf/simulated/floor,
 /area/hallway/primary/central)
+"kvZ" = (
+/obj/structure/window/reinforced/tinted,
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/crew_quarters/fitness)
 "kGw" = (
 /obj/machinery/light{
 	dir = 1
@@ -99050,6 +99114,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
+"mDZ" = (
+/obj/structure/largecrate/showers,
+/turf/simulated/floor/plating,
+/area/maintenance/port)
 "mZl" = (
 /obj/structure/closet/gmcloset{
 	name = "formal wardrobe"
@@ -99063,10 +99131,6 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor,
 /area/hallway/secondary/exit)
-"nlk" = (
-/obj/effect/decal/cleanable/vomit/pre_dry,
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2)
 "nGG" = (
 /obj/structure/table/woodentable,
 /obj/machinery/disk_duplicator,
@@ -99087,6 +99151,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"nSX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard2)
 "nYI" = (
 /obj/machinery/cooking/still,
 /obj/machinery/light/small{
@@ -99114,6 +99188,13 @@
 	icon_state = "white"
 	},
 /area/science/xenobiology)
+"okI" = (
+/obj/machinery/camera{
+	name = "Holodeck North";
+	pixel_y = -32
+	},
+/turf/simulated/wall,
+/area/crew_quarters/fitness)
 "olS" = (
 /obj/item/clothing/accessory/storage/bandolier,
 /obj/item/weapon/gun/projectile/shotgun/doublebarrel,
@@ -99137,6 +99218,17 @@
 /obj/item/stack/rcd_ammo,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"oqf" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/structure/window/reinforced/tinted,
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/crew_quarters/fitness)
 "otF" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -99171,6 +99263,10 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
+"oVF" = (
+/obj/effect/decal/cleanable/vomit/pre_dry,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2)
 "oXL" = (
 /obj/machinery/power/apc{
 	name = "_South APC";
@@ -99222,6 +99318,17 @@
 	},
 /turf/simulated/floor,
 /area/hallway/primary/central)
+"pIR" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/structure/window/reinforced/tinted,
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/fitness)
 "pLQ" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet,
@@ -99284,6 +99391,16 @@
 	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
+"qDq" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/fitness)
 "qEt" = (
 /obj/abstract/map/spawner/floorpill,
 /turf/simulated/floor/plating{
@@ -99306,10 +99423,19 @@
 /mob/living/simple_animal/mouse/common,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
-"qXU" = (
-/obj/structure/largecrate/skele_stand,
+"qWL" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/port)
+/area/crew_quarters/fitness)
 "rfu" = (
 /obj/machinery/electric_loom,
 /turf/simulated/floor/plating,
@@ -99384,6 +99510,17 @@
 "rVF" = (
 /turf/simulated/wall,
 /area/crew_quarters/captain)
+"svQ" = (
+/obj/structure/window/reinforced/tinted,
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/crew_quarters/fitness)
 "sAX" = (
 /obj/effect/landmark{
 	name = "bluespacerift"
@@ -99437,16 +99574,43 @@
 /obj/item/weapon/book/manual/security_antag_guide,
 /turf/simulated/floor/wood,
 /area/library)
+"sQI" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	name = "_North Fire Alarm";
+	pixel_y = 26
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/crew_quarters/locker)
+"sSq" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/crew_quarters/fitness)
+"tcx" = (
+/obj/structure/closet/emcloset/vox,
+/turf/simulated/floor,
+/area/hallway/primary/starboard)
 "tdv" = (
 /obj/effect/landmark/start{
 	name = "Medical Doctor"
 	},
 /turf/simulated/floor,
 /area/medical/exam_room)
-"tvj" = (
-/obj/structure/closet/emcloset/vox,
-/turf/simulated/floor,
-/area/hallway/primary/starboard)
 "tCs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -99555,6 +99719,14 @@
 	icon_state = "barber"
 	},
 /area/medical/cmo)
+"vtm" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/structure/window/reinforced/tinted,
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/crew_quarters/fitness)
 "vty" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/stamp/judge,
@@ -99611,6 +99783,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/supply/qm)
+"wdd" = (
+/obj/structure/window/reinforced/tinted,
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/crew_quarters/fitness)
 "why" = (
 /turf/simulated/wall,
 /area/mine/unexplored)
@@ -99666,10 +99846,6 @@
 /obj/structure/window/full/reinforced/plasma,
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/trade/start)
-"wAS" = (
-/obj/structure/largecrate/showers,
-/turf/simulated/floor/plating,
-/area/maintenance/port)
 "wBP" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor,
@@ -99738,12 +99914,6 @@
 	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
-"xXQ" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/turf/simulated/floor/plating,
-/area/science/podbay)
 
 (1,1,1) = {"
 aaa
@@ -192901,7 +193071,7 @@ bRS
 bOM
 bQs
 bNm
-wAS
+mDZ
 bnn
 bnn
 caU
@@ -193403,9 +193573,9 @@ bRT
 bTb
 bUB
 bNm
-qXU
-bnn
 bwI
+bnn
+bZP
 caV
 aaa
 abP
@@ -193904,11 +194074,11 @@ bOO
 bRU
 bOO
 bOO
-xXQ
+krQ
 bnn
 bnn
-bZP
-chL
+htt
+caV
 aaa
 abR
 aaa
@@ -194409,7 +194579,7 @@ bOP
 bNm
 bNm
 bnn
-bwI
+bZP
 caW
 aai
 cdg
@@ -194912,7 +195082,7 @@ bWb
 bNm
 bnn
 bnn
-chL
+caV
 aaa
 aai
 aaa
@@ -232519,7 +232689,7 @@ aTM
 aQZ
 aWP
 aPq
-nlk
+oVF
 aZH
 bch
 aZL
@@ -239057,9 +239227,9 @@ aaa
 bkM
 blU
 bng
-bnP
-bnP
-bnP
+fnO
+eWs
+oqf
 bnP
 brA
 bsH
@@ -239067,8 +239237,8 @@ btS
 brA
 bnP
 bnP
-bnP
-bnP
+sSq
+kvZ
 bBm
 bCW
 bEf
@@ -239559,7 +239729,7 @@ aaa
 bkM
 blV
 bng
-bnP
+chL
 boD
 boD
 boD
@@ -239570,7 +239740,7 @@ boD
 boD
 boD
 boD
-bnP
+wdd
 bBn
 bCV
 bCV
@@ -240061,7 +240231,7 @@ aaa
 bkM
 blW
 bng
-bnP
+chL
 boD
 boD
 boD
@@ -240072,7 +240242,7 @@ boD
 boD
 boD
 boD
-bnP
+wdd
 bBo
 bCV
 bCV
@@ -240563,7 +240733,7 @@ aaa
 bkM
 blW
 bng
-bnP
+chL
 boD
 boD
 boD
@@ -240574,7 +240744,7 @@ boD
 boD
 boD
 boD
-bnP
+wdd
 bBp
 bCV
 bCV
@@ -241065,7 +241235,7 @@ aaa
 bkM
 blX
 bng
-bnP
+chL
 boD
 boD
 boD
@@ -241076,7 +241246,7 @@ boD
 boD
 boD
 boD
-bnP
+wdd
 bBq
 bCV
 bEg
@@ -241567,7 +241737,7 @@ aaa
 bkM
 blX
 bng
-bnP
+dSW
 boD
 boD
 boD
@@ -241578,7 +241748,7 @@ boD
 boD
 boD
 boD
-bnP
+svQ
 bBr
 bCV
 bCV
@@ -242068,8 +242238,8 @@ aaa
 aaa
 bkM
 blX
-bng
-bnP
+nSX
+okI
 boE
 boD
 boD
@@ -242571,7 +242741,7 @@ aaa
 bkM
 blX
 bng
-bnP
+pIR
 boD
 boD
 boD
@@ -242582,7 +242752,7 @@ boD
 boD
 boD
 boD
-bnP
+bsI
 bzU
 bzU
 bzU
@@ -243073,7 +243243,7 @@ aaa
 bkM
 blY
 bng
-bnP
+chL
 boD
 boD
 boD
@@ -243084,7 +243254,7 @@ boD
 boD
 boD
 boD
-bnP
+wdd
 bBt
 bCY
 bEi
@@ -243575,7 +243745,7 @@ aai
 bkM
 blX
 bng
-bnP
+chL
 boD
 boD
 boD
@@ -243586,7 +243756,7 @@ boD
 boD
 boD
 boD
-bnP
+wdd
 bBu
 bCZ
 bCZ
@@ -244077,7 +244247,7 @@ aai
 bkM
 blZ
 bng
-bnP
+chL
 boD
 boD
 boD
@@ -244088,7 +244258,7 @@ boD
 boD
 boD
 boD
-bnP
+wdd
 bBv
 bDa
 bEj
@@ -244579,7 +244749,7 @@ aai
 bkM
 bma
 bng
-bnP
+chL
 boD
 boD
 boD
@@ -244590,7 +244760,7 @@ boD
 boD
 boD
 boD
-bnP
+wdd
 bBw
 bDa
 bEk
@@ -245081,18 +245251,18 @@ aai
 bkM
 bmb
 bng
-bnP
-bnP
-bnP
-bnP
+qDq
+eWs
+eWs
+oqf
 brB
-bnP
-bnP
+qWL
+oqf
 brB
-bnP
-bnP
-bnP
-bnP
+gtk
+eWs
+eWs
+vtm
 bBx
 bDa
 bEk
@@ -245588,7 +245758,7 @@ bnO
 bnO
 bqF
 brC
-bsI
+btT
 btT
 bvb
 bwo
@@ -246097,7 +246267,7 @@ bnP
 bxC
 byY
 bzV
-bBv
+sQI
 bDa
 bEl
 bFV
@@ -248113,7 +248283,7 @@ bHt
 bIK
 bKn
 brz
-tvj
+tcx
 bOu
 bQc
 bRI

--- a/maps/synergy.dmm
+++ b/maps/synergy.dmm
@@ -50496,14 +50496,10 @@
 /turf/simulated/floor,
 /area/hallway/secondary/entry)
 "bLR" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning";
-	tag = "icon-warning"
+/obj/structure/bed/chair/comfy/beige{
+	dir = 4
 	},
-/obj/machinery/status_display{
-	pixel_y = -32
-	},
-/turf/simulated/floor,
+/turf/simulated/floor/carpet,
 /area/hallway/secondary/entry)
 "bLS" = (
 /obj/effect/decal/warning_stripes{
@@ -50525,12 +50521,9 @@
 /turf/simulated/floor,
 /area/hallway/secondary/entry)
 "bLU" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	name = "_South Fire Alarm";
-	pixel_y = -26
+/turf/simulated/floor{
+	icon_state = "grimy"
 	},
-/turf/simulated/floor,
 /area/hallway/secondary/entry)
 "bLV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -80247,6 +80240,19 @@
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/escape/centcom)
+"cUi" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/storage/fancy/cigarettes{
+	pixel_y = 2
+	},
+/obj/item/weapon/lighter{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/hallway/secondary/entry)
 "cUj" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -98609,6 +98615,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
+"edo" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/reagent_containers/food/snacks/chips,
+/obj/item/weapon/reagent_containers/food/drinks/soda_cans/cola,
+/obj/machinery/light/small,
+/turf/simulated/floor/carpet,
+/area/hallway/secondary/entry)
+"ehN" = (
+/obj/machinery/vending/snack,
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/hallway/secondary/entry)
 "eyG" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor,
@@ -98842,6 +98861,12 @@
 	icon_state = "dark"
 	},
 /area/chapel/office)
+"hAN" = (
+/obj/structure/flora/pottedplant/random,
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/hallway/secondary/entry)
 "hDO" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -98991,6 +99016,15 @@
 /obj/docking_port/destination/pod3/shuttle,
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/escape/centcom)
+"kgQ" = (
+/obj/structure/sign/poster{
+	icon_state = "poster7";
+	pixel_x = -32
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/hallway/secondary/entry)
 "knr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
@@ -99204,21 +99238,6 @@
 	},
 /turf/simulated/wall,
 /area/crew_quarters/fitness)
-"olu" = (
-/obj/structure/window/full/plasma,
-/obj/structure/grille,
-/obj/structure/window/reinforced/plasma,
-/obj/structure/window/reinforced/plasma{
-	dir = 1
-	},
-/obj/structure/window/reinforced/plasma{
-	dir = 8
-	},
-/obj/structure/window/reinforced/plasma{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/bridge)
 "olS" = (
 /obj/item/clothing/accessory/storage/bandolier,
 /obj/item/weapon/gun/projectile/shotgun/doublebarrel,
@@ -99291,6 +99310,17 @@
 /obj/effect/decal/cleanable/vomit/pre_dry,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
+"oWV" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = -30
+	},
+/obj/structure/bed/chair/comfy/couch/right/beige{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/hallway/secondary/entry)
 "oXL" = (
 /obj/machinery/power/apc{
 	name = "_South APC";
@@ -99334,6 +99364,21 @@
 /obj/machinery/researcharchive,
 /turf/simulated/floor/wood,
 /area/library)
+"pxg" = (
+/obj/structure/window/full/plasma,
+/obj/structure/grille,
+/obj/structure/window/reinforced/plasma,
+/obj/structure/window/reinforced/plasma{
+	dir = 1
+	},
+/obj/structure/window/reinforced/plasma{
+	dir = 8
+	},
+/obj/structure/window/reinforced/plasma{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/bridge)
 "pEX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
@@ -99447,6 +99492,13 @@
 /mob/living/simple_animal/mouse/common,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"qVL" = (
+/obj/machinery/light,
+/obj/machinery/status_display{
+	pixel_y = -32
+	},
+/turf/simulated/floor,
+/area/hallway/secondary/entry)
 "qWL" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 4
@@ -99464,6 +99516,16 @@
 /obj/machinery/electric_loom,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
+"rqE" = (
+/obj/structure/table/woodentable,
+/obj/item/device/flashlight/lamp/green{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/hallway/secondary/entry)
 "rBu" = (
 /obj/structure/table,
 /obj/item/weapon/storage/toolbox/paint{
@@ -99663,6 +99725,9 @@
 	icon_state = "whitepurple"
 	},
 /area/science/hallway)
+"tXM" = (
+/turf/simulated/floor/carpet,
+/area/hallway/secondary/entry)
 "ubc" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -99705,6 +99770,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/glass/airless,
 /area/maintenance/port)
+"vaZ" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = -30
+	},
+/obj/structure/bed/chair/comfy/couch/left/beige{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/hallway/secondary/entry)
 "vbp" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -99918,6 +99994,12 @@
 	tag = "icon-platingdmg3"
 	},
 /area/maintenance/port)
+"xAR" = (
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/hallway/secondary/entry)
 "xBz" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
@@ -99938,6 +100020,10 @@
 	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
+"ybI" = (
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/carpet,
+/area/hallway/secondary/entry)
 
 (1,1,1) = {"
 aaa
@@ -211628,7 +211714,7 @@ aEz
 aTk
 aUP
 aWr
-olu
+pxg
 aaa
 baz
 bbL
@@ -254832,13 +254918,13 @@ bwA
 bHE
 bIR
 bKs
-bLP
+qVL
 bNf
 bNf
 bNf
 bNf
 bNf
-bNf
+bNe
 bNf
 bOD
 bOD
@@ -255334,13 +255420,13 @@ bwB
 bHF
 bIS
 bKt
-bLR
-bGd
-bOE
-bve
-bRP
-bRP
-bUx
+bwx
+bLU
+vaZ
+oWV
+hAN
+kgQ
+bLU
 bNf
 bNf
 bNf
@@ -255836,14 +255922,14 @@ bwB
 bHG
 bIT
 bKu
-bLS
-bNg
-bOF
-bQk
-bRQ
-bSZ
-bUy
-aaa
+bwx
+bLU
+bLU
+bLU
+bLU
+tXM
+bLR
+bGd
 aaa
 aaa
 aaa
@@ -256338,14 +256424,14 @@ bGf
 bHC
 bIU
 bKv
-bLT
-bNh
-bOG
-bvg
-bRP
-bRP
-bUz
-aaa
+bwx
+xAR
+rqE
+ehN
+cUi
+ybI
+edo
+bGd
 aaa
 aaa
 aaa
@@ -256840,14 +256926,14 @@ bDh
 bHD
 bIV
 bKw
-bLU
+bwx
 bGd
 bGd
 bGd
-aaa
-aaa
-aaa
-aaa
+bGd
+bGd
+bGd
+bGd
 aaa
 aaa
 aaa
@@ -257342,13 +257428,13 @@ bwA
 bHE
 bIW
 bKx
-bwx
-bGe
-aaa
-aaa
-aaa
-aaa
-aaa
+bLT
+bGd
+bOE
+bve
+bRP
+bRP
+bUx
 aaa
 aaa
 aaa
@@ -257844,13 +257930,13 @@ bwC
 bHH
 bIQ
 bKr
-bwx
-bwB
-aaa
-aaa
-aaa
-aaa
-aaa
+bLS
+bNg
+bOF
+bQk
+bRQ
+bSZ
+bUy
 aaa
 aaa
 aaa
@@ -258346,13 +258432,13 @@ bvm
 bHB
 bIQ
 bKr
-bwx
-bwC
-aaa
-aaa
-aaa
-aaa
-aaa
+bLT
+bNh
+bOG
+bvg
+bRP
+bRP
+bUz
 aaa
 aaa
 aaa
@@ -258849,9 +258935,9 @@ bHI
 bIQ
 bKr
 bwx
-bvm
-aaa
-aaa
+bGd
+bGd
+bGd
 aaa
 aaa
 aaa


### PR DESCRIPTION
Synergy is an alright map, but it needed some love. First step of this process (If I end up doing more anyways) is to hallways both in maint and in primary.
- Rewires a good amount of wiring to go through maint (Standard on maps when it can be done)
- Adds a few doors into maint (notably one in the chapel and one in the pod bay) 
- Moves a pai from maint into the bar because I got bullied into it 
- Adds some firelocks and emergency lockers (Holy shit there were like none)
- Makes holodeck tinted windows instead of walls (standard)
- Adds skub

For more technical autism, I also improved a lot of the area definitions (holy shit some were dumb)
[synergy]
:cl:
 * tweak: Various tweaks to Synergy
