### PR TITLE
Removes Syndie Origin from Tesla Energy Relay

### DIFF
--- a/code/modules/mecha/equipment/tools/tools.dm
+++ b/code/modules/mecha/equipment/tools/tools.dm
@@ -995,7 +995,7 @@
 	name = "\improper Energy Relay Module"
 	desc = "Wirelessly drains energy from any available power channel in area. The performance index is quite low."
 	icon_state = "tesla"
-	origin_tech = Tc_MAGNETS + "=4;" + Tc_SYNDICATE + "=2"
+	origin_tech = Tc_MAGNETS + "=4;" + Tc_POWERSTORAGE + "=3"
 	equip_cooldown = 10
 	energy_drain = 0
 	range = 0


### PR DESCRIPTION
# Free Syndie Gear Nerfs!

## What this does
This closes a research ~~exploit~~fully intended ability where you could print a Tesla Energy Relay (requiring only Magnets 4 and Power 3) and get Syndicate research up to 3 from it. It's been replaced with Power 3.

## Why it's good
Because now you have to actually sacrifice syndicate items to produce syndicate gear, it's not.

## How it was tested
Compiled, yeeted myself into science, spawned one, threw it in the destructo-machine.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscdel: Tesla Energy Relay Modules no longer give Syndicate research.
