### PR TITLE
New Changeling upgrade: Faster Absorb DNA

### DIFF
--- a/code/datums/gamemode/powers/changeling.dm
+++ b/code/datums/gamemode/powers/changeling.dm
@@ -264,3 +264,17 @@
 	helptext = "It does not purge the diseases nor provides antigens, but instead causes the symptoms to never appear."
 	cost = 2
 	spellpath = /spell/changeling/disease_immunity
+
+/datum/power/changeling/faster_suck
+	name = "Faster Absorb DNA"
+	desc = "We optimize the development process and pressure differential of our proboscis, permitting faster development and consumption."
+	helptext = "Reduces DNA absorption time from 45 seconds to 24 seconds."
+	cost = 4
+
+/datum/power/changeling/faster_suck/add_power(var/datum/role/R)
+	. = ..()
+	if (!.)
+		return
+	var/datum/role/changeling/changeling = R
+	to_chat(changeling.antag.current, span_notice("We improved our proboscis, and can now absorb targets in 24 seconds."))
+	changeling.faster_suck = TRUE

--- a/code/datums/gamemode/role/changeling.dm
+++ b/code/datums/gamemode/role/changeling.dm
@@ -27,7 +27,8 @@
 	spell_exclude = /spell/changeling/evolve
 
 	var/mimicing = ""
-	var/disease_immunity = 0 //If on, the changeling doesn't suffer any symptoms from diseases
+	var/disease_immunity = FALSE //If on, the changeling doesn't suffer any symptoms from diseases
+	var/faster_suck = FALSE //If on, reduces the delay between the changeling's absorb DNA stages from 15 seconds to 8 seconds.
 
 /datum/role/changeling/OnPostSetup(var/laterole = FALSE)
 	. = ..()

--- a/code/modules/spells/changeling/absorb_dna.dm
+++ b/code/modules/spells/changeling/absorb_dna.dm
@@ -43,7 +43,7 @@
 	var/obj/item/weapon/grab/G = user.get_active_hand() //You need to be grabbing the target
 	var/mob/living/carbon/human/T = G.affecting
 	var/datum/role/changeling/changeling = user.mind.GetRole(CHANGELING)
-	var/absorbtime = 15 SECONDS
+	var/absorbtime = changeling.faster_suck ? 8 SECONDS : 15 SECONDS
 	inuse = TRUE
 	for(var/stage in 1 to 3)
 		switch(stage)


### PR DESCRIPTION
Because they've been starting to lack strength in that regard compared to their bloodsucking cousins who dine and dash.
Adds a new upgrade that can be purchased for 4 points which improves Absorb DNA's ability to absorb from 45 seconds to 24 seconds. Can be increased to 5 points if there are concerns about it. No, they can already parasting people the whole time they're being sucked as is, and a maxed out grab stunlocks and mutes people.
It's 24 seconds because the changeling suck is divided into 3 stages that each take 15 seconds, and with the upgrade each stage takes 8 seconds.
Tested.

:cl:
 * rscadd: Added a new Changeling upgrade - Faster Absorb DNA, which reduces the Absorb DNA duration from 45 seconds to 24 seconds.