### PR TITLE
Fixes Runechat Arbitrary Javascript Exploit

### DIFF
--- a/code/datums/chat_message.dm
+++ b/code/datums/chat_message.dm
@@ -213,7 +213,7 @@ var/runechat_icon = null
 	// Check for virtual speakers (aka hearing a message through a radio)
 	if (existing_extra_classes.Find("radio"))
 		return
-
+	raw_message = html_encode(raw_message)
 	var/list/extra_classes = list()
 	extra_classes += existing_extra_classes
 


### PR DESCRIPTION
# It's actually loose

## What this does
Special thanks to @Code-Alpha777 for discovering the exploit. This fixes a bug with runechat where it actually parses html tags, including ``<script>``, which allows arbitrary execution of javascript. An example use is attempting to have the main game window redirect to a youtube page (which only crashes dreamseeker, thankfully).

## Why it's good
IT'S LOOSE!!

## How it was tested
Traced all calls to runechat (just one) and protected them. Tested arbitrary html before and after. 
<img width="304" height="200" alt="image" src="https://github.com/user-attachments/assets/6d83d05b-f9b7-44e3-bf80-1ad4307a8f84" />

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed an html exploit with runetext.
