### PR TITLE
Does Not Tip Update

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -130,7 +130,8 @@
 /obj/item/weapon/reagent_containers/food/snacks/proc/make_poisonous(var/list/additional_poisons)
 	var/original_total_volume = reagents.total_volume
 	reagents.clear_reagents()
-	var/static/list/possible_poisons = list(
+	//Generic poisonous chemicals
+	var/list/possible_poisons = list(
 		BLEACH,
 		PLASMA,
 		TOXIN,
@@ -1520,6 +1521,12 @@
 	reagents.add_reagent(NUTRIMENT, 6)
 	bitesize = 2
 
+/obj/item/weapon/reagent_containers/food/snacks/monkeyburger/make_poisonous(var/list/additional_poisons)
+	var/original_total_volume = reagents.total_volume
+	reagents.clear_reagents()
+	reagents.add_reagent(BEFF, original_total_volume/2)
+	reagents.add_reagent(HEARTBREAKER, original_total_volume/2)
+
 /obj/item/weapon/reagent_containers/food/snacks/monkeyburger/on_vending_machine_spawn()//Fast-Food Menu
 	reagents.chem_temp = COOKTEMP_READY
 
@@ -2550,6 +2557,12 @@
 	reagents.add_reagent(NUTRIMENT, 4)
 	bitesize = 2
 
+/obj/item/weapon/reagent_containers/food/snacks/fries/make_poisonous(var/list/additional_poisons)
+	var/original_total_volume = reagents.total_volume
+	reagents.clear_reagents()
+	reagents.add_reagent(SODIUMCHLORIDE, original_total_volume/2)
+	reagents.add_reagent(DIAMONDDUST, original_total_volume/2)
+
 /obj/item/weapon/reagent_containers/food/snacks/fries/processed/New()
 	..()
 	reagents.clear_reagents()
@@ -2669,6 +2682,13 @@
 	..()
 	reagents.add_reagent(NUTRIMENT, 6)
 	bitesize = 2
+
+/obj/item/weapon/reagent_containers/food/snacks/cheesyfries/make_poisonous(var/list/additional_poisons)
+	var/original_total_volume = reagents.total_volume
+	reagents.clear_reagents()
+	reagents.add_reagent(SODIUMCHLORIDE, original_total_volume/3)
+	reagents.add_reagent(DIAMONDDUST, original_total_volume/3)
+	reagents.add_reagent(CHEESYGLOOP, original_total_volume/3)
 
 /obj/item/weapon/reagent_containers/food/snacks/cheesyfries/punnet
 	name = "punnet of Cheesy Fries"
@@ -3097,6 +3117,12 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/bigbiteburger/on_vending_machine_spawn()//Fast-Food Menu XL
 	reagents.chem_temp = COOKTEMP_READY
+
+/obj/item/weapon/reagent_containers/food/snacks/bigbiteburger/make_poisonous(var/list/additional_poisons)
+	var/original_total_volume = reagents.total_volume
+	reagents.clear_reagents()
+	reagents.add_reagent(BEFF, original_total_volume/2)
+	reagents.add_reagent(HEARTBREAKER, original_total_volume/2)
 
 /obj/item/weapon/reagent_containers/food/snacks/enchiladas
 	name = "Enchiladas"
@@ -4388,6 +4414,25 @@
 	reagents.add_reagent(TOMATOJUICE, 6)
 	bitesize = 2
 
+/obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/margherita/make_poisonous(var/list/additional_poisons)
+	var/original_total_volume = reagents.total_volume
+	reagents.clear_reagents()
+	var/list/possible_poisons = list(
+		BLEACH,
+		PLASMA,
+		TOXIN,
+		SOLANINE,
+		PLASTICIDE,
+		RADIUM,
+		CRYPTOBIOLIN,
+		IMPEDREZENE,
+		SOYSAUCE
+	)
+	if(additional_poisons && additional_poisons.len)
+		possible_poisons += additional_poisons.Copy()
+	while(reagents.total_volume < original_total_volume)
+		reagents.add_reagent(pick(possible_poisons), rand(5, 10))
+
 /obj/item/weapon/reagent_containers/food/snacks/margheritaslice
 	name = "Margherita slice"
 	desc = "A slice of the most cheesy pizza in galaxy."
@@ -4421,6 +4466,43 @@
 	reagents.add_reagent(NUTRIMENT, 50)
 	reagents.add_reagent(TOMATOJUICE, 6)
 	bitesize = 2
+
+/obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/meatpizza/make_poisonous(var/list/additional_poisons)
+	var/original_total_volume = reagents.total_volume
+	reagents.clear_reagents()
+
+	var/virus_choice = pick(subtypesof(/datum/disease2/disease) - typesof(/datum/disease2/disease/predefined))
+	var/datum/disease2/disease/new_virus = new virus_choice
+
+	var/list/anti = list(
+		ANTIGEN_BLOOD	= 0,
+		ANTIGEN_COMMON	= 1,
+		ANTIGEN_RARE	= 2,
+		ANTIGEN_ALIEN	= 0,
+		)
+	var/list/bad = list(
+		EFFECT_DANGER_HELPFUL	= 0,
+		EFFECT_DANGER_FLAVOR	= 0,
+		EFFECT_DANGER_ANNOYING	= 1,
+		EFFECT_DANGER_HINDRANCE	= 2,
+		EFFECT_DANGER_HARMFUL	= 4,
+		EFFECT_DANGER_DEADLY	= 0,
+		)
+
+	new_virus.origin = "Poisoned Pizza"
+
+	new_virus.makerandom(list(40,60),list(20,90),anti,bad,src)
+
+	var/list/blood_data = list(
+		"viruses" = null,
+		"blood_DNA" = null,
+		"blood_type" = "O-",
+		"resistances" = null,
+		"trace_chem" = null,
+		"virus2" = list()
+	)
+	blood_data["virus2"]["[new_virus.uniqueID]-[new_virus.subID]"] = new_virus
+	reagents.add_reagent(BLOOD, original_total_volume, blood_data)
 
 /obj/item/weapon/reagent_containers/food/snacks/meatpizzaslice
 	name = "Meatpizza slice"
@@ -4461,6 +4543,15 @@
 	reagents.add_reagent(NUTRIMENT, 35)
 	bitesize = 2
 
+/obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/mushroompizza/make_poisonous(var/list/additional_poisons)
+	var/original_total_volume = reagents.total_volume
+	reagents.clear_reagents()
+	var/static/list/possible_poisons = list(
+		MINDBREAKER,
+		SPIRITBREAKER
+	)
+	reagents.add_reagent(pick(possible_poisons), original_total_volume)
+
 /obj/item/weapon/reagent_containers/food/snacks/mushroompizzaslice
 	name = "Mushroompizza slice"
 	desc = "Maybe it's the last slice of pizza in your life."
@@ -4482,6 +4573,11 @@
 	reagents.add_reagent(TOMATOJUICE, 6)
 	reagents.add_reagent(IMIDAZOLINE, 12)
 	bitesize = 2
+
+/obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/vegetablepizza/make_poisonous(var/list/additional_poisons)
+	var/original_total_volume = reagents.total_volume
+	reagents.clear_reagents()
+	reagents.add_reagent(MUTAGEN, original_total_volume)
 
 /obj/item/weapon/reagent_containers/food/snacks/vegetablepizzaslice
 	name = "Vegetable pizza slice"
@@ -4506,6 +4602,23 @@
 	reagents.add_reagent(DIAMONDDUST, 3)
 	reagents.add_reagent(TRICORDRAZINE, 8) //ambrosia's medical chems replacement
 	bitesize = 2
+
+
+/obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/blingpizza/make_poisonous(var/list/additional_poisons)
+	var/original_total_volume = reagents.total_volume
+	reagents.clear_reagents()
+	var/list/possible_poisons = list(
+		CYANIDE,
+		DIAMONDDUST,
+		RADIUM,
+		MERCURY,
+		URANIUM,
+		LEAD,
+	)
+	if(additional_poisons && additional_poisons.len)
+		possible_poisons += additional_poisons.Copy()
+	while(reagents.total_volume < original_total_volume)
+		reagents.add_reagent(pick(possible_poisons), rand(5, 10))
 
 /obj/item/weapon/reagent_containers/food/snacks/blingpizzaslice
 	name = "Blingpizza slice"

--- a/code/modules/store/items.dm
+++ b/code/modules/store/items.dm
@@ -13,19 +13,10 @@
 	var/thing = new typepath(merchcomp.loc)
 	var/turf/T = get_turf(merchcomp)
 	T.turf_animation('icons/effects/96x96.dmi',"beamin",-32,0,MOB_LAYER+1,'sound/weapons/emitter2.ogg',anim_plane = EFFECTS_PLANE)
-	if(istype(typepath,/obj/item/weapon/storage))
+	if(ispath(typepath,/obj/item/weapon/storage))
 		var/obj/item/weapon/storage/S = thing
 		if(station_does_not_tip)
-			var/list/additional_types = list(
-				IRRADIATEDBEANS,
-				MUTATEDBEANS,
-				CHEESYGLOOP,
-				DIABEETUSOL,
-				HORSEMEAT,
-				BEFF,
-				TOXICWASTE,
-				MOONROCKS,
-			)
+			var/list/additional_types = list()
 			if(istype(S,/obj/item/weapon/storage/bag/zam_food/))
 				additional_types.Add(WATER) //Bad for greys
 			for(var/obj/item/weapon/reagent_containers/food/snacks/F in S)


### PR DESCRIPTION
# Ordering out is dangerous again!

## What this does
This PR cleans up the "Does Not Tip" traitor tool a little bit, changing some effects and fixing some bugs. The new functionality is as follows.
1. Cargo pizzas will arrive poisoned in specific ways depending on the type of pizza, as they originally were many years back before #32130 modified how poisoning food worked.
   1. Meatpizza will be poisoned with blood, containing a deadly disease from being undercooked!
   2. Margherita will be a variety of poisons, all of which are quite deadly. A variety of bad cheeses!
   3. Mushroom will have you tripping out hard with Spiritbreaker and Mindbreaker. Bad shrooms.
   4. Vegetables? They're grown in botany, using mutated plants. They forgot to wash them before using them.
   5. And the new NT Blingpizza, made from the finest and most expensive ingredients. Now, it's made with the even more finest of metals and sauces money could buy.
2. Merch Computers will now actually have poisoned food - #32130 never worked due to a bug.
   1. Fast food burgers will be a little bit on the artery blocking side. Heartbreaker with a side of beff will clog those lungs up good with real bad acid reflux.
   2. Fries will be hard as rocks and drenched in salt. Borers beware!
   3. Lunch boxed foods and other misc foods will have various poisons spread amongst them due to poor quality control.
   4. Zam foods will function like lunch boxed foods, but with the additional poison of water being available.
3. Randomized Kegs maintain their current functionality, increasing the danger of having deadly poisons mixed in with their brew from mishandling.
4. Regular chef ingredients, such as fresh meat, fruits, animals, etc, are unaffected by not tipping just like before.

## Why it's good
Because it's a nerf to the Merch Computer, it's actually good. This is not grudgecode this is not grudgecode it's not no it's not no no no no.

## How it was tested
![image](https://github.com/user-attachments/assets/c6e28474-bf9a-40a8-ae17-ed7aba9ca63c)
![image](https://github.com/user-attachments/assets/4d7f9869-13c1-4833-bcc2-bb8a661844f0)
![image](https://github.com/user-attachments/assets/31b71d66-6a40-448c-9d7b-b64b997afd9c)
![image](https://github.com/user-attachments/assets/a5762fd6-204d-43be-af7d-223d4423d6af)
![image](https://github.com/user-attachments/assets/fa45c04b-4ba4-4086-b61b-1c0aab3c915f)
![image](https://github.com/user-attachments/assets/35193777-712c-4b23-81b6-aca76fe5298d)
![image](https://github.com/user-attachments/assets/23f522fb-2750-47b5-80b4-8073c253cd63)

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: The Merch Computer is now affected by Does Not Tip. Buyer beware!
 * tweak: Cargo Pizzas now contain specific poisons when the station Does Not Tip.
