### PR TITLE
Stunbaton fixes

### DIFF
--- a/code/datums/supply_packs/security.dm
+++ b/code/datums/supply_packs/security.dm
@@ -74,8 +74,8 @@
 
 /datum/supply_packs/greyweapons
 	name = "MDF surplus weapons"
-	contains = list(/obj/item/weapon/melee/stunprobe,
-					/obj/item/weapon/melee/stunprobe,
+	contains = list(/obj/item/weapon/melee/baton/stunprobe,
+					/obj/item/weapon/melee/baton/stunprobe,
 					/obj/item/weapon/gun/energy/smalldisintegrator,
 					/obj/item/weapon/gun/energy/smalldisintegrator)
 	cost = 60

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -103,7 +103,7 @@
 	if(!anchored)
 		to_chat(user, "<span class='warning'>You must secure \the [src] before you can make use of it!</span>")
 		return 1
-	if(istype(G, /obj/item/weapon/gun/energy) || istype(G, /obj/item/weapon/melee/baton) || istype(G, /obj/item/weapon/melee/stunprobe) || istype(G, /obj/item/energy_magazine) || istype(G, /obj/item/ammo_storage/magazine/lawgiver) || istype(G, /obj/item/weapon/rcs) || istype(G, /obj/item/clothing/head/helmet/stun))
+	if(istype(G, /obj/item/weapon/gun/energy) || istype(G, /obj/item/weapon/melee/baton) || istype(G, /obj/item/energy_magazine) || istype(G, /obj/item/ammo_storage/magazine/lawgiver) || istype(G, /obj/item/weapon/rcs) || istype(G, /obj/item/clothing/head/helmet/stun))
 		if (istype(G, /obj/item/weapon/gun/energy))
 			var/obj/item/weapon/gun/energy/gun = G
 			if (!gun.rechargeable)
@@ -235,20 +235,6 @@
 					has_beeped = TRUE
 			else
 				icon_state = "recharger0"
-		else if(istype(charging, /obj/item/weapon/melee/stunprobe)) //25e power loss is so minor that the game shouldn't bother calculating the efficiency of better parts for it
-			var/obj/item/weapon/melee/stunprobe/B = charging
-			if(B.bcell)
-				if(B.bcell.give(175*charging_speed_modifier))
-					icon_state = "recharger1"
-					if(!self_powered)
-						use_power(200*charging_speed_modifier)
-				else
-					icon_state = "recharger2"
-					if(!has_beeped)
-						playsound(src, 'sound/machines/charge_finish.ogg', 50)
-					has_beeped = TRUE
-			else
-				icon_state = "recharger0"
 		else if(istype(charging, /obj/item/clothing/head/helmet/stun))
 			var/obj/item/clothing/head/helmet/stun/B = charging
 			if(B.bcell)
@@ -290,11 +276,6 @@
 		var/obj/item/weapon/gun/energy/E = charging
 		if(E.power_supply)
 			E.power_supply.emp_act(severity)
-
-	if(istype(charging, /obj/item/weapon/melee/stunprobe))
-		var/obj/item/weapon/melee/stunprobe/B = charging
-		if(B.bcell)
-			B.bcell.charge = 0
 
 	else if(istype(charging, /obj/item/weapon/melee/baton))
 		var/obj/item/weapon/melee/baton/B = charging
@@ -356,17 +337,6 @@
 			return
 		if(istype(charging, /obj/item/weapon/melee/baton))
 			var/obj/item/weapon/melee/baton/B = charging
-			if(B.bcell)
-				if(B.bcell.give(175))
-					icon_state = "wrecharger1"
-					if(!self_powered)
-						use_power(200)
-				else
-					icon_state = "wrecharger2"
-			else
-				icon_state = "wrecharger3"
-		if(istype(charging, /obj/item/weapon/melee/stunprobe))
-			var/obj/item/weapon/melee/stunprobe/B = charging
 			if(B.bcell)
 				if(B.bcell.give(175))
 					icon_state = "wrecharger1"

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -194,7 +194,7 @@
 			return FALSE
 
 	//Has to be turned on.
-	//Either hit (returned 1 on harm intent attack), or isn't on harm intent (we quit early).
+	//Either hit (returned 1 on harm intent attack), or isn't on harm intent (we quit early if it is on harm intent and failed).
 	//Help intent has no chance to miss on an attack.
 	if(status && (. || baton_tap)) // This is charged : we stun
 		user.lastattacked = L

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -16,7 +16,9 @@
 	var/obj/item/weapon/cell/bcell = null
 	var/hitcost = 100 // 10 hits on crap cell
 	var/stunsound = 'sound/weapons/Egloves.ogg'
-	var/swingsound = "swing_hit"
+	var/can_swap_cell = TRUE // Determines whether the cell can be swapped
+	var/has_stun_message = TRUE // Determines if it'll say that the target has been stunned. Only important for the alien stun probe currently
+	hitsound = "swing_hit"
 
 /obj/item/weapon/melee/baton/get_cell()
 	return bcell
@@ -78,9 +80,9 @@
 /obj/item/weapon/melee/baton/examine(mob/user)
 	..()
 	if(bcell)
-		to_chat(user, "<span class='info'>The baton is [round(bcell.percent())]% charged.</span>")
+		to_chat(user, "<span class='info'>\The [src] is [round(bcell.percent())]% charged.</span>")
 	if(!bcell)
-		to_chat(user, "<span class='warning'>The baton does not have a power source installed.</span>")
+		to_chat(user, "<span class='warning'>\The [src] does not have a power source installed.</span>")
 
 /obj/item/weapon/melee/baton/attackby(obj/item/weapon/W, mob/user)
 	if(ispowercell(W))
@@ -93,7 +95,7 @@
 			to_chat(user, "<span class='notice'>[src] already has a cell.</span>")
 
 	else if(W.is_screwdriver(user))
-		if(bcell)
+		if(bcell && can_swap_cell)
 			bcell.updateicon()
 			bcell.forceMove(get_turf(src.loc))
 			bcell = null
@@ -125,13 +127,11 @@
 				qdel(HONKER)
 				qdel(src)
 
-/obj/item/weapon/melee/baton/proc/apply_baton_effect(mob/victim)
-	victim.Knockdown(stunforce)
-	victim.Stun(stunforce)
-	if(iscarbon(victim))
-		var/mob/living/L = victim
+/obj/item/weapon/melee/baton/proc/apply_baton_effect(mob/living/L)
+	L.Knockdown(stunforce)
+	L.Stun(stunforce)
+	if(iscarbon(L))
 		L.apply_effect(10, STUTTER)
-	return
 
 /obj/item/weapon/melee/baton/attack_self(mob/user)
 	if(status && clumsy_check(user) && prob(50))
@@ -169,16 +169,16 @@
 		return
 
 	if(isrobot(M))
-		..()
-		return
+		return ..()
 	if(!isliving(M))
 		return
 
 	var/mob/living/L = M
 
+	var/harm_intent = FALSE //Used in determining if the stun is applied
 	if(user.a_intent == I_HURT) // Harm intent : possibility to miss (in exchange for doing actual damage)
-		. = ..() // Does the actual damage and missing chance. Returns null on sucess ; 0 on failure (blame oldcoders)
-		playsound(loc, swingsound, 50, 1, -1)
+		. = ..() // Does the actual damage and missing chance. Returns 1 on success, 0 on failure.
+		harm_intent = TRUE
 
 	else
 		if(!status) // Help intent + no charge = nothing
@@ -186,20 +186,23 @@
 				self_drugged_message="<span class='warning'>\The [name] decides to spare this one.</span>")
 			return
 
