### PR TITLE
Changes SMES charge designation from W to KW

### DIFF
--- a/code/modules/power/battery.dm
+++ b/code/modules/power/battery.dm
@@ -265,8 +265,8 @@ var/global/list/battery_online =	list(
 	var/data[0]
 	data["nameTag"] = name_tag
 	data["storedCapacity"] = round(100.0*charge/capacity, 0.1)
-	data["charge"] = charge ? charge/SMESRATE : 0 //Compensates for the input/output rate
-	data["capacity"] = capacity ? capacity/SMESRATE : 0
+	data["charge"] = charge ? charge/SMESRATE/1000 : 0 //Compensates for the input/output rate
+	data["capacity"] = capacity ? capacity/SMESRATE/1000 : 0
 	data["charging"] = charging
 	data["chargeMode"] = chargemode
 	data["chargeLoad"] = round(chargereceived)

--- a/code/modules/power/battery.dm
+++ b/code/modules/power/battery.dm
@@ -265,7 +265,7 @@ var/global/list/battery_online =	list(
 	var/data[0]
 	data["nameTag"] = name_tag
 	data["storedCapacity"] = round(100.0*charge/capacity, 0.1)
-	data["charge"] = charge ? charge/SMESRATE/1000 : 0 //Compensates for the input/output rate
+	data["charge"] = charge ? charge/SMESRATE/1000 : 0 //Compensates for the input/output rate, and converts the value into kilo (1000)
 	data["capacity"] = capacity ? capacity/SMESRATE/1000 : 0
 	data["charging"] = charging
 	data["chargeMode"] = chargemode

--- a/nano/templates/smes.tmpl
+++ b/nano/templates/smes.tmpl
@@ -6,7 +6,7 @@
 		Stored Capacity:
 	</div>
 	<div class="itemContent">
-		{{:helper.displayBar(data.storedCapacity, 0, 100, data.charging ? 'good' : 'average', data.charge + '/' + data.capacity)}}
+		{{:helper.displayBar(data.storedCapacity, 0, 100, data.charging ? 'good' : 'average', data.charge + '/' + data.capacity + 'KW')}}
 		<div class="statusValue">
 			{{:helper.round(data.storedCapacity)}}%
 		</div>

--- a/nano/templates/smes.tmpl
+++ b/nano/templates/smes.tmpl
@@ -6,7 +6,7 @@
 		Stored Capacity:
 	</div>
 	<div class="itemContent">
-		{{:helper.displayBar(data.storedCapacity, 0, 100, data.charging ? 'good' : 'average', data.charge + '/' + data.capacity + 'KW')}}
+		{{:helper.displayBar(data.storedCapacity, 0, 100, data.charging ? 'good' : 'average', data.charge + '/' + data.capacity + ' kW')}}
 		<div class="statusValue">
 			{{:helper.round(data.storedCapacity)}}%
 		</div>


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/b3f22a93-feae-4ed4-a726-8bb30705a01e"/>

It's more descriptive at a glance than the huge number it used to have.
:cl:
 * tweak: The charge amount in the SMES menu has been changed from showing W to KW.