### PR TITLE
Prevents Staff of Polymorph from polymorphing people into hivelord guardian brood

### DIFF
--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -304,24 +304,25 @@ var/holomaps_initialized = 0
 
 //Broken mob list
 var/list/blacklisted_mobs = list(
-		/mob/living/simple_animal/space_worm,							// Unfinished. Very buggy, they seem to just spawn additional space worms everywhere and eating your own tail results in new worms spawning.
-		/mob/living/simple_animal/hostile/humanoid,						// JUST DON'T DO IT, OK?
-		/mob/living/simple_animal/hostile/retaliate/cockatrice,			// I'm just copying this from transmog.
-		/mob/living/simple_animal/hostile/giant_spider/hunter/dead,		// They are dead.
-		/mob/living/simple_animal/hostile/asteroid/hivelordbrood,		// Your motherfucking life ends in 5 seconds.
-		/mob/living/simple_animal/hologram,								// Can't live outside the holodeck.
-		/mob/living/simple_animal/hostile/carp/holocarp,				// These can but they're just a retarded hologram carp reskin for the love of god.
-		/mob/living/slime_pile,											// They are dead.
-		/mob/living/adamantine_dust, 									// Ditto
-		/mob/living/simple_animal/hostile/viscerator,					// Nope.
-		/mob/living/simple_animal/hostile/mining_drone,					// This thing is super broken in the hands of a player and it was never meant to be summoned out of actual mining drone cubes.
-		/mob/living/simple_animal/bee,									// Aren't set up to be playable
-		/mob/living/simple_animal/hostile/asteroid/goliath/david/dave,	// Isn't supposed to be spawnable by xenobio
-		/mob/living/simple_animal/hostile/bunnybot,						// See viscerator
-		/mob/living/carbon/human/NPC,									// Unfinished, with its own AI that conflicts with player movements.
-		/mob/living/simple_animal/hostile/pulse_demon,					// Your motherfucking life ends in 0 seconds.
-		/mob/living/simple_animal/hostile/pulse_demon/maxedout,			// Admin testing mob, do not ever spawn otherwise.
-		/mob/living/simple_animal/hostile/slime,						// Instantly kills player and destroys the MC.
+		/mob/living/simple_animal/space_worm,								// Unfinished. Very buggy, they seem to just spawn additional space worms everywhere and eating your own tail results in new worms spawning.
+		/mob/living/simple_animal/hostile/humanoid,							// JUST DON'T DO IT, OK?
+		/mob/living/simple_animal/hostile/retaliate/cockatrice,				// I'm just copying this from transmog.
+		/mob/living/simple_animal/hostile/giant_spider/hunter/dead,			// They are dead.
+		/mob/living/simple_animal/hostile/asteroid/hivelordbrood,			// Your motherfucking life ends in 5 seconds.
+		/mob/living/simple_animal/hostile/asteroid/hivelordbrood/guardian,	// Ditto
+		/mob/living/simple_animal/hologram,									// Can't live outside the holodeck.
+		/mob/living/simple_animal/hostile/carp/holocarp,					// These can but they're just a retarded hologram carp reskin for the love of god.
+		/mob/living/slime_pile,												// They are dead.
+		/mob/living/adamantine_dust, 										// Ditto
+		/mob/living/simple_animal/hostile/viscerator,						// Nope.
+		/mob/living/simple_animal/hostile/mining_drone,						// This thing is super broken in the hands of a player and it was never meant to be summoned out of actual mining drone cubes.
+		/mob/living/simple_animal/bee,										// Aren't set up to be playable
+		/mob/living/simple_animal/hostile/asteroid/goliath/david/dave,		// Isn't supposed to be spawnable by xenobio
+		/mob/living/simple_animal/hostile/bunnybot,							// See viscerator
+		/mob/living/carbon/human/NPC,										// Unfinished, with its own AI that conflicts with player movements.
+		/mob/living/simple_animal/hostile/pulse_demon,						// Your motherfucking life ends in 0 seconds.
+		/mob/living/simple_animal/hostile/pulse_demon/maxedout,				// Admin testing mob, do not ever spawn otherwise.
+		/mob/living/simple_animal/hostile/slime,							// Instantly kills player and destroys the MC.
 		)
 
 //Boss monster list

--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -323,6 +323,7 @@ var/list/blacklisted_mobs = list(
 		/mob/living/simple_animal/hostile/pulse_demon,						// Your motherfucking life ends in 0 seconds.
 		/mob/living/simple_animal/hostile/pulse_demon/maxedout,				// Admin testing mob, do not ever spawn otherwise.
 		/mob/living/simple_animal/hostile/slime,							// Instantly kills player and destroys the MC.
+		/mob/living/simple_animal/hostile/asteroid/goldgrub,                 // High chance of running off and disappearing.
 		)
 
 //Boss monster list

--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -323,7 +323,7 @@ var/list/blacklisted_mobs = list(
 		/mob/living/simple_animal/hostile/pulse_demon,						// Your motherfucking life ends in 0 seconds.
 		/mob/living/simple_animal/hostile/pulse_demon/maxedout,				// Admin testing mob, do not ever spawn otherwise.
 		/mob/living/simple_animal/hostile/slime,							// Instantly kills player and destroys the MC.
-		/mob/living/simple_animal/hostile/asteroid/goldgrub,                 // High chance of running off and disappearing.
+		/mob/living/simple_animal/hostile/asteroid/goldgrub,				// High chance of running off and disappearing.
 		)
 
 //Boss monster list


### PR DESCRIPTION
They disappear in 10 seconds and have a high chance of breaking polymorphing altogether due to #37964. Regular hive broods are already blacklisted.

:cl:
 * bugfix: The Staff of Polymorph and other polymorphing effects can no longer turn people into hivelord guardian broods.