### PR TITLE
Juke Update 1: Eclipse

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult.dm
@@ -91,6 +91,7 @@
 			eclipse_trigger_cult()
 			for(var/obj/structure/cult/spire/S in cult_spires)
 				S.upgrade(3)
+			ticker.StartThematic("eclipse")
 		if (BLOODCULT_STAGE_MISSED)
 			for (var/datum/role/cultist in members)
 				var/mob/M = cultist.antag.current
@@ -98,6 +99,7 @@
 					to_chat(M, "<span class='sinister'>The Eclipse has passed. You won't be able to tear reality aboard this station anymore. Escape the station alive with your fellow cultists so you may try again another day.</span>")
 			for(var/obj/structure/cult/spire/S in cult_spires)
 				S.upgrade(1)
+			ticker.StopThematic()
 		if (BLOODCULT_STAGE_ECLIPSE)
 			update_all_parallax()
 			var/datum/zLevel/ZL = map.zLevels[map.zMainStation]

--- a/code/modules/media/jukebox.dm
+++ b/code/modules/media/jukebox.dm
@@ -9,7 +9,7 @@ var/global/global_playlists = list()
 	set waitfor = 0//tentative fix so the proc stops hanging if it takes too long
 	if(!config.media_base_url)
 		return
-	for(var/playlist_id in list("lilslugger", "bar", "jazzswing", "bomberman", "depresso", "echoes", "electronica", "emagged", "endgame", "filk", "funk", "folk", "IDM", "malfdelta", "medbay", "metal", "muzakjazz", "nukesquad", "rap", "rock", "shoegaze", "security", "shuttle", "thunderdome", "upbeathypedancejam", "vidya", "SCOTLANDFOREVER", "halloween", "christmas"))
+	for(var/playlist_id in list("bar", "jazzswing", "bomberman", "depresso", "eclipse", "electronica", "emagged", "endgame", "filk", "funk", "folk", "malfdelta", "medbay", "metal", "muzakjazz", "nukesquad", "rap", "rock", "shoegaze", "security", "shuttle", "thunderdome", "upbeathypedancejam", "vidya", "SCOTLANDFOREVER", "halloween", "christmas"))
 		var/url="[config.media_base_url]/index.php?playlist=[playlist_id]"
 		log_debug("Begin updating playlist: [playlist_id]...")
 
