### PR TITLE
Pulse Demons cannot be grabbed/dragged anymore

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
@@ -558,9 +558,17 @@
 
 //Can't be scooped up
 /mob/living/simple_animal/hostile/pulse_demon/scoop_up(mob/M)
-	to_chat(M, span_warning("You attempt to grab \the [src] but it slips out of your hands!"))
+	var/obj/item/clothing/gloves/golden/G = M.get_item_by_slot(slot_gloves)
+	if(istype(G))
+		return ..()
+	M.visible_message(span_warning("[M] attempted to grab the [src] but it slipped right through their hands!"))
+	shockMob(M)
 
 //Can't be dragged either
 /mob/living/simple_animal/hostile/pulse_demon/can_be_pulled(mob/user)
-	to_chat(user, span_warning("You attempt to grab \the [src] but it slips out of your hands!"))
+	var/obj/item/clothing/gloves/golden/G = user.get_item_by_slot(slot_gloves)
+	if(istype(G))
+		return ..()
+	user.visible_message(span_warning("[user] attempted to grab the [src] but it slipped right through their hands!"))
+	shockMob(user)
 	return 0

--- a/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
@@ -234,7 +234,7 @@
 	if(current_cable?.powernet)
 		current_cable.powernet.haspulsedemon = FALSE
 	. = ..()
-	
+
 /mob/living/simple_animal/hostile/pulse_demon/proc/is_under_tile()
 	var/turf/simulated/floor/F = get_turf(src)
 	return istype(F,/turf/simulated/floor) && F.floor_tile
@@ -555,3 +555,12 @@
 				CI.plane = ABOVE_LIGHTING_PLANE
 				cables_shown += CI
 				client.images += CI
+
+//Can't be scooped up
+/mob/living/simple_animal/hostile/pulse_demon/scoop_up(mob/M)
+	to_chat(M, span_warning("You attempt to grab \the [src] but it slips out of your hands!"))
+
+//Can't be dragged either
+/mob/living/simple_animal/hostile/pulse_demon/can_be_pulled(mob/user)
+	to_chat(user, span_warning("You attempt to grab \the [src] but it slips out of your hands!"))
+	return 0


### PR DESCRIPTION
As fun as the imagery is it doesn't make a lot of sense because pulse demons are already pretty much immune to most forms of attacks save for ions/EMPs, they are electricity, can't really grab that, things pass through them. Despite the circumstances in which I found out about this feature (being dragged while playing pulse demon) I don't do this because of that.
They can still be grabbed and dragged if you have the Golden Gloves from a trader.

:cl:
 * tweak: Pulse Demons can no longer be dragged nor grabbed, unless you have certain golden gloves from the Trader (NOT the regular insulated gloves). They're pure electricity!