### PR TITLE
Hitting robots with items will now properly play hitsounds instead of merely sparking

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -163,23 +163,10 @@
 				else
 					to_chat(user, "<span class='warning'>You attack [M] with [I]!</span>")
 
-	if(istype(M, /mob/living/carbon))
-		var/mob/living/carbon/C = M
-		if(originator)
-			. = C.attacked_by(I, user, def_zone, originator, crit = is_crit)
-		else
-			. = C.attacked_by(I, user, def_zone, crit = is_crit)
+	if(originator)
+		. = M.attacked_by(I, user, def_zone, originator, crit = is_crit, force = power)
 	else
-		switch(I.damtype)
-			if("brute")
-				M.take_organ_damage(power)
-				if (prob(33) && I.force) // Added blood for whacking non-humans too
-					var/turf/simulated/location = M.loc
-					if (istype(location))
-						location.add_blood_floor(M)
-			if("fire")
-				if (!(M_RESIST_COLD in M.mutations))
-					M.take_organ_damage(0, power)
+		. = M.attacked_by(I, user, def_zone, crit = is_crit, force = power)
 
 	//Break the item if applicable.
 	if(power && (I.breakable_flags & BREAKABLE_AS_MELEE) && (I.breakable_flags & BREAKABLE_MOB) && (I.damtype == BRUTE))

--- a/code/modules/mob/living/carbon/combat.dm
+++ b/code/modules/mob/living/carbon/combat.dm
@@ -22,7 +22,8 @@
 
 
 //Checks armor, special attackby of object instances, and miss chance
-/mob/living/carbon/proc/attacked_by(var/obj/item/I, var/mob/living/user, var/def_zone, var/originator = null, var/crit = FALSE, var/flavor)
+//This intentionally does not use the "force" variable, as it performs its own damage calculations for carbon mobs.
+/mob/living/carbon/attacked_by(var/obj/item/I, var/mob/living/user, var/def_zone, var/originator = null, var/crit = FALSE, var/flavor, var/force)
 	if(!I || !user)
 		return FALSE
 	var/accuracy_modifier = get_total_accuracy_modifier(user, src) //Negative value make it more likely to hit, and the opposite for positive values

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -235,7 +235,7 @@ emp_act
 	..()
 
 
-/mob/living/carbon/human/attacked_by(var/obj/item/I, var/mob/living/user, var/def_zone, var/originator = null, var/crit = FALSE, var/flavor)
+/mob/living/carbon/human/attacked_by(var/obj/item/I, var/mob/living/user, var/def_zone, var/originator = null, var/crit = FALSE, var/flavor, var/force)
 	if(!..())
 		return
 	var/power = I.force

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -309,7 +309,7 @@
 			else if(!(O.can_reenter_corpse))
 				to_chat(O,"<span class='notice'>While \the [src] may be mindless, you have recently ghosted and thus are not allowed to take over for now.</span>")
 
-/mob/living/carbon/monkey/attacked_by(var/obj/item/I, var/mob/living/user, var/def_zone, var/originator = null, var/crit = FALSE, var/flavor)
+/mob/living/carbon/monkey/attacked_by(var/obj/item/I, var/mob/living/user, var/def_zone, var/originator = null, var/crit = FALSE, var/flavor, var/force)
 	if(!..())
 		return
 

--- a/code/modules/mob/living/combat.dm
+++ b/code/modules/mob/living/combat.dm
@@ -166,3 +166,18 @@
 
 /mob/living/proc/get_defender_accuracy_decrease()
 	return 0
+
+/mob/living/proc/attacked_by(var/obj/item/I, var/mob/living/user, var/def_zone, var/originator = null, var/crit = FALSE, var/flavor, var/force)
+	if(!I || !user)
+		return FALSE
+	switch(I.damtype)
+		if("brute")
+			take_organ_damage(force)
+			if (prob(33) && I.force) // Added blood for whacking non-humans too
+				var/turf/simulated/location = loc
+				if (istype(location))
+					location.add_blood_floor(src)
+		if("fire")
+			if (!(M_RESIST_COLD in mutations))
+				take_organ_damage(0, force)
+	return TRUE

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -364,7 +364,7 @@
 		return state_laws_ui_interact(user, ui_key, ui, force_open) //state_laws.dm
 
 //A separate check from attacked_by (a carbon-level proc), with only a fragment in order to play hitsounds
-/mob/living/silicon/attacked_by(var/obj/item/I, var/mob/living/user, def_zone, originator, crit, flavor)
+/mob/living/silicon/attacked_by(var/obj/item/I, var/mob/living/user, def_zone, originator, crit, flavor, force)
 	if(!..())
 		return FALSE
 	if(I.hitsound)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -362,3 +362,11 @@
 		return
 	if(ui_key == "state_laws")
 		return state_laws_ui_interact(user, ui_key, ui, force_open) //state_laws.dm
+
+//A separate check from attacked_by (a carbon-level proc), with only a fragment in order to play hitsounds
+/mob/living/silicon/attacked_by(var/obj/item/I, var/mob/living/user, def_zone, originator, crit, flavor)
+	if(!..())
+		return FALSE
+	if(I.hitsound)
+		playsound(loc, I.hitsound, 50, 1, -1)
+	return TRUE


### PR DESCRIPTION
Tested it, hopefully it doesn't have unintended features.

:cl:
 * rscadd: Hitting cyborgs with items will now play the item's regular hit sound.