### PR TITLE
Temporarily disable SMES hum sound

### DIFF
--- a/code/modules/power/battery.dm
+++ b/code/modules/power/battery.dm
@@ -58,7 +58,7 @@ var/global/list/battery_online =	list(
 	if(online)
 		if (!sound_emitter.is_currently_playing())
 			sound_emitter.play("smes_switch")
-		sound_emitter.play("smes_hum")
+		//sound_emitter.play("smes_hum")
 	else
 		if (sound_emitter.is_currently_playing())
 			sound_emitter.play("smes_switch")
@@ -116,16 +116,16 @@ var/global/list/battery_online =	list(
 /obj/machinery/power/battery/initialize()
 	..()
 	setup_sound()
-	update_sound()
+	//update_sound()
 
 /obj/machinery/power/battery/setup_sound()
 	sound_emitter = new /datum/sound_emitter(src, is_static = TRUE)
 	if(sound_emitter)
-		var/sound/smes_hum = sound()
-		smes_hum.file = 'sound/machines/looping/smes_hum.ogg'
-		smes_hum.repeat = 1
-		smes_hum.volume = 15
-		sound_emitter.add(smes_hum, "smes_hum")
+		//var/sound/smes_hum = sound()
+		//smes_hum.file = 'sound/machines/looping/smes_hum.ogg'
+		//smes_hum.repeat = 1
+		//smes_hum.volume = 15
+		//sound_emitter.add(smes_hum, "smes_hum")
 
 		var/sound/smes_switch = sound()
 		smes_switch.file = 'sound/machines/effects/smes_switch.ogg'
@@ -206,7 +206,7 @@ var/global/list/battery_online =	list(
 	// Reflect state change
 	if(_charging != charging || _online != online || _chargedisplay != chargedisplay())
 		update_icon()
-		update_sound()
+		//update_sound()
 
 /obj/machinery/power/battery/proc/chargedisplay()
 	return clamp(round(5.5*charge/(capacity ? capacity : 5e6)), 0, battery_charge.len)
@@ -325,7 +325,9 @@ var/global/list/battery_online =	list(
 	else if( href_list["online"] )
 		online = !online
 		update_icon()
-		update_sound()
+		if (sound_emitter)
+			sound_emitter.play("smes_switch")
+		//update_sound()
 	else if( href_list["input"] )
 		switch( href_list["input"] )
 			if("min")
@@ -396,7 +398,9 @@ var/global/list/battery_online =	list(
 	if(prob(50)) //Toggle on/off
 		online = !online
 		update_icon()
-		update_sound()
+		if (sound_emitter)
+			sound_emitter.play("smes_switch")
+		//update_sound()
 	else //Screw up power input/output
 		chargelevel = rand(0, max_input)
 		outputlevel = rand(0, max_output)


### PR DESCRIPTION
## What this does
Temporarily disable the SMES hum until a solution that doesn't involve the AI suffering endlessly is found

## Why it's good
AI can only hear whats in their core, which happens to only be a SMES most of the time. The AI can only hear a SMES buzzing, for the whole round

## How it was tested
joined local as AI and couldn't hear SMES buzz

 * tweak: Disabled SMES hum due to undue suffering on AI players in the current implementation
