### PR TITLE
Pulse Demons inside APCs will now lock silicons out of the local machinery

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -495,6 +495,10 @@ Class Procs:
 
 /obj/machinery/attack_ai(mob/user as mob)
 	src.add_hiddenprint(user)
+	var/area/A = get_area(src)
+	if(A.areaapc && A.areaapc.pulselocked)
+		to_chat(user, span_warning("Electromagnetic anomalies are preventing you from interfacing with the area's machinery!"))
+		return
 	if(isrobot(user))
 		// For some reason attack_robot doesn't work
 		// This is to stop robots from using cameras to remotely control machines.

--- a/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
@@ -204,9 +204,11 @@
 		if(istype(current_power,/obj/machinery/power/battery) && draining)
 			var/obj/machinery/power/battery/current_battery = current_power
 			suckBattery(current_battery)
-		else if(istype(current_power,/obj/machinery/power/apc) && draining)
+		else if(istype(current_power,/obj/machinery/power/apc))
 			var/obj/machinery/power/apc/current_apc = current_power
-			drainAPC(current_apc)
+			if(draining)
+				drainAPC(current_apc)
+			current_apc.pulselocked = min(current_apc.pulselocked + 2, 5) //Up to 10 seconds of locking silicons out of controlling an area's machinery
 		if(current_power.avail() < amount_per_regen)
 			power_lost()
 		else
@@ -234,7 +236,7 @@
 	if(current_cable?.powernet)
 		current_cable.powernet.haspulsedemon = FALSE
 	. = ..()
-	
+
 /mob/living/simple_animal/hostile/pulse_demon/proc/is_under_tile()
 	var/turf/simulated/floor/F = get_turf(src)
 	return istype(F,/turf/simulated/floor) && F.floor_tile
@@ -267,6 +269,7 @@
 				controlling_area = get_area(current_power)
 				PCC.Grant(src)
 				to_chat(src, "<span class='notice'>You can interact with various electronic objects in the room while connected to the APC.</span>")
+				current_apc.pulselocked = 5
 			else
 				hijackAPC(current_apc)
 			if(draining)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -121,6 +121,8 @@
 
 	var/recharge_load = 0 // How much power we've requested for recharging purposes
 
+	var/pulselocked = 0 // Determines in process() how long silicons are locked out from interacting with machinery in the APC's area
+
 /obj/machinery/power/apc/get_cell()
 	return cell
 
@@ -1149,7 +1151,7 @@
 		return 0
 
 /obj/machinery/power/apc/process()
-
+	pulselocked = max(0, --pulselocked)
 	if(stat & (BROKEN|MAINT|FORCEDISABLE))
 		return
 	var/area/this_area = get_area(src)


### PR DESCRIPTION
Now THIS is menacing.
Pulse Demons inside APCs and for a few seconds after leaving it will prevent silicons from remotely interfacing with the area's machinery. They may still interact in some cases such as walking into airlocks to open them but they cannot access computers or anything of the sort until the anomaly is gone. This is both more in theme with the Pulse Demon causing havoc and being dangerous to machines, and I kinda enjoy this change in particular.

To-do: Actually test this
To-do: Remove or rework pulselocked variable change upon entering an APC
To-do: Unique overlay sprites for an APC that's currently affected, such as electricity arcing out of it.
To-do: Maybe change how it's handled so that it doesn't tick down pulselocked every single tick and when the APC is disabled, and instead have the silicon check if the APC is active in the first place for pulselocked to matter.

:cl:
 * rscadd: Pulse Demons inside APCs will lock out silicons from interfacing with machines in the same area as the APC while the Pulse Demon is inside the APC and for a few seconds afterwards.