### PR TITLE
Removes Killdozer Modkits from the Protolathe

### DIFF
--- a/code/modules/research/designs/robotics.dm
+++ b/code/modules/research/designs/robotics.dm
@@ -113,6 +113,7 @@
 	category = "Misc"
 	build_path = /obj/item/device/mech_painter
 
+/* Perhaps this can come back one day in the future, when one can't spam them every round
 /datum/design/killdozer_modkit
 	name = "Ripley Killdozer kit"
 	desc = "this never even shows up ingame???"
@@ -122,3 +123,4 @@
 	materials = list(MAT_IRON = 275000, MAT_GLASS = 1000) //LODSOFMETAL
 	category = "Robotics"
 	build_path = /obj/item/mecha_parts/mecha_equipment/passive/killdozer_kit
+*/


### PR DESCRIPTION
# The Double Nerf

## What this does
This PR removes the killdozer modkit from being printed from the protolathe.

## Why it's good
Killdozers were meant to be something like a single traitor (likely a cargo tech or miner) finally going full rage mode; taking what would normally be standard heavy machinery and going to town with it. Not, uh, a single nerdy scientist handing out assembly line combat mechs that don't require anything more than iron or glass.

## How it was tested
It wasn't.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscdel: Removes killdozers from the protolathe.