-	if(iscarbon(L))
+	if(iscarbon(L) && !harm_intent) //Shield checking is already handled in ..(), this is for non-harmful stunbatons.
 		var/mob/living/carbon/C = L
 		if(C.check_shields(force,src))
-			return FALSE //That way during a harmbaton it will not check for the shield twice
+			return FALSE
 
-	if(status && . != FALSE) // This is charged : we stun
+	//Has to be turned on.
+	//Either hit (returned 1 on ..()), or didn't hit (returned 0 or was not defined) but isn't on harm intent (thus it's a non-harmful baton attack).
+	//Help intent has no chance to miss on an attack.
+	if(status && (. || (!. && !harm_intent))) // This is charged : we stun
 		user.lastattacked = L
 		L.lastattacker = user
 
 		apply_baton_effect(L)
-
-		L.visible_message("<span class='danger'>\The [L] has been stunned with \the [src] by [user]!</span>",\
-			"<span class='userdanger'>You have been stunned with \the [src] by \the [user]!</span>",\
-			self_drugged_message="<span class='userdanger'>\The [user]'s [src] sucks the life right out of you!</span>")
+		if(has_stun_message)
+			L.visible_message("<span class='danger'>\The [L] has been stunned with \the [src] by [user]!</span>",\
+				"<span class='userdanger'>You have been stunned with \the [src] by \the [user]!</span>",\
+				self_drugged_message="<span class='userdanger'>\The [user]'s [src] sucks the life right out of you!</span>")
 		playsound(loc, stunsound, 50, 1, -1)
 
 		deductcharge(hitcost)
