### PR TITLE
Adds a destructive analyzer board and a conduction plate board to the boarded up room in Lowfat Bagel's Vox Outpost

### DIFF
--- a/maps/lowfatbagel.dmm
+++ b/maps/lowfatbagel.dmm
@@ -59080,6 +59080,7 @@
 /obj/item/weapon/fishtools/fish_food,
 /obj/item/weapon/fishtools/fish_net,
 /obj/item/weapon/fishtools/fish_tank_brush,
+/obj/item/weapon/circuitboard/conduction_plate,
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/vault)
 "jTD" = (
@@ -108520,6 +108521,7 @@
 /obj/structure/hanging_lantern{
 	dir = 1
 	},
+/obj/item/weapon/circuitboard/destructive_analyzer,
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/vault)
 "yhW" = (


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
What it says on the tin
## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Traders start with a R&D console and a circuit printer but no DA board. Now they can do some research on their own. Also the conduction plate is to power the outpost with eels, since the outpost spawns some eel eggs.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
yep the things are there

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Lowfat Bagel's Vox Outpost now starts with an extra destructive analyzer board and a conduction plate board.

