### PR TITLE
Items disappearing from storage will now properly update the storage

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -113,6 +113,11 @@
 		H.drop_from_inventory(src) // items at the very least get unequipped from their mob before being deleted
 	for(var/x in actions)
 		qdel(x)
+	if(istype(loc, /obj/item/weapon/storage)) //Update the storage screen for current users.
+		var/obj/item/weapon/storage/S = loc
+		spawn() //Allows properly removing the item from storage so that there's not an unused slot in the middle of its inventory until next refresh.
+			if(S && !S.gcDestroyed) //Double check to see if the storage still exists.
+				S.refresh_all()
 	..()
 
 


### PR DESCRIPTION
![gif](https://github.com/user-attachments/assets/32ed0f3f-a049-4b24-908a-a602d43b58db)

:cl:
 * bugfix: Fixed an issue where storage inventories such as from a backpack would not update the inventory menu properly if the item was deleted.