### PR TITLE
Change R&D console access restrictions

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -375,7 +375,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 	if(href_list["menu"]) //Switches menu screens. Converts a sent text string into a number. Saves a LOT of code.
 		var/temp_screen = text2num(href_list["menu"])
-		if(temp_screen <= CONSOLE_RESEARCH_MENU || ((DA_UNLINKED <= temp_screen) && (CIRCUIT_UPPER_LIMIT >= temp_screen)) || src.allowed(usr) || emagged) //Unless you are making something, you need access.
+		if(temp_screen <= 1.1 || 1.5 || 1.6|| (2 <= temp_screen && 4.9 >= temp_screen) || src.allowed(usr) || emagged) //Unless you are making something, relinking devices, or syncing data, you need access.
 			screen = temp_screen
 		else
 			to_chat(usr, "Unauthorized Access.")


### PR DESCRIPTION
This PR removes the R&D console (and related science machine consoles) checking for ID access when syncing the R&D database, linking devices, or doing disk operations. It does not remove the restriction on removing materials from machine storage or change the lock console functionality.

 * tweak: Syncing the database, relinking devices, and disk operations in the R&D settings menu no longer checks for user access

