### PR TITLE
Deletes mystery box APC

### DIFF
--- a/maps/tgstation.dmm
+++ b/maps/tgstation.dmm
@@ -34614,10 +34614,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	pixel_x = -24
-	},
 /turf/simulated/floor,
 /area/hallway/primary/starboard)
 "bnQ" = (


### PR DESCRIPTION
This is not the APC for the hallway. I do not know why it's here but I noticed it get deleted on server startup while testing my blob pr so uhhh lets just brush it away ok? I don't think this even needs a changelog because for all purposes it doesn't exist already.