### PR TITLE
Allows RPEDs to upgrade borg components

### DIFF
--- a/code/game/objects/items/weapons/storage/RPED.dm
+++ b/code/game/objects/items/weapons/storage/RPED.dm
@@ -49,16 +49,14 @@
 			for(var/part2 in subtypesof(/obj/item/weapon/cell))
 				var/obj/item/weapon/cell/C = part2
 				if(initial(C.rating) == cell_rating)
-					for(var/i in 1 to 10)
-						C = new part2(src)
-						handle_item_insertion(C, 1)
+					C = new part2(src)
+					handle_item_insertion(C, 1)
 		if(borg_upgrades)
 			for(var/part3 in subtypesof(/obj/item/robot_parts/robot_component))
 				var/obj/item/robot_parts/robot_component/R = part3
 				if(initial(R.isupgrade))
-					for(var/i in 1 to 10)
-						R = new part3(src)
-						handle_item_insertion(R, 1)
+					R = new part3(src)
+					handle_item_insertion(R, 1)
 		to_chat(user,"[src] contains: [counted_english_list(contents)]")
 	. = ..()
 

--- a/code/game/objects/items/weapons/storage/RPED.dm
+++ b/code/game/objects/items/weapons/storage/RPED.dm
@@ -24,6 +24,7 @@
 /obj/item/weapon/storage/bag/gadgets/part_replacer/bluespace/admin
 	var/stock_rating = 4
 	var/cell_rating = 15
+	var/borg_upgrades = TRUE
 	admin_desc = "This one seems to have infinite parts. Use this in hand to change the ratings of stock parts applied."
 
 /obj/item/weapon/storage/bag/gadgets/part_replacer/bluespace/admin/attack_self(mob/user)
@@ -41,13 +42,15 @@
 				if(initial(S.rating) == stock_rating)
 					for(var/i in 1 to 10)
 						S = new part(src)
-						handle_item_insertion(S, 1)	
+						handle_item_insertion(S, 1)
+		if(cell_rating > 1)
 			for(var/part2 in subtypesof(/obj/item/weapon/cell))
 				var/obj/item/weapon/cell/C = part2
 				if(initial(C.rating) == cell_rating)
 					for(var/i in 1 to 10)
 						C = new part2(src)
-						handle_item_insertion(C, 1)	
+						handle_item_insertion(C, 1)
+		if(borg_upgrades)
 			for(var/part3 in subtypesof(/obj/item/robot_parts/robot_component))
 				var/obj/item/robot_parts/robot_component/R = part3
 				if(initial(R.isupgrade))

--- a/code/game/objects/items/weapons/storage/RPED.dm
+++ b/code/game/objects/items/weapons/storage/RPED.dm
@@ -25,11 +25,13 @@
 	var/stock_rating = 4
 	var/cell_rating = 15
 	var/borg_upgrades = TRUE
-	admin_desc = "This one seems to have infinite parts. Use this in hand to change the ratings of stock parts applied."
+	admin_desc = "This one seems to have infinite parts. Use this in hand to change the ratings of stock parts, power cells and robot upgrades applied."
 
 /obj/item/weapon/storage/bag/gadgets/part_replacer/bluespace/admin/attack_self(mob/user)
 	if(user.check_rights(R_ADMIN))
-		stock_rating = clamp(input(user,"Which part rating to use?","Part ratings",4) as num,2,4)
+		stock_rating = clamp(input(user,"Which part rating to use?","Part ratings",stock_rating) as num,2,4)
+		cell_rating = clamp(input(user,"Which cell rating to use?","Cell ratings",cell_rating) as num,1,15)
+		borg_upgrades = alert(user,"Use borg upgrades?","Borg upgrades","Yes","No") == "Yes"
 	else
 		..()
 

--- a/code/game/objects/items/weapons/storage/RPED.dm
+++ b/code/game/objects/items/weapons/storage/RPED.dm
@@ -23,6 +23,7 @@
 
 /obj/item/weapon/storage/bag/gadgets/part_replacer/bluespace/admin
 	var/stock_rating = 4
+	var/cell_rating = 15
 	admin_desc = "This one seems to have infinite parts. Use this in hand to change the ratings of stock parts applied."
 
 /obj/item/weapon/storage/bag/gadgets/part_replacer/bluespace/admin/attack_self(mob/user)
@@ -39,8 +40,20 @@
 				var/obj/item/weapon/stock_parts/S = part
 				if(initial(S.rating) == stock_rating)
 					for(var/i in 1 to 10)
-						new part(src)
+						S = new part(src)
 						handle_item_insertion(S, 1)	
+			for(var/part2 in subtypesof(/obj/item/weapon/cell))
+				var/obj/item/weapon/cell/C = part2
+				if(initial(C.rating) == cell_rating)
+					for(var/i in 1 to 10)
+						C = new part2(src)
+						handle_item_insertion(C, 1)	
+			for(var/part3 in subtypesof(/obj/item/robot_parts/robot_component))
+				var/obj/item/robot_parts/robot_component/R = part3
+				if(initial(R.isupgrade))
+					for(var/i in 1 to 10)
+						R = new part3(src)
+						handle_item_insertion(R, 1)
 		to_chat(user,"[src] contains: [counted_english_list(contents)]")
 	. = ..()
 

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -187,7 +187,18 @@
 		var/shouldplaysound = FALSE
 		for(var/V in components)
 			var/datum/robot_component/C = components[V]
