### PR TITLE
Spreads the Clown Cart's Peels

### DIFF
--- a/code/game/objects/structures/vehicles/clowncart.dm
+++ b/code/game/objects/structures/vehicles/clowncart.dm
@@ -256,7 +256,7 @@
 				colour1 = "#000000"
 				colour2 = "#6D6D6D"
 				to_chat(user, "Selected color: Boring Black")
-		
+
 /obj/structure/bed/chair/vehicle/clowncart/emag_act(mob/user)
 	if(!emagged)
 		emagged = 1
@@ -301,10 +301,14 @@
 			draw_graffiti(old_pos)
 		else if(mode == MODE_PEELS)
 			if(!emagged)
-				new /obj/item/weapon/bananapeel/(old_pos)
+				var/atom/peel = new /obj/item/weapon/bananapeel/(old_pos)
+				peel.pixel_x = rand(-12,12)
+				peel.pixel_y = rand(-12,12)
 				reagents.remove_reagent(BANANA,BANANA_FOR_NORMAL_PEEL)
 			else
-				new /obj/item/weapon/bananapeel/traitorpeel/(old_pos)
+				var/atom/peel = new /obj/item/weapon/bananapeel/traitorpeel/(old_pos)
+				peel.pixel_x = rand(-12,12)
+				peel.pixel_y = rand(-12,12)
 				reagents.remove_reagent(BANANA,BANANA_FOR_TRAITOR_PEEL)
 	else
 		if(can_warn())


### PR DESCRIPTION
# Gunk Machine Visual Upgrade

## What this does
Changes the clown cart so that the peels are not all placed exactly in the middle of the tile when laid, leading to an unknowable peril for those having to clean it up. Instead, it looks like this.
![image](https://github.com/user-attachments/assets/6dc4f4dc-c4a7-40ad-9d82-61828064d458)
![image](https://github.com/user-attachments/assets/3df3fcd1-fc3d-45dd-9489-0d55e2d2556d)
![image](https://github.com/user-attachments/assets/94defa6b-3f61-4620-b2ed-ab829dc6adb5)

This is purely a visual upgrade. No mechanics of the PEEL have been changed.

## Why it's good
Well. Because this might remind people that the clown cart exists, it's not.

## How it was tested
honk see above honk honk

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Clown Cart Peels experience a wider placement range.