@@ -225,7 +228,8 @@
 
 	apply_baton_effect(L)
 
-	L.visible_message("<span class='danger'>[L] has been stunned with [src] by [foundmob ? foundmob : "Unknown"]!</span>")
+	if(has_stun_message)
+		L.visible_message("<span class='danger'>[L] has been stunned with [src] by [foundmob ? foundmob : "Unknown"]!</span>")
 	playsound(loc, stunsound, 50, 1, -1)
 
 	deductcharge(hitcost)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -175,10 +175,12 @@
 
 	var/mob/living/L = M
 
-	var/harm_intent = FALSE //Used in determining if the stun is applied
+	var/baton_tap = TRUE //Used in determining if the stun is applied
 	if(user.a_intent == I_HURT) // Harm intent : possibility to miss (in exchange for doing actual damage)
 		. = ..() // Does the actual damage and missing chance. Returns 1 on success, 0 on failure.
-		harm_intent = TRUE
+		if(!.) //We didn't hit, do not attempt to stun.
+			return
+		baton_tap = FALSE
 
 	else
 		if(!status) // Help intent + no charge = nothing
@@ -186,15 +188,15 @@
 				self_drugged_message="<span class='warning'>\The [name] decides to spare this one.</span>")
 			return
 
-	if(iscarbon(L) && !harm_intent) //Shield checking is already handled in ..(), this is for non-harmful stunbatons.
+	if(baton_tap && iscarbon(L)) //Shield checking is already handled in ..(), this is for non-harmful stunbatons.
 		var/mob/living/carbon/C = L
 		if(C.check_shields(force,src))
 			return FALSE
 
 	//Has to be turned on.
-	//Either hit (returned 1 on ..()), or didn't hit (returned 0 or was not defined) but isn't on harm intent (thus it's a non-harmful baton attack).
+	//Either hit (returned 1 on harm intent attack), or isn't on harm intent (we quit early).
 	//Help intent has no chance to miss on an attack.
-	if(status && (. || (!. && !harm_intent))) // This is charged : we stun
+	if(status && (. || baton_tap)) // This is charged : we stun
 		user.lastattacked = L
 		L.lastattacker = user
 
@@ -215,7 +217,7 @@
 		M.assaulted_by(user)
 
 /obj/item/weapon/melee/baton/throw_impact(atom/hit_atom)
-	if(prob(50)) //Landed handle-first into the target
+	if(prob(50) || isrobot(hit_atom)) //Landed handle-first into the target, or is a robot that's not supposed to be affected by baton effects.
 		return ..()
 	if(!isliving(hit_atom) || !status)
 		return
@@ -301,7 +303,6 @@
 	L.apply_effect(10, STUTTER) //sanity
 	L.apply_effect(stunforce, AGONY) //apply pain by throwing, it doesn't damage them though
 	L.audible_scream()
