### PR TITLE
Connects all of deff's waste loop to atmospherics.

### DIFF
--- a/maps/defficiency.dmm
+++ b/maps/defficiency.dmm
@@ -18378,6 +18378,9 @@
 	codes_txt = "patrol;next_patrol=ArrivalsR";
 	location = "Engineering"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},


### PR DESCRIPTION
It's not often that I think a mapping fix needs speedmerged but this might be one of them
[deff]

 * bugfix: Deff waste loop now works.

