### PR TITLE
Pulse Demon powers should no longer show maxed levels for attributes that can't be upgraded

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon_powers.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon_powers.dm
@@ -133,8 +133,11 @@
 			if(!S.invisible) //Do not list abilities that aren't meant to be shown, like drain toggling or abilities
 				var/icon/spellimg = icon('icons/mob/screen_spells.dmi', S.hud_state)
 				dat += "<img class='icon' src='data:image/png;base64,[iconsouth2base64(spellimg)]'> <B>[S.name]</B> "
-				dat += "[S.can_improve(SP_SPEED) ? "<A href='byond://?src=\ref[src];quicken=1;spell=\ref[S]'>Quicken for [S.quicken_cost]W ([S.spell_levels[SP_SPEED]]/[S.level_max[SP_SPEED]])</A>" : "Quicken (MAXED)"] "
-				dat += "[S.can_improve(SP_POWER) ? "<A href='byond://?src=\ref[src];empower=1;spell=\ref[S]'>Empower for [S.empower_cost]W ([S.spell_levels[SP_POWER]]/[S.level_max[SP_POWER]])</A>" : "Empower (MAXED)"]<BR>"
+				if(S.level_max[SP_SPEED] > 1)
+					dat += "[S.can_improve(SP_SPEED) ? "<A href='byond://?src=\ref[src];quicken=1;spell=\ref[S]'>Quicken for [S.quicken_cost]W ([S.spell_levels[SP_SPEED]]/[S.level_max[SP_SPEED]])</A>" : "Quicken (MAXED)"] "
+				if(S.level_max[SP_POWER] > 1)
+					dat += "[S.can_improve(SP_POWER) ? "<A href='byond://?src=\ref[src];empower=1;spell=\ref[S]'>Empower for [S.empower_cost]W ([S.spell_levels[SP_POWER]]/[S.level_max[SP_POWER]])</A>" : "Empower (MAXED)"]"
+				dat += "<BR>"
 				if(show_desc)
 					dat += "<I>[S.desc]</I><BR>"
 		dat += "<HR>"


### PR DESCRIPTION
Now the attributes simply don't show up at all, so it'll look just like Quicken (MAXED) instead of both Quicken (MAXED) and Empower (MAXED) 

:cl:
 * bugfix: Spells in the Pulse Demon's power menu will no longer show (MAXED) upgrades that it could not upgrade in the first place.