### PR TITLE
Gives derelict mommis access to Sandstone, Wood, Cloth and Brick.

### DIFF
--- a/code/game/objects/items/devices/mat_synth.dm
+++ b/code/game/objects/items/devices/mat_synth.dm
@@ -98,10 +98,9 @@ var/static/list/mat2type = list(
 							 "plasma" = /obj/item/stack/sheet/mineral/plasma,
 							 "uranium" = /obj/item/stack/sheet/mineral/uranium,
 							 "plastic" = /obj/item/stack/sheet/mineral/plastic,
-							 "bananium" = /obj/item/stack/sheet/mineral/clown,
-							 "phazon" = /obj/item/stack/sheet/mineral/phazon,
 							 "sandstone" = /obj/item/stack/sheet/mineral/sandstone,
-							 "wooden planks" = /obj/item/stack/sheet/wood)
+							 "wooden planks" = /obj/item/stack/sheet/wood,
+							 "bricks" = /obj/item/stack/sheet/mineral/brick)
 
 /obj/item/device/material_synth/update_icon()
 	icon_state = "mat_synth[mode ? "on" : "off"]"

--- a/code/game/objects/items/devices/mat_synth.dm
+++ b/code/game/objects/items/devices/mat_synth.dm
@@ -100,6 +100,7 @@ var/static/list/mat2type = list(
 							 "plastic" = /obj/item/stack/sheet/mineral/plastic,
 							 "sandstone" = /obj/item/stack/sheet/mineral/sandstone,
 							 "wooden planks" = /obj/item/stack/sheet/wood,
+							 "cloth" = /obj/item/stack/sheet/cloth
 							 "bricks" = /obj/item/stack/sheet/mineral/brick)
 
 /obj/item/device/material_synth/update_icon()

--- a/code/game/objects/items/devices/mat_synth.dm
+++ b/code/game/objects/items/devices/mat_synth.dm
@@ -97,7 +97,11 @@ var/static/list/mat2type = list(
 							 "diamond" = /obj/item/stack/sheet/mineral/diamond,
 							 "plasma" = /obj/item/stack/sheet/mineral/plasma,
 							 "uranium" = /obj/item/stack/sheet/mineral/uranium,
-							 "plastic" = /obj/item/stack/sheet/mineral/plastic)
+							 "plastic" = /obj/item/stack/sheet/mineral/plastic,
+							 "bananium" = /obj/item/stack/sheet/mineral/clown,
+							 "phazon" = /obj/item/stack/sheet/mineral/phazon,
+							 "sandstone" = /obj/item/stack/sheet/mineral/sandstone,
+							 "wooden planks" = /obj/item/stack/sheet/wood)
 
 /obj/item/device/material_synth/update_icon()
 	icon_state = "mat_synth[mode ? "on" : "off"]"

--- a/code/game/objects/items/devices/mat_synth.dm
+++ b/code/game/objects/items/devices/mat_synth.dm
@@ -100,7 +100,7 @@ var/static/list/mat2type = list(
 							 "plastic" = /obj/item/stack/sheet/mineral/plastic,
 							 "sandstone" = /obj/item/stack/sheet/mineral/sandstone,
 							 "wooden planks" = /obj/item/stack/sheet/wood,
-							 "cloth" = /obj/item/stack/sheet/cloth
+							 "cloth" = /obj/item/stack/sheet/cloth,
 							 "bricks" = /obj/item/stack/sheet/mineral/brick)
 
 /obj/item/device/material_synth/update_icon()


### PR DESCRIPTION
## What this does
Gives the derelict crabs access to the aforementioned resources via the matsynth.
## Why it's good
You can get sandstone already if you find a roid tile, or make grass -> sand -> sandstone,  then scan.
Same with wood, you can just set the RCD to build a wooden wall, then disassemble and scan.
You can get cloth if you bother with zero-start botany and get flax to then turn into cloth.
Derelict mommi is more of a playground to test weird and obtuse shit in the (relative) safety of the derelict. Giving them access to all materials (within reason) is sensible, since they cannot leave the derelict, nor interact with non crabs.

## Changelog
:cl:
 * rscadd: Derelict Mommis have been upgraded by SovietComm, and now have access to wood, sandstone, cloth and brick in their internal material synthesizer.