@@ -878,7 +878,6 @@ var/global/list/loopModeNames=list(
 	playlist_id="bar"
 	// Must be defined on your server.
 	playlists=list(
-		"lilslugger" = "Battle of Lil Slugger",
 		"bar"  = "Bar Mix",
 		"jazzswing" = "Jazz & Swing",
 		"depresso" ="Depresso",
@@ -914,7 +913,6 @@ var/global/list/loopModeNames=list(
 		"filk" = "Filk",
 		"funk" = "Funk",
 		"folk" = "Folk",
-		"IDM" = "90's IDM",
 		"medbay" = "Medbay",
 		"metal" = "Heavy Metal",
 		"muzakjazz" = "Muzak",
@@ -944,7 +942,6 @@ var/global/list/loopModeNames=list(
 	playlist_id="bar"
 	// Must be defined on your server.
 	playlists=list(
-		"lilslugger" = "Battle of Lil' Slugger",
 		"bar"  = "Bar Mix",
 		"jazzswing" = "Jazz & Swing",
 		"depresso" ="Depresso",
@@ -952,7 +949,6 @@ var/global/list/loopModeNames=list(
 		"filk" = "Filk",
 		"funk" = "Funk",
 		"folk" = "Folk",
-		"IDM" = "90's IDM",
 		"medbay" = "Medbay",
 		"metal" = "Heavy Metal",
 		"muzakjazz" = "Muzak",
@@ -973,7 +969,7 @@ var/global/list/loopModeNames=list(
 		"malfdelta"= "Silicon Assault",
 		"bomberman" = "Bomberman",
 		"SCOTLANDFOREVER"= "Highlander",
-		"echoes" = "Echoes"
+		"eclipse" = "Eclipse"
 	)
 
 /obj/machinery/media/jukebox/superjuke/New()
@@ -1170,10 +1166,11 @@ var/global/list/loopModeNames=list(
 	unformatted = "depresso"
 	formatted = "Depresso"
 	mask = "#000000"//black
-/obj/item/weapon/vinyl/echoes
-	name = "nanovinyl - echoes"
-	unformatted = "echoes"
-	formatted = "Echoes"
+/obj/item/weapon/vinyl/eclipse
+	name = "nanovinyl - Vague Threat"
+	unformatted = "eclipse"
+	formatted = "Eclipse"
+	desc = "For when a vague threat plagues the station."
 /obj/item/weapon/vinyl/electronica
 	name = "nanovinyl - electronic"
 	unformatted = "electronica"
@@ -1199,10 +1196,6 @@ var/global/list/loopModeNames=list(
 	name = "nanovinyl - folk"
 	unformatted = "folk"
 	formatted = "Folk"
-/obj/item/weapon/vinyl/idm
-	name = "nanovinyl - 90's IDM"
-	unformatted = "IDM"
-	formatted = "90's IDM"
 /obj/item/weapon/vinyl/jazz
 	name = "nanovinyl - jazz & swing"
 	unformatted = "jazzswing"
@@ -1273,11 +1266,6 @@ var/global/list/loopModeNames=list(
 	name = "nanovinyl - halloween"
 	unformatted = "halloween"
 	formatted = "Halloween"
-/obj/item/weapon/vinyl/slugger
-	name = "nanovynil - slugger"
-	desc = "A go-to for bars all over the sector. Every time you walk in one, you can almost bet it's playing."
-	unformatted = "lilslugger"
-	formatted = "Battle of Lil Slugger"
 /obj/item/weapon/vinyl/christmas
 	name = "nanovynil - christmas"
 	unformatted = "christmas"

--- a/code/modules/trader/crates/shoaljunk.dm
+++ b/code/modules/trader/crates/shoaljunk.dm
@@ -9,7 +9,6 @@ var/global/list/shoal_stuff = list(
 	/obj/item/clothing/accessory/wristwatch/black,/obj/item/clothing/accessory/wristwatch/black,/obj/item/clothing/accessory/wristwatch/black,
 	//1 of a kind
 	/obj/item/weapon/reagent_containers/food/snacks/borer_egg,
-	/obj/item/weapon/vinyl/echoes,
 	/obj/item/fish_eggs/seadevil,
 	/obj/structure/bed/therapy,
 	/obj/item/weapon/grenade/station/discount,

--- a/code/modules/trader/crates/zincsaucier.dm
+++ b/code/modules/trader/crates/zincsaucier.dm
@@ -7,7 +7,6 @@ var/global/list/chef_stuff = list(
 	/obj/item/fish_eggs/seadevil,/obj/item/fish_eggs/seadevil, //fish_items.dm
 	/obj/item/apiary/langstroth,/obj/item/apiary/langstroth,
 	//one of a kind
-	/obj/item/weapon/vinyl/echoes, //media/jukebox.dm
 	/obj/item/sushimat,
 	/obj/structure/dishwasher,
 	/obj/item/cricketfarm,


### PR DESCRIPTION
Many people have bitched about the cult eclipse having no music, which later turned into complaining about how apocalypse wouldn't quite fit when shit hasn't quite hit the fan yet just during the eclipse (Primed), which turned into me fuckin wit da juke.

This fiddles with some of the playlists as well, for clarity. Some stuff from apoc gets moved into the new eclipse playlist, Eclipse is aimed to be a "Shit is not quite at the fan but it is approaching and things are already bad" playlist.
Medbay also gets touched, going from 2/3rds random shit 1/3rd rock into more of a lobby music juke.
This also kills slugger (it gets put back into bar where it belongs), echoes (nobody uses it and it pollutes trader and crate pools), and IDM (that playlist is just fucking broken but nobody cared anyways)

For full musical changelog, please view the readme and then bitch at me on discord in #spriting-sound or the comments when How to Save a Life's strongest defender finds me.
[Readme.txt](https://github.com/user-attachments/files/21245436/Readme.txt)


[dnm] because pomf should do everything at 
the same time
[sound] 

 * rscadd: Added Eclipse playlist to cult eclipse, and rearranged some jukebox songs.