### PR TITLE
Borg component prying fixes

### DIFF
--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -32,8 +32,7 @@
 			to_chat(owner, "<span class='info' style=\"font-family:Courier\">New [I.name] installed.</span>")
 
 /datum/robot_component/proc/uninstall(var/mob/user,var/loud = FALSE)
-	if(installed == COMPONENT_INSTALLED)
-		installed = FALSE
+	installed = FALSE
 	if(wrapped)
 		to_chat(user, "You remove \the [wrapped].")
 		if(owner.can_diagnose())

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -692,6 +692,7 @@
 				var/datum/robot_component/C = components[remove]
 				if(C.wrapped)
 					C.wrapped.forceMove(loc)
+					user.put_in_hands(C.wrapped)
 				C.uninstall(user)
 
 		else


### PR DESCRIPTION
[bugfix][qol]

## What this does
makes broken borg components actually remove from their pry list when taken out
puts the removed component in a player's hand if possible when removed

# Why it's good
not dropped hidden behind the borg anymore

## How it was tested
prying the broken components out of a borg after heavy damage

## Changelog
:cl:
 * bugfix: Broken components now properly remove themselves from the cyborg pryout list.
 * tweak: Components pried out of cyborgs now show up in player's hands if possible.