-	return
 
 /obj/item/weapon/melee/baton/harm/attack_self(mob/user) //putting this here because having damage increases closer to harm baton is more clear
 	if(status && clumsy_check(user) && prob(50))

--- a/code/modules/mob/living/simple_animal/hostile/human/grey.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/grey.dm
@@ -397,7 +397,7 @@
 	melee_damage_upper = 20 // Decent melee damage, but the stun is the real danger
 	move_to_delay = 1.8 // This is what he trained for! To fill the unforgiving minute with sixty seconds of distance sprinting
 
-	items_to_drop = list(/obj/item/weapon/melee/stunprobe)
+	items_to_drop = list(/obj/item/weapon/melee/baton/stunprobe)
 
 	attacktext = "beats"
 	attack_sound = 'sound/weapons/genhit1.ogg'
@@ -658,7 +658,7 @@
 	melee_damage_upper = 20 // Decent melee damage, but the stun is the real danger
 	move_to_delay = 1.8 // This is what he trained for! To fill the unforgiving minute with sixty seconds of distance sprinting
 
-	items_to_drop = list(/obj/item/weapon/melee/stunprobe)
+	items_to_drop = list(/obj/item/weapon/melee/baton/stunprobe)
 
 	attacktext = "beats"
 	attack_sound = 'sound/weapons/genhit1.ogg'