-			if(!C.installed)
+			if(istype(C.wrapped,/obj/item/weapon/cell))
+				var/obj/item/weapon/cell/cell = C.wrapped
+				for(var/obj/item/weapon/cell/I2 in W.contents)
+					if((I2.rating > cell.rating))
+						C.uninstall(user)
+						if(C.wrapped)
+							W.handle_item_insertion(C.wrapped, 1)
+						C.install(user,I2)
+						W.remove_from_storage(I2, null)
+						shouldplaysound = TRUE //Only play the sound when parts are actually replaced!
+						break
+			else
 				for(var/obj/item/robot_parts/robot_component/I in W.contents)
 					if((I.isupgrade && !C.upgraded) && istype(I, C.external_type))
 						C.uninstall(user)
@@ -197,17 +208,6 @@
 						W.remove_from_storage(I, null)
 						shouldplaysound = TRUE //Only play the sound when parts are actually replaced!
 						break
-				if(istype(C.wrapped,/obj/item/weapon/cell))
-					var/obj/item/weapon/cell/cell = C.wrapped
-					for(var/obj/item/weapon/cell/I2 in W.contents)
-						if((I2.rating > cell.rating))
-							C.uninstall(user)
-							if(C.wrapped)
-								W.handle_item_insertion(C.wrapped, 1)
-							C.install(user,I2)
-							W.remove_from_storage(I2, null)
-							shouldplaysound = TRUE //Only play the sound when parts are actually replaced!
-							break
 		if(shouldplaysound)
 			W.play_rped_sound()
 		else

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -195,7 +195,7 @@
 						if(C.wrapped)
 							W.handle_item_insertion(C.wrapped, 1)
 						C.install(user,I2)
-						W.remove_from_storage(I2, null)
+						W.remove_from_storage(I2, src)
 						shouldplaysound = TRUE //Only play the sound when parts are actually replaced!
 						break
 			else
@@ -205,7 +205,7 @@
 						if(C.wrapped)
 							W.handle_item_insertion(C.wrapped, 1)
 						C.install(user,I)
-						W.remove_from_storage(I, null)
+						W.remove_from_storage(I, src)
 						shouldplaysound = TRUE //Only play the sound when parts are actually replaced!
 						break
 		if(shouldplaysound)

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -182,7 +182,7 @@
 	var/datum/robot_component/C = components[module_name]
 	return C && C.installed == COMPONENT_INSTALLED && C.toggled && C.is_powered()
 
-/*/mob/living/silicon/robot/proc/exchange_parts(mob/user, obj/item/weapon/storage/bag/gadgets/part_replacer/W)
+/mob/living/silicon/robot/proc/exchange_parts(mob/user, obj/item/weapon/storage/bag/gadgets/part_replacer/W)
 	if (W.bluespace || wiresexposed || opened)
 		var/shouldplaysound = FALSE
 		for(var/V in components)
@@ -215,7 +215,7 @@
 			for(var/V2 in components)
 				var/datum/robot_component/C = components[V2]
 				if(C.wrapped)
-					to_chat(user, "<span class='notice'>    [C.wrapped.name]</span>")*/
+					to_chat(user, "<span class='notice'>    [C.wrapped.name]</span>")
 
 /obj/item/broken_device
 	name = "broken component"

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -191,21 +191,23 @@
 				var/obj/item/weapon/cell/cell = C.wrapped
 				for(var/obj/item/weapon/cell/I2 in W.contents)
 					if((I2.rating > cell.rating))
-						C.uninstall(user)
 						if(C.wrapped)
 							W.handle_item_insertion(C.wrapped, 1)
+						C.uninstall(user)
 						C.install(user,I2)
-						W.remove_from_storage(I2, src)
+						W.remove_from_storage(I2, null)
+						I2.forceMove(src)
 						shouldplaysound = TRUE //Only play the sound when parts are actually replaced!
 						break
 			else
 				for(var/obj/item/robot_parts/robot_component/I in W.contents)
 					if((I.isupgrade && !C.upgraded) && istype(I, C.external_type))
-						C.uninstall(user)
 						if(C.wrapped)
 							W.handle_item_insertion(C.wrapped, 1)
+						C.uninstall(user)
 						C.install(user,I)
-						W.remove_from_storage(I, src)
+						W.remove_from_storage(I, null)
+						I.forceMove(src)
 						shouldplaysound = TRUE //Only play the sound when parts are actually replaced!
 						break
 		if(shouldplaysound)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -782,8 +782,8 @@
 		help_shake_act(user)
 		return FALSE
 
-	/*else if(istype(W, /obj/item/weapon/storage/bag/gadgets/part_replacer))
-		return exchange_parts(user, W)*/
+	else if(istype(W, /obj/item/weapon/storage/bag/gadgets/part_replacer))
+		return exchange_parts(user, W)
 
 	else
 		if(W.force > 0)


### PR DESCRIPTION
[content]

## What this does
Namely, just upgrade them and not also replace damaged ones, for now.
Also makes the new admin debug RPEDs refresh with cells and robot components too.
What I meant to do before getting sidetracked by making cells into a component.

## Why it's good
Thematic, (the repair-only thing being disabled keeps it resembling surgery) removes hassle.

## How it was tested
Using the admin RPED on a spawned borg.

## Changelog
:cl:
 * rscadd: Cyborgs can now have their components upgraded with part replacers, including their power cell. Their components can only be part replaced with others of a higher upgrade level. This requires their cover open and wires exposed, unless using a bluespace RPED.