### PR TITLE
Blob Thematic Music Starts Sooner

### DIFF
--- a/code/datums/gamemode/factions/blob.dm
+++ b/code/datums/gamemode/factions/blob.dm
@@ -160,6 +160,7 @@
 				set_security_level("red")//We raise the sec level to red, unless some malf AI has it set to delta already
 			command_alert(/datum/command_alert/blob_defcon_3)
 			stage = BLOB_DEFCON_3
+			ticker.StartThematic("endgame")
 
 		if (BLOB_DEFCON_2) // 30% blob count: free borg reset and allow the ERT to be called
 			command_alert(/datum/command_alert/blob_defcon_2)
@@ -196,7 +197,8 @@
 				var/law = "Directive 7-12 has been authorized. Allow no sentient being to escape the purge. The nuclear failsafe must be activated at any cost, the code is: [nukecode]."
 				aiPlayer.set_zeroth_law(law)
 				to_chat(aiPlayer, "Laws Updated: [law]")
-			..() //Set thematic
+		/*	..() //Set thematic
+		This goes to the faction endgame stuff, but all of that is done here already and it would interfere with the thematic to have this uncommented. Break glass in case of emergency. */
 		if (FACTION_DEFEATED) //Cleanup time
 			command_alert(/datum/command_alert/biohazard_station_unlock)
 			send_intercept(FACTION_DEFEATED)

--- a/code/datums/gamemode/factions/blob.dm
+++ b/code/datums/gamemode/factions/blob.dm
@@ -197,6 +197,7 @@
 				var/law = "Directive 7-12 has been authorized. Allow no sentient being to escape the purge. The nuclear failsafe must be activated at any cost, the code is: [nukecode]."
 				aiPlayer.set_zeroth_law(law)
 				to_chat(aiPlayer, "Laws Updated: [law]")
+			stage = FACTION_ENDGAME
 		/*	..() //Set thematic
 		This goes to the faction endgame stuff, but all of that is done here already and it would interfere with the thematic to have this uncommented. Break glass in case of emergency. */
 		if (FACTION_DEFEATED) //Cleanup time


### PR DESCRIPTION
It only starts when you're in the endgame, which is when you get the nuke code, so it generally won't even play a whole song.
This should also help the mode itself as people will stop fluoride staring and going "I didn't know there was a blob???"
I opted to pick this specific segment since it's where you get forced on code red, which is usually what happens when the thematic starts.

Tested by making sure it compiled :)

 * tweak: Blob Thematic Jukebox starts sooner.