--- a/maps/randomvaults/dungeons/habitation.dmm
+++ b/maps/randomvaults/dungeons/habitation.dmm
@@ -2406,7 +2406,7 @@
 /turf/unsimulated/floor/lab_asteroid,
 /area/vault/mothership_lab/raidtunnel_lower)
 "uE" = (
-/obj/item/weapon/melee/stunprobe,
+/obj/item/weapon/melee/baton/stunprobe,
 /turf/unsimulated/floor/lab_sterile,
 /area/vault/mothership_lab/habitation)
 "uF" = (

--- a/maps/randomvaults/dungeons/research.dmm
+++ b/maps/randomvaults/dungeons/research.dmm
@@ -54,9 +54,9 @@
 /turf/unsimulated/floor/ayy/fancy,
 /area/vault/mothership_lab/research)
 "au" = (
-/obj/item/weapon/melee/stunprobe,
-/obj/item/weapon/melee/stunprobe,
-/obj/item/weapon/melee/stunprobe,
+/obj/item/weapon/melee/baton/stunprobe,
+/obj/item/weapon/melee/baton/stunprobe,
+/obj/item/weapon/melee/baton/stunprobe,
 /obj/structure/closet/secure_closet/ayy2{
 	anchored = 1;
 	req_access_txt = "162";
@@ -4948,7 +4948,7 @@
 	icon_state = "gib4"
 	},
 /obj/machinery/light/he/broken,
-/obj/item/weapon/melee/stunprobe,
+/obj/item/weapon/melee/baton/stunprobe,
 /turf/unsimulated/floor/ayy,
 /area/vault/mothership_lab/research)
 "Zs" = (

--- a/maps/randomvaults/mothership_lab.dm
+++ b/maps/randomvaults/mothership_lab.dm
@@ -685,7 +685,7 @@
 	can_only_hold = list(
 		"/obj/item/weapon/gun/energy/smalldisintegrator",
 		"/obj/item/weapon/gun/energy/ionrifle/ioncarbine/ionpistol",
-		"/obj/item/weapon/melee/stunprobe",
+		"/obj/item/weapon/melee/baton/stunprobe",
 		"/obj/item/device/flash",
 		"/obj/item/weapon/grenade",
 		"/obj/item/weapon/handcuffs",
@@ -962,201 +962,35 @@
 // AYY-THEMED STUN BATON (I tried several times to make this a child of the stun baton, but couldn't get it to play nice with the sprites. My apologies for what you're about to see)
 //////////////////////////////
 
-/obj/item/weapon/melee/stunprobe
+/obj/item/weapon/melee/baton/stunprobe
 	name = "stun probe"
 	desc = "An unusual baton used by MDF pacifiers. Less than lethal, not quite nonlethal."
 	icon_state = "stun probe"
 	item_state = "s_probe0"
-	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/swords_axes.dmi', "right_hand" = 'icons/mob/in-hand/right/swords_axes.dmi')
-	flags = FPRINT
-	slot_flags = SLOT_BELT
-	force = 10
-	throwforce = 7
-	w_class = W_CLASS_MEDIUM
 	origin_tech = Tc_COMBAT + "=3" + Tc_POWERSTORAGE + "=2"
-	attack_verb = list("beats")
-	var/status = 0
-	var/obj/item/weapon/cell/bcell = null
-	var/hitcost = 50 // 20 stuns with integrated cell, but can't upgrade or remove it. Doesn't have a normal baton's vulnerability to emp blasts. Compatible with rechargers
-	var/stunsound = 'sound/weapons/electriczap.ogg'
-	var/swingsound = "swing_hit"
+	hitcost = 50 // 20 stuns with integrated cell, but can't upgrade or remove it. Doesn't have a normal baton's vulnerability to emp blasts. Compatible with rechargers
+	can_swap_cell = FALSE
+	has_stun_message = FALSE
+	stunsound = 'sound/weapons/electriczap.ogg'
 
-/obj/item/weapon/melee/stunprobe/get_cell()
-	return bcell
-
-/obj/item/weapon/melee/stunprobe/suicide_act(var/mob/living/user)
-	to_chat(viewers(user), "<span class='danger'>[user] is putting the live [src.name] in \his mouth! It looks like \he's trying to commit suicide.</span>")
-	return (SUICIDE_ACT_FIRELOSS)
-
-/obj/item/weapon/melee/stunprobe/New() // Should always start with a cell integrated
+/obj/item/weapon/melee/baton/stunprobe/New() // Should always start with a cell integrated
 	..()
 	bcell = new(src)
 	bcell.charge=bcell.maxcharge // Charge this shit
 	update_icon()
 
-/obj/item/weapon/melee/stunprobe/Destroy()
-	if (bcell)
-		QDEL_NULL(bcell)
+/obj/item/weapon/melee/baton/stunprobe/canbehonkified()
+	return FALSE
 
-	return ..()
-
-/obj/item/weapon/melee/stunprobe/proc/deductcharge(var/chrgdeductamt)
-	if(bcell)
-		if(bcell.use(chrgdeductamt))
-			if(bcell.charge < hitcost)
-				status = 0
-				update_icon()
-				depower()
-			return 1
-		else
-			status = 0
-			update_icon()
-			depower()
-			return 0
-
-/obj/item/weapon/melee/stunprobe/update_icon()
-	if(status)
-		icon_state = "[initial(name)]_active"
-		item_state = "s_probe1"
-	else if(!bcell)
-		icon_state = "[initial(name)]_nocell"
-		item_state = "s_probe0"
-	else
-		icon_state = "[initial(name)]"
-		item_state = "s_probe0"
-
-	if (istype(loc,/mob/living/carbon))
-		var/mob/living/carbon/M = loc
-		M.update_inv_back()
-		M.update_inv_hands()
-
-/obj/item/weapon/melee/stunprobe/examine(mob/user)
-	..()
-	if(bcell)
-		to_chat(user, "<span class='info'>The probe is [round(bcell.percent())]% charged.</span>")
-	if(!bcell)
-		to_chat(user, "<span class='warning'>The probe does not have a power source installed.</span>")
-
-/obj/item/weapon/melee/stunprobe/proc/shockAttack(mob/living/carbon/human/target) // The main difference between this and a stun baton. It uses an electric shock attack, so genetics can make a player resistant
+/obj/item/weapon/melee/baton/stunprobe/apply_baton_effect(mob/living/L) // The main difference between this and a stun baton. It uses an electric shock attack, so genetics can make a player resistant
 	var/damage = rand(5, 10)
-	target.electrocute_act(damage, src, incapacitation_duration = 20 SECONDS, def_zone = LIMB_CHEST) // 20 code seconds is more like 10 real seconds, thus making the stun equal to the stun baton
-	if(iscarbon(target))
-		var/mob/living/L = target
-		L.apply_effect(10, STUTTER)
-	return
-
-/obj/item/weapon/melee/stunprobe/attack_self(mob/user)
-	if(status && clumsy_check(user) && prob(50))
-		user.simple_message("<span class='warning'>You grab the [src] on the wrong side.</span>",
-			"<span class='danger'>The [name] blasts you with its power!</span>")
-		shockAttack(user)
-		playsound(loc, "sparks", 75, 1, -1)
-		deductcharge(hitcost)
-		return
-	if(bcell && bcell.charge >= hitcost)
-		status = !status
-		user.simple_message("<span class='notice'>[src] is now [status ? "on" : "off"].</span>",
-			"<span class='notice'>[src] is now [pick("drowsy","hungry","thirsty","bored","unhappy")].</span>")
-		playsound(loc, "sparks", 75, 1, -1)
-		update_icon()
+	if(ishuman(L))
+		var/mob/living/carbon/human/H = L
+		H.electrocute_act(damage, src, incapacitation_duration = 20 SECONDS, def_zone = LIMB_CHEST) // 20 code seconds is more like 10 real seconds, thus making the stun equal to the stun baton
 	else
-		status = 0
-		if(!bcell)
-			user.simple_message("<span class='warning'>[src] does not have a power source!</span>",
-				"<span class='warning'>[src] has no pulse and its soul has departed...</span>")
-		else if (bcell.maxcharge < hitcost)
-			to_chat(user, "<span class='warning'>[src] clicks but nothing happens. Something must be wrong with the battery.</span>")
-		else
-			user.simple_message("<span class='warning'>[src] is out of charge.</span>",
-				"<span class='warning'>[src] refuses to obey you.</span>")
-
-	add_fingerprint(user)
-
-/obj/item/weapon/melee/stunprobe/attack(mob/M, mob/user)
-	if(status && clumsy_check(user) && prob(50))
-		user.simple_message("<span class='danger'>You accidentally hit yourself with [src]!</span>",
-			"<span class='danger'>The [name] goes mad!</span>")
-		shockAttack(user)
-		deductcharge(hitcost)
-		return
-
-	if(isrobot(M))
-		..()
-		return
-	if(!isliving(M))
-		return
-
-	var/mob/living/L = M
-
-	if(user.a_intent == I_HURT) // Harm intent : possibility to miss (in exchange for doing actual damage)
-		. = ..() // Does the actual damage and missing chance. Returns null on sucess ; 0 on failure (blame oldcoders)
-		playsound(loc, swingsound, 50, 1, -1)
-
-	else
-		if(!status) // Help intent + no charge = nothing
-			L.visible_message("<span class='attack'>\The [L] has been prodded with \the [src] by \the [user]. Luckily it was off.</span>",
-				self_drugged_message="<span class='warning'>\The [name] decides to spare this one.</span>")
-			return
-
+		L.electrocute_act(damage, src)
 	if(iscarbon(L))
-		var/mob/living/carbon/C = L
-		if(C.check_shields(force,src))
-			return FALSE //That way during a harmbaton it will not check for the shield twice
-
-	if(status && . != FALSE) // This is charged : we stun
-		user.lastattacked = L
-		L.lastattacker = user
-
-		shockAttack(L)
-		playsound(loc, stunsound, 50, 1, -1)
-
-		deductcharge(hitcost)
-
-		L.forcesay(hit_appends)
-
-		user.attack_log += "\[[time_stamp()]\]<font color='red'> Zapped [L.name] ([L.ckey]) with [name]</font>"
-		L.attack_log += "\[[time_stamp()]\]<font color='orange'> Zapped by [user.name] ([user.ckey]) with [name]</font>"
-		log_attack("<font color='red'>[user.name] ([user.ckey]) zapped [L.name] ([L.ckey]) with [name]</font>" )
-		M.assaulted_by(user)
-
-/obj/item/weapon/melee/stunprobe/throw_impact(atom/hit_atom)
-	if(prob(50))
-		return ..()
-	if(!isliving(hit_atom) || !status)
-		return
-	var/client/foundclient = directory[ckey(fingerprintslast)]
-	var/mob/foundmob = foundclient.mob
-	var/mob/living/L = hit_atom
-	if(foundmob && ismob(foundmob))
-		foundmob.lastattacked = L
-		L.lastattacker = foundmob
-
-	shockAttack(L)
-	playsound(loc, stunsound, 50, 1, -1)
-
-	deductcharge(hitcost)
-
-	L.forcesay(hit_appends)
-
-	foundmob.attack_log += "\[[time_stamp()]\]<font color='red'> Zapped [L.name] ([L.ckey]) with [name]</font>"
-	L.attack_log += "\[[time_stamp()]\]<font color='orange'> Zapped by thrown [src] by [istype(foundmob) ? foundmob.name : ""] ([istype(foundmob) ? foundmob.ckey : ""])</font>"
-	log_attack("<font color='red'>Flying [src.name], thrown by [istype(foundmob) ? foundmob.name : ""] ([istype(foundmob) ? foundmob.ckey : ""]) zapped [L.name] ([L.ckey])</font>" )
-	L.assaulted_by(foundmob)
-
-/obj/item/weapon/melee/stunprobe/emp_act(severity)
-	if(bcell)
-		deductcharge(1000 / severity)
-		if(bcell.reliability != 100 && prob(50/severity))
-			bcell.reliability -= 10 / severity
-	..()
-
-/obj/item/weapon/melee/stunprobe/restock()
-	if(bcell)
-		bcell.charge = bcell.maxcharge
-
-/obj/item/weapon/melee/stunprobe/proc/depower()
-	force = initial(force)
-	throwforce = initial(throwforce)
+		L.apply_effect(10, STUTTER)
 
 //////////////////////////////
 // AYY SINKS, TOILETS, AND SHOWERS (Only attainable via the vault and bussing for now. Coders forgive me for this terrible copy-paste apocalypse.)

--- a/maps/randomvaults/mothership_lab.dmm
+++ b/maps/randomvaults/mothership_lab.dmm
@@ -1620,8 +1620,8 @@
 /turf/unsimulated/floor/ayy/fancy,
 /area/vault/mothership_lab/entrance)
 "xX" = (
-/obj/item/weapon/melee/stunprobe,
-/obj/item/weapon/melee/stunprobe,
+/obj/item/weapon/melee/baton/stunprobe,
+/obj/item/weapon/melee/baton/stunprobe,
 /obj/structure/closet/secure_closet/ayy2{
 	anchored = 1;
 	req_access_txt = "162";
@@ -3338,7 +3338,7 @@
 "YU" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/plasma,
-/obj/item/weapon/melee/stunprobe,
+/obj/item/weapon/melee/baton/stunprobe,
 /turf/unsimulated/floor/ayy/fancy,
 /area/vault/mothership_lab/control_room)
 "Zh" = (


### PR DESCRIPTION
Fixes #37992 - I am not sure why this happened but it's fixed now.
Fixed harm-batoning checking for shields twice.
Turned the alien stun probe into a subtype of baton and added a few modifications to the code to support it being a subtype with its functionality relatively intact. Please report any oversights that I forgot to account for to maintain the stun probe.
Description for the baton when examining its charge level has been changed so that it does not say "baton" or "probe" anymore but instead calls the item's name.
Fixed baton effects having a 50% chance to affect cyborgs if they were thrown, letting you stun cyborgs for 20 seconds with a regular baton if thrown.
Fixed hit sound playing even when the baton misses (and playing twice otherwise) and removed the variable associated with it since hitsound does the same thing.
Fixed ..() not returning as a value when attacking robots with a baton. It doesn't really affect anything.

:cl:
 * bugfix: Batons on harm intent will now properly miss instead of applying a stun while missing.
 * bugfix: Batons on harm intent will no longer check for shields twice, which caused shields to have a roughly 72% chance of blocking stunbatons.
 * bugfix: Thrown batons no longer have an unintentional chance to stun cyborgs. Cyborgs are not supposed to be stunned by it.
 * bugfix: Batons on harm intent will no longer play a hit sound when missing the target, and fixed a bug where the hit sound would play twice.