### PR TITLE
Adds Stamps to Office Supplies Crate

### DIFF
--- a/code/datums/supply_packs/supplies.dm
+++ b/code/datums/supply_packs/supplies.dm
@@ -184,7 +184,9 @@
 					/obj/item/weapon/pen/red,
 					/obj/item/weapon/pen/fountain,
 					/obj/item/device/flashlight/lamp,
-					/obj/item/device/flashlight/lamp)
+					/obj/item/device/flashlight/lamp,
+					/obj/item/weapon/stamp,
+					/obj/item/weapon/stamp/denied,)
 	cost = 15
 	containertype = /obj/structure/closet/crate/basic
 	containername = "office supply crate"


### PR DESCRIPTION
## What this does
This PR adds a regular stamp and a DENIED stamp to the office supplies crate.

## Why it's good
Gives a way for the crew to get replacement stamps should all the existing stamps on the station get stamped out of existing. Only basic stamps though, required for cargo/mail functionality.

## How it was tested
<img width="129" height="129" alt="image" src="https://github.com/user-attachments/assets/e5c08d65-a44c-43c8-897c-ec70df09af68" />

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Office Supplies crate now contains spare stamps.
