### PR TITLE
Enables Browser Inspect for Admins

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -807,6 +807,7 @@ var/list/admin_verbs_mod = list(
 				send2adminirc("[key_name(src, showantag = FALSE)] deadminned themself - no more non-AFK admins online. - [admin_number_afk] AFK.")
 				send2admindiscord("[key_name(src, showantag = FALSE)] deadminned themself. **No more non-AFK admins online.** - **[admin_number_afk]** AFK", TRUE)
 		deadmin()
+		winset(src, null, list("browser-options"="-devtools"))
 		verbs += /client/proc/readmin
 		deadmins += ckey
 		to_chat(src, "<span class='interface'>You are now a normal player.</span>")

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -36,6 +36,8 @@ var/list/admin_datums = list()
 		owner = C
 		owner.holder = src
 		owner.add_admin_verbs()	//TODO
+		if(C.byond_version >= 516 && C.holder.rights & R_DEBUG)
+			winset(C, null, list("browser-options"="+devtools"))
 		admins |= C
 		owner.verbs -= /client/proc/readmin
 


### PR DESCRIPTION
# Now I can see the secret HTML codes!

## What this does
This uses a new web 516 feature (see here: [reference](https://www.byond.com/docs/ref/index.html#/proc/winset)) to enable admins to inspect browser windows via right click if they have +DEBUG.

## Why it's good
Because this is allowing me to quickly make more cursed clown sleepers, it's not.

## How it was tested
Got on as admin, worked, deadminned, didn't work, readminned, worked. Make sure ctrl+f and refresh still worked while testing.
<img width="221" height="284" alt="image" src="https://github.com/user-attachments/assets/5d5ecefc-0b6a-4a29-b447-e32e2d9065d9" />
<img width="537" height="445" alt="image" src="https://github.com/user-attachments/assets/13446ac8-aaef-4faf-a400-88524ed4c27d" />

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Admins can directly inspect UIs now.