### PR TITLE
Fixes Autonomous Fire Suppression

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -551,6 +551,8 @@ var/global/list/air_alarms = list()
 		if(this_area.fire)
 			preset_key = "Fire Suppression"
 			apply_preset(1)
+			auto_suppress = FALSE
+			config.suppression_mode = FALSE
 	return
 
 /obj/machinery/alarm/proc/calculate_local_danger_level(const/datum/gas_mixture/environment)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Disables Autonomous Fire Suppression mode after a fire occurs.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Fixes air alarms getting locked into Fire Suppression mode for the full duration of the fire alarm, rendering a room fully inhabitable for extended periods of time.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
- Verified the preset can still be enabled/disabled manually.
- Verified the AFS feature can be toggled on/off while in any preset.
- Verified the AFS still triggers Fire Suppression mode when a fire is present in the air alarm region.
- Verified AFS toggles to OFF when a fire occurs.
- Verified Fire Suppression mode can be disabled and replaced with standard presets after AFS is toggled off.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed Autonomous Fire Suppression locking a room to the Fire Suppression preset.