### PR TITLE
Day/Night Cycle Subsystem Refactor

### DIFF
--- a/code/controllers/subsystem/daynightcycle.dm
+++ b/code/controllers/subsystem/daynightcycle.dm
@@ -34,7 +34,7 @@ Basically, you are going to overwrite the flags.
 
 	See: Both of them right here!
 */
-	flags 		  = SS_FIRE_IN_LOBBY
+	flags = SS_FIRE_IN_LOBBY
 
 	var/current_timeOfDay = TOD_DAYTIME //This is more or less the color and duration since its in a switch.
 	var/next_light_power = 10 // As much as you would want to change these for cool factor.

--- a/code/controllers/subsystem/daynightcycle.dm
+++ b/code/controllers/subsystem/daynightcycle.dm
@@ -2,7 +2,7 @@ var/datum/subsystem/daynightcycle/SSDayNight
 
 var/list/daynight_turfs = list()
 var/list/daynight_z_lvls = list()
-/* Original Plan
+/* Default Timing
 Morning	  - 2 Mins
 Sunrise   - 2 Mins
 Daytime   - 16 Minutes
@@ -25,14 +25,10 @@ Nighttime - 36 Minutes
 	priority      = SS_PRIORITY_DAYNIGHT
 	wait          = 1 MINUTES
 /*
-On the map dm file, append the following to activate day/night lighting.
-Basically, you are going to overwrite the flags.
-
-/datum/subsystem/daynightcycle
-	flags = SS_FIRE_IN_LOBBY       This is basically how you want it to run.
-	daynight_z_lvl = 1   This basically is the z level it will be on. Defaults to main station unless specified here.
-
-	See: Both of them right here!
+On the map dm file, redefine the following:
+	- 'daynight_z_lvls' to change the zLevels that the day/night cycle applies to. Do not redefine if you want this subsystem disabled.
+	- 'process_lighting()' to change the lighting scheme.
+	- 'play_globalsound()' to change or disable the sound played at sunrise and sunset (if process_lighting() is unchanged).
 */
 	flags = SS_FIRE_IN_LOBBY
 

--- a/code/controllers/subsystem/daynightcycle.dm
+++ b/code/controllers/subsystem/daynightcycle.dm
@@ -77,9 +77,8 @@ Basically, you are going to overwrite the flags.
 
 /datum/subsystem/daynightcycle/proc/get_turflist()
 	message_admins("get_turflist fired")
-	for(var/datum/zLevel/Z in daynight_z_lvls)
-		message_admins("[Z] in daynight_z_lvls [daynight_z_lvls]")
-		for(var/turf/T in block(locate(1, 1, Z.z), locate(world.maxx, world.maxy, Z.z)))
+	for(var/z in daynight_z_lvls)
+		for(var/turf/T in block(locate(1, 1, z), locate(world.maxx, world.maxy, z)))
 			if(IsEven(T.x)) //If we are also even.
 				if(IsEven(T.y)) //If we are also even.
 					var/area/A = get_area(T)

--- a/code/controllers/subsystem/daynightcycle.dm
+++ b/code/controllers/subsystem/daynightcycle.dm
@@ -76,7 +76,9 @@ Basically, you are going to overwrite the flags.
 			currentrun = daynight_turfs.Copy()
 
 /datum/subsystem/daynightcycle/proc/get_turflist()
+	message_admins("get_turflist fired")
 	for(var/datum/zLevel/Z in daynight_z_lvls)
+		message_admins("[Z] in daynight_z_lvls [daynight_z_lvls]")
 		for(var/turf/T in block(locate(1, 1, Z.z), locate(world.maxx, world.maxy, Z.z)))
 			if(IsEven(T.x)) //If we are also even.
 				if(IsEven(T.y)) //If we are also even.
@@ -89,6 +91,7 @@ Basically, you are going to overwrite the flags.
 							var/area/A1 = get_area(T1)
 							if(istype(A1, /area/surface)) //If we are outside.
 								daynight_turfs += T
+	message_admins("daynight_turfs: [daynight_turfs.len] turfs")
 
 /datum/subsystem/daynightcycle/proc/play_globalsound()
 	for(var/mob/M in player_list)

--- a/code/controllers/subsystem/daynightcycle.dm
+++ b/code/controllers/subsystem/daynightcycle.dm
@@ -76,7 +76,6 @@ Basically, you are going to overwrite the flags.
 			currentrun = daynight_turfs.Copy()
 
 /datum/subsystem/daynightcycle/proc/get_turflist()
-	message_admins("get_turflist fired")
 	for(var/z in daynight_z_lvls)
 		for(var/turf/T in block(locate(1, 1, z), locate(world.maxx, world.maxy, z)))
 			if(IsEven(T.x)) //If we are also even.
@@ -90,7 +89,6 @@ Basically, you are going to overwrite the flags.
 							var/area/A1 = get_area(T1)
 							if(istype(A1, /area/surface)) //If we are outside.
 								daynight_turfs += T
-	message_admins("daynight_turfs: [daynight_turfs.len] turfs")
 
 /datum/subsystem/daynightcycle/proc/play_globalsound()
 	for(var/mob/M in player_list)

--- a/code/controllers/subsystem/daynightcycle.dm
+++ b/code/controllers/subsystem/daynightcycle.dm
@@ -1,7 +1,7 @@
 var/datum/subsystem/daynightcycle/SSDayNight
-var/datum/subsystem/daynightcycle/SSDayNightJungle
 
 var/list/daynight_turfs = list()
+var/list/daynight_z_lvls = list()
 /* Original Plan
 Morning	  - 2 Mins
 Sunrise   - 2 Mins
@@ -10,8 +10,8 @@ Afternoon - 16 Minutes
 Sunset    - 2 Minutes
 Nighttime - 36 Minutes
 */
-					
-#define TOD_MORNING 	"#4d6f86" 
+
+#define TOD_MORNING 	"#4d6f86"
 #define TOD_SUNRISE 	"#fdc5a0"
 #define TOD_DAYTIME 	"#FFFFFF"
 #define TOD_AFTERNOON 	"#ffeedf"
@@ -34,12 +34,11 @@ Basically, you are going to overwrite the flags.
 
 	See: Both of them right here!
 */
-	flags 		  = SS_NO_FIRE | SS_NO_INIT
-	var/daynight_z_lvl = FALSE
+	flags 		  = SS_FIRE_IN_LOBBY
 
 	var/current_timeOfDay = TOD_DAYTIME //This is more or less the color and duration since its in a switch.
 	var/next_light_power = 10 // As much as you would want to change these for cool factor.
-	var/next_light_range = 1 //	They basically are at the maximum values to not have overlapping light. 
+	var/next_light_range = 1 //	They basically are at the maximum values to not have overlapping light.
 							// Along with mesh evenly that is, the dir scan handles missed diagonals stylishly.
 
 	//The initial values don't matter, it just needs to fire initially, then set itself into the cycle.
@@ -50,37 +49,14 @@ Basically, you are going to overwrite the flags.
 	NEW_SS_GLOBAL(SSDayNight)
 
 /datum/subsystem/daynightcycle/Initialize()
-	if(!daynight_z_lvl)
-		daynight_z_lvl = map.zMainStation
+	if(!daynight_z_lvls.len)
+		flags = SS_NO_INIT | SS_NO_FIRE
 	get_turflist()
 	..()
 
 /datum/subsystem/daynightcycle/fire(resumed = FALSE)
 	if(world.time >= next_firetime)
-		switch(current_timeOfDay) //Then set the next segment up.
-			if(TOD_MORNING)
-				current_timeOfDay = TOD_SUNRISE
-				next_firetime = world.time + 3 MINUTES
-				play_globalsound()
-			if(TOD_SUNRISE)
-				current_timeOfDay = TOD_DAYTIME
-				next_firetime = world.time + 14 MINUTES
-			if(TOD_DAYTIME)
-				current_timeOfDay = TOD_AFTERNOON
-				next_firetime = world.time + 15 MINUTES
-			if(TOD_AFTERNOON)
-				current_timeOfDay = TOD_SUNSET
-				next_firetime = world.time + 3 MINUTES
-			if(TOD_SUNSET)
-				current_timeOfDay = TOD_NIGHTTIME
-				next_light_power = 3
-				next_firetime = world.time + 36 MINUTES
-				play_globalsound()
-			if(TOD_NIGHTTIME)
-				current_timeOfDay = TOD_MORNING
-				next_light_power = 10
-				next_firetime = world.time + 5 MINUTES
-			
+		process_lighting()
 		if(!resumed)
 			currentrun = daynight_turfs.Copy()
 
@@ -96,19 +72,23 @@ Basically, you are going to overwrite the flags.
 		if(MC_TICK_CHECK)
 			return
 
+		if(!resumed)
+			currentrun = daynight_turfs.Copy()
+
 /datum/subsystem/daynightcycle/proc/get_turflist()
-	for(var/turf/T in block(locate(1, 1, daynight_z_lvl), locate(world.maxx, world.maxy, daynight_z_lvl)))
-		if(IsEven(T.x)) //If we are also even.
-			if(IsEven(T.y)) //If we are also even.
-				var/area/A = get_area(T)
-				if(istype(A, /area/surface)) //If we are outside.
-					daynight_turfs += T
-				else //If We aren't we need to make sure we handle the outside segment
-					for(var/cdir in cardinal)//Ironically, this part didn't work correctly but....
-						var/turf/T1 = get_step(T,cdir)// It also ironically produced better looking day/night lighting
-						var/area/A1 = get_area(T1)
-						if(istype(A1, /area/surface)) //If we are outside.
-							daynight_turfs += T
+	for(var/datum/zLevel/Z in daynight_z_lvls)
+		for(var/turf/T in block(locate(1, 1, Z.z), locate(world.maxx, world.maxy, Z.z)))
+			if(IsEven(T.x)) //If we are also even.
+				if(IsEven(T.y)) //If we are also even.
+					var/area/A = get_area(T)
+					if(istype(A, /area/surface)) //If we are outside.
+						daynight_turfs += T
+					else //If We aren't we need to make sure we handle the outside segment
+						for(var/cdir in cardinal)//Ironically, this part didn't work correctly but....
+							var/turf/T1 = get_step(T,cdir)// It also ironically produced better looking day/night lighting
+							var/area/A1 = get_area(T1)
+							if(istype(A1, /area/surface)) //If we are outside.
+								daynight_turfs += T
 
 /datum/subsystem/daynightcycle/proc/play_globalsound()
 	for(var/mob/M in player_list)
@@ -122,116 +102,28 @@ Basically, you are going to overwrite the flags.
 					M << 'sound/misc/6pmWolf.wav'
 
 
-
-//junglestation uses a different system, to simulate being nearby multiple stars.
-/datum/subsystem/daynightcycle/jungle
-	name          = "Jungle Day Night Cycle"
-	var/solartime=0 //start at 0. set not like that for debugging.
-	
-/datum/subsystem/daynightcycle/jungle/New()
-	NEW_SS_GLOBAL(SSDayNightJungle)	
-	//solartime=rand(0,30) //add some variance
-
-/datum/subsystem/daynightcycle/jungle/fire(resumed = FALSE)
-	if(world.time >= next_firetime)
-	
-		// YCbCr is a superior colorspace. fight me.
-		var/luma=0.0
-		var/chroma_b=0.0
-		var/chroma_r=0.0
-		
-		//orbit 1: fast, red dwarf:: roughly 33 minutes, red-orange colors.
-		//this is the primary star we are orbiting, so it's fairly simple
-		var/power=max(0.0,sin(solartime*27.0))
-		
-		luma+=0.8*power //red dwarves are weak stars.
-		chroma_r+=0.60*power //they also would give off fuckhuge solar flares.
-		chroma_b-=0.25*power // but that's a problem for silicons to deal with.
-	
-	
-		//orbit 2: slow, blue giant. more distant, but more power. i hope you brought sunscreen.
-		power=max(0.0,sin(solartime*9.186+12.423)) // about 90 minutes. a bit of offset, too.
-		luma+=1.25*power
-		chroma_r-=0.20*power
-		chroma_b+=0.75*power
-	
-	
-		luma+=0.02 // minimum light level so it's not pitch black everywhere. atmospheric scattering would cause this.
-		chroma_b-=0.05
-		chroma_r+=0.04 // chroma shift so light appears a bit green to account for shortwave atmospheric absorption.
-		
-	
-		luma=luma**(1/2.2) //apply gamma correction
-		
-		//constants defined by ITU-R BT.2020
-		var/r = luma + 1.659 * chroma_r
-		var/g = luma - (0.396 * chroma_b) - (0.775 * chroma_r)
-		var/b = luma + 2.034 * chroma_b
-		
-		/*
-		why do this? because it makes brighter colors look better.
-		Also, because it simulates bright light desaturating colors
-		muh immulsions.
-		*/
-		for(var/n=0,n<3,n++) //3 smoothing passes seems good. This isn't particularly heavy math, anyways.
-			if (r>1)
-				var/redist=(r-1)
-				redist*=0.1
-				r-=2*redist/3
-				g+=redist/3
-				b+=redist/3
-			if (g>1)
-				var/redist=(g-1)
-				redist*=0.1
-				g-=2*redist/3
-				r+=redist/3
-				b+=redist/3
-			if (b>1)
-				var/redist=(b-1)
-				redist*=0.1
-				b-=2*redist/3
-				g+=redist/3
-				r+=redist/3	
-		
-		r=min(r,1)
-		g=min(g,1)
-		b=min(b,1)
-		
-		//convert from 0-1 to 0-255
-		r=floor(r*255)
-		g=floor(g*255)
-		b=floor(b*255)
-		
-		
-		next_light_power=luma*7.5
-		
-		message_admins("Jungle day/night system beginning new phase at [world.time], cycle #[solartime], with light stats of [next_light_power]-[r],[g],[b]")
-		
-		current_timeOfDay=rgb(r,g,b)
-	
-	
-		next_firetime=world.time + 5 MINUTES //station is too big to tick at 2 minutes. not without severe sever raep, at least.
-		solartime++
-			
-		if(!resumed)
-			currentrun = daynight_turfs.Copy()
-
-	while(currentrun.len)
-		var/turf/T = currentrun[currentrun.len]
-		currentrun.len--
-
-		if(!T || T.gcDestroyed)
-			continue
-
-		T.set_light(next_light_range,next_light_power,current_timeOfDay,TRUE)
-
-// MC_TICK_CHECK uses this (defined in __DEFINES/MC.dm):
-// ( ( world.tick_usage > CURRENT_TICKLIMIT || src.state != SS_RUNNING ) ? pause() : 0 )
-// now, the main issue is that if we use the tick limit, the server will stop executing things
-// so, the solution is to create our own check, which gives leeway.
-		if(MC_TICK_CHECK)
-			return	
-
-/datum/subsystem/daynightcycle/jungle/play_globalsound()
-	return
-
+//Default lighting scheme; intitially purpose-built for Snaxi. Overwrite this proc in your map.dm file if you want to change the lighting scheme. See junglestation.dm for an example.
+/datum/subsystem/daynightcycle/proc/process_lighting()
+	switch(current_timeOfDay) //Then set the next segment up.
+		if(TOD_MORNING)
+			current_timeOfDay = TOD_SUNRISE
+			next_firetime = world.time + 3 MINUTES
+			play_globalsound()
+		if(TOD_SUNRISE)
+			current_timeOfDay = TOD_DAYTIME
+			next_firetime = world.time + 14 MINUTES
+		if(TOD_DAYTIME)
+			current_timeOfDay = TOD_AFTERNOON
+			next_firetime = world.time + 15 MINUTES
+		if(TOD_AFTERNOON)
+			current_timeOfDay = TOD_SUNSET
+			next_firetime = world.time + 3 MINUTES
+		if(TOD_SUNSET)
+			current_timeOfDay = TOD_NIGHTTIME
+			next_light_power = 3
+			next_firetime = world.time + 36 MINUTES
+			play_globalsound()
+		if(TOD_NIGHTTIME)
+			current_timeOfDay = TOD_MORNING
+			next_light_power = 10
+			next_firetime = world.time + 5 MINUTES

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -459,14 +459,14 @@
 	if(density != old_density)
 		densityChanged()
 	if(istype(loc,/area/surface/jungle) && !istype(original_area,/area/surface/jungle) ) //outdoor areas need to be illuminated.
-		if(SSDayNightJungle && .)
+		if(SSDayNight && .)
 			var/turf/NewTurf=.
 			NewTurf.affecting_lights=list()
 			NewTurf.lighting_clear_overlay()
 			NewTurf.lighting_build_overlay()
-			NewTurf.set_light(SSDayNightJungle.next_light_range,SSDayNightJungle.next_light_power,SSDayNightJungle.current_timeOfDay)
-			
-			
+			NewTurf.set_light(SSDayNight.next_light_range,SSDayNight.next_light_power,SSDayNight.current_timeOfDay)
+
+
 
 /turf/proc/AddDecal(var/image/decal)
 	if(!turfdecals)
@@ -779,7 +779,7 @@
 				OnEmptyReagents()
 		return TRUE
 	return ..()
-		
+
 //Pathnode stuff
 
 /turf/proc/FindPathNode(var/id)
@@ -803,7 +803,7 @@
 		return
 	if(turf_reagent_amount==null)
 		return
-	
+
 	for(var/RID in turf_reagents)
 		var/datum/reagent/D = chemical_reagents_list[RID]
 		if(D)
@@ -820,7 +820,7 @@
 						R.reaction_mob(A, turf_reagent_method , turf_reagent_amount, ALL_LIMBS)
 			else if ( istype(A,/obj/machinery) || istype(A,/obj/item)  || istype(A,/obj/structure) )
 				R.reaction_obj(A, turf_reagent_amount)
-			
+
 			qdel(R)
 
 	if(turf_reagents_limited!=null)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -459,7 +459,7 @@
 	if(density != old_density)
 		densityChanged()
 	if(istype(loc,/area/surface/jungle) && !istype(original_area,/area/surface/jungle) ) //outdoor areas need to be illuminated.
-		if(SSDayNight && .)
+		if(.)
 			var/turf/NewTurf=.
 			NewTurf.affecting_lights=list()
 			NewTurf.lighting_clear_overlay()

--- a/code/game/turfs/unsimulated/jungle.dm
+++ b/code/game/turfs/unsimulated/jungle.dm
@@ -43,20 +43,20 @@
 /turf/unsimulated/floor/jungle/proc/item_terraforming_ispickaxe(obj/item/C)
 	if(istype(C,/obj/item/weapon/pickaxe) && !istype(C,/obj/item/weapon/pickaxe/shovel))
 		return (1/C.toolspeed)/2.5 //default toolspeed is 0.4. do this math because lower=faster, but we want higher=faster.
-	if(istype(C,/obj/item/tool/crowbar)) 
+	if(istype(C,/obj/item/tool/crowbar))
 		if(istype(C,/obj/item/tool/crowbar/halligan)) //halligans have a pick end.
 			return 0.75
 		return 0.5
 	if(istype(C,/obj/item/weapon/kitchen/utensil/knife))  //for those daring prison escapes, also because it's funny.
 		return 0.1
 	return 0.0
-	
+
 /turf/unsimulated/floor/jungle/proc/item_terraforming_isshovel(obj/item/C)
 	if(istype(C,/obj/item/weapon/pickaxe/shovel))
 		return (1/C.toolspeed)/2.5
 	if(istype(C,/obj/item/weapon/kitchen/utensil/spoon) || istype(C,/obj/item/weapon/kitchen/utensil/spork))  //see above
 		return 0.1
-	return 0.0	
+	return 0.0
 
 //shared construction code.
 /turf/unsimulated/floor/jungle/attackby(obj/item/C as obj, mob/user as mob)
@@ -64,10 +64,9 @@
 		return FALSE
 	for(var/obj/structure/flora/F in contents)
 		return ..()
-		return FALSE
 	if(!construction_allowed)
 		return ..()
-	
+
 	if(C.type== /obj/item/stack/tile/metal) // lattice -> plating
 		var/obj/item/stack/tile/T = C
 		for(var/obj/structure/lattice/L in contents)
@@ -109,7 +108,7 @@
 		var/obj/item/stack/sheet/wood/W=C
 		if(W.use(1))
 			new/obj/structure/lattice/wood(src)
-			return TRUE				
+			return TRUE
 	return ..()
 
 var/list/foliage_choices=list(
@@ -143,7 +142,7 @@ var/list/foliage_replacments=list(
 	icon_state = "grass_alt1"
 	turf_speed_multiplier=1.1 // tall grass.
 	construction_allowed=TRUE
-	
+
 /turf/unsimulated/floor/jungle/grass/New(var/loc,var/NO_GROW=FALSE)
 	..()
 	footstep_sound = sounds_grass
@@ -151,7 +150,7 @@ var/list/foliage_replacments=list(
 	footstep_sound_claw = sounds_grass
 	if(NO_GROW)
 		return
-	
+
 	//var/area/A = loc
 	//if(prob( (A.type!=/area/surface/jungle) ? 50 : 100 )) //populated areas have less plants. DOESN'T WORK. IS NULL. WHYYYYYYYYYYYYY
 	if (prob(50))
@@ -162,7 +161,7 @@ var/list/foliage_replacments=list(
 		else //45% over all
 			var/plantseed = abs(( sin((x+rand(-2,2))*5.01+213.998) + sin((y+rand(-2,2))*4.56+71.294) )%%1.0)
 			plantseed = 1+floor(plantseed*(foliage_choices.len-0.01))//mmm, dumb float math
-	
+
 			var/create=foliage_choices[plantseed]
 			if(create)
 				new create(src)
@@ -171,12 +170,12 @@ var/list/foliage_replacments=list(
 		if( !(locate(/obj/structure/flora/tree) in range(2,src)) )
 			new/obj/structure/flora/tree/shitty(src)
 
-		
+
 /turf/unsimulated/floor/jungle/grass/Destroy()
 	..()
 	for(var/obj/structure/flora/F in contents)
 		qdel(F)
-	
+
 /turf/unsimulated/floor/jungle/grass/attackby(obj/item/C as obj, mob/user as mob)
 	..()
 	if(!C || !user)
@@ -187,10 +186,10 @@ var/list/foliage_replacments=list(
 		to_chat(user, "<span class='notice'>You start breaking up the soil</span>")
 		if(do_after(user, src, 20/s ))
 			ChangeTurf(/turf/unsimulated/floor/jungle/dirt)
-			new /obj/item/stack/tile/grass(src,1)	
-	
-	
-/turf/unsimulated/floor/jungle/grass/ex_act(severity)	
+			new /obj/item/stack/tile/grass(src,1)
+
+
+/turf/unsimulated/floor/jungle/grass/ex_act(severity)
 	switch(severity)
 		if(1.0)
 			ChangeTurf(/turf/unsimulated/floor/jungle/dirt)
@@ -219,7 +218,7 @@ var/list/foliage_replacments=list(
 
 /turf/unsimulated/floor/jungle/mud/New()
 	..()
-	icon_state="ironsand[rand(1,15)]"	
+	icon_state="ironsand[rand(1,15)]"
 
 
 /turf/unsimulated/floor/jungle/concrete
@@ -229,7 +228,7 @@ var/list/foliage_replacments=list(
 	icon_state = "concrete"
 	DIGGING_BLOCKED = "Something hard blocks the way."
 
-/turf/unsimulated/floor/jungle/concrete/ex_act(severity)	
+/turf/unsimulated/floor/jungle/concrete/ex_act(severity)
 	switch(severity)
 		if(1)
 			if(prob(50))
@@ -275,7 +274,7 @@ var/list/foliage_replacments=list(
 			if(!hashole)
 				to_chat(usr,"you finish making a hole.")
 				var/obj/structure/ladder/jungle_tunnel/l_surf=new(src)
-				var/obj/structure/ladder/jungle_tunnel/l_tunnel=new(locate(x,y,2))	
+				var/obj/structure/ladder/jungle_tunnel/l_tunnel=new(locate(x,y,2))
 				l_tunnel.up=l_surf
 				l_surf.down=l_tunnel
 				hashole=l_surf
@@ -283,13 +282,13 @@ var/list/foliage_replacments=list(
 				T2?.ChangeTurf(/turf/unsimulated/floor/jungle/bedrock)
 				var/turf/unsimulated/floor/jungle/bedrock/TT=T2
 				TT?.hashole=l_tunnel
-			return	
+			return
 	if(C.type== /obj/item/stack/ore/glass && hashole)
 		var/obj/item/stack/ore/glass/T = C
 		if(T.amount<50)
 			to_chat(usr,"you need 50 sand to do this!")
 			return
-		to_chat(usr,"you start filling the hole back with soil...")	
+		to_chat(usr,"you start filling the hole back with soil...")
 		if(do_after(user, src, 80 ))
 			if(T.use(50))
 				to_chat(usr,"you fill the hole back with soil.")
@@ -298,7 +297,7 @@ var/list/foliage_replacments=list(
 				qdel(hashole.down)
 				qdel(hashole)
 				hashole=null
-				
+
 
 /turf/unsimulated/floor/jungle/path
 	name="Compressed Dirt"
@@ -333,7 +332,7 @@ var/list/foliage_replacments=list(
 /turf/unsimulated/floor/jungle/path/can_place_cables()
 	return TRUE
 
-/turf/unsimulated/floor/jungle/path/ex_act(severity)	
+/turf/unsimulated/floor/jungle/path/ex_act(severity)
 	switch(severity)
 		if(1)
 			ChangeTurf(/turf/unsimulated/floor/jungle/dirt)
@@ -416,17 +415,17 @@ var/list/foliage_replacments=list(
 	icon = 'icons/misc/beach.dmi'
 	icon_state = "sand"
 	construction_allowed=TRUE
-	
-	
+
+
 /turf/unsimulated/floor/jungle/underground
 	name="Packed Soil"
 	density=1
 	opacity=1
 	desc="Solid dirt as far as the eye can see."
 	icon='icons/turf/walls.dmi'
-	icon_state = "gingerbread15"	
+	icon_state = "gingerbread15"
 	var/loosened=FALSE // you dig with a pickaxe, too, dumbass.
-	
+
 
 /turf/unsimulated/floor/jungle/underground/ex_act(severity)
 	switch(severity)
@@ -454,7 +453,7 @@ var/list/foliage_replacments=list(
 			to_chat(user, "<span class='notice'>You start to loosen the soil...</span>")
 			if(do_after(user, src, 20/s ))
 				loosened=TRUE
-	s=item_terraforming_isshovel(C)			
+	s=item_terraforming_isshovel(C)
 	if(s>0.0)
 		to_chat(user, loosened ? "<span class='notice'>You begin to break apart the soil...</span>" : "<span class='notice'>You struggle to break up the soil...</span>")
 		if(do_after(user, src, (loosened ? 20 : 60)/s ))
@@ -485,7 +484,7 @@ var/list/foliage_replacments=list(
 	name="Bedrock"
 	desc="A very dense rock. Nothing seems to be able to dig through it."
 	icon='icons/turf/walls.dmi'
-	icon_state = "mariahive_noanimation"	
+	icon_state = "mariahive_noanimation"
 	var/obj/structure/ladder/jungle_tunnel/hashole=null
 	construction_allowed=TRUE
 
@@ -493,7 +492,7 @@ var/list/foliage_replacments=list(
 /turf/unsimulated/floor/jungle/bedrock/New(var/loc)
 	if(locate(/obj/structure/ladder/jungle_tunnel) in contents)
 		icon_state="mariahive_noanimation_l"
-		
+
 	if(cannot_dig_up())
 		icon_state="mariahive_noanimation_d"
 
@@ -510,13 +509,13 @@ var/list/foliage_replacments=list(
 				if(!hashole && !cannot_dig_up() )
 					to_chat(usr,"you finish making a hole.")
 					icon_state="mariahive_noanimation_l"
-					
+
 					var/obj/structure/ladder/jungle_tunnel/l_tunnel=new(src)
 					var/obj/structure/ladder/jungle_tunnel/l_surf=new(locate(x,y,1))
-					
+
 					l_tunnel.up=l_surf
 					l_surf.down=l_tunnel
-					
+
 					var/turf/T2=locate(x,y,1)
 					T2?.ChangeTurf(/turf/unsimulated/floor/jungle/dirt)
 					var/turf/unsimulated/floor/jungle/dirt/TT=T2
@@ -527,8 +526,8 @@ var/list/foliage_replacments=list(
 				return
 		else
 			to_chat(usr,cannot_dig_up() || "something solid prevents you from tunneling upwards.")
-			
-	
+
+
 /turf/unsimulated/floor/jungle/bedrock/examine()
 	..()
 	if(icon_state=="mariahive_noanimation_d")
@@ -543,13 +542,13 @@ var/list/foliage_replacments=list(
 	if(recursive)
 		..()
 	icon_state="mariahive_noanimation"
-	
+
 	if(locate(/obj/structure/ladder/jungle_tunnel) in contents)
 		icon_state="mariahive_noanimation_l"
-	
+
 	if(cannot_dig_up())
 		icon_state="mariahive_noanimation_d"
-	
+
 	if(recursive) //we reveal the state of surrounding bedrock. there's probably a better way to do this.
 		var/turf/T2=get_step(src,NORTH)
 		if(T2 && T2.type==/turf/unsimulated/floor/jungle/bedrock)
@@ -574,8 +573,8 @@ var/list/foliage_replacments=list(
 			T2.Entered(Obj,FALSE)
 		T2=get_step(src,SOUTHWEST)
 		if(T2 && T2.type==/turf/unsimulated/floor/jungle/bedrock)
-			T2.Entered(Obj,FALSE)				
-	
+			T2.Entered(Obj,FALSE)
+
 /turf/unsimulated/floor/jungle/bedrock/proc/cannot_dig_up()
 	var/turf/T=locate(x,y,1)
 	if(!istype(T,/turf/unsimulated/floor/jungle))
@@ -586,8 +585,8 @@ var/list/foliage_replacments=list(
 	if(locate(/obj/structure/flora/tree) in T.contents)
 		return "there's too many roots in the way."
 	return null
-	
-/turf/unsimulated/floor/jungle/bedrock/ex_act(severity)	
+
+/turf/unsimulated/floor/jungle/bedrock/ex_act(severity)
 	return
 
 /turf/unsimulated/floor/jungle/bedrock/can_place_cables()
@@ -600,8 +599,8 @@ var/list/foliage_replacments=list(
 	desc="you cannot go this way..."
 	icon='icons/turf/walls.dmi'
 	icon_state="rock"
-	
-/turf/unsimulated/floor/jungle/worldborder/ex_act(severity)	
+
+/turf/unsimulated/floor/jungle/worldborder/ex_act(severity)
 	return
 /turf/unsimulated/floor/jungle/worldborder/attackby(obj/item/C as obj, mob/user as mob)
 	return

--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -31,9 +31,9 @@
 	var/zDerelict = 4
 	var/zAsteroid = 5
 	var/zDeepSpace = 6
-	
+
 	var/zAdditionalStationZlevel = -1 // -1 because surely nothing will ever go to Z -1, right? why not null? because nullspace
-	
+
 	var/skip_hobo_shack = FALSE // if true, skips hobo shack generation. set to TRUE if you want to map your own custom one for the map.
 
 	//Holomap offsets

--- a/maps/junglestation.dm
+++ b/maps/junglestation.dm
@@ -134,6 +134,9 @@
 	next_firetime=world.time + 5 MINUTES //station is too big to tick at 2 minutes. not without severe sever raep, at least.
 	solartime++
 
+
+/datum/subsystem/daynightcycle/get_turflist()
+
 /datum/subsystem/daynightcycle/play_globalsound()
 	return
 

--- a/maps/junglestation.dm
+++ b/maps/junglestation.dm
@@ -7,16 +7,16 @@
 	nameShort = "Jungle"
 	nameLong = "Jungle Station"
 	map_dir = "junglestation"
-	
+
 	zMainStation = 1
 	zAdditionalStationZlevel = 2
 	zCentcomm = 3
 	zAsteroid = 4
 	zDerelict = 5
-	
+
 	zDeepSpace = -1
 	zTCommSat = -1
-	
+
 	zLevels = list(
 		/datum/zLevel/junglesurface,
 		/datum/zLevel/jungleunderground,
@@ -46,13 +46,96 @@
 	world.name = "NT Colony Gamma-8"
 	station_name="NT Colony Gamma-8"
 
+	daynight_z_lvls = list(zLevels[1])
+
 /****************************
 **	Day and Night Lighting **
 **	See: daynightcycle.dm  **
 ****************************/
-/datum/subsystem/daynightcycle/jungle
-	flags = SS_FIRE_IN_LOBBY
+/datum/subsystem/daynightcycle
+	var/solartime=0 //start at 0. set not like that for debugging.
 
+/datum/subsystem/daynightcycle/process_lighting()
+	// YCbCr is a superior colorspace. fight me.
+	var/luma=0.0
+	var/chroma_b=0.0
+	var/chroma_r=0.0
+
+	//orbit 1: fast, red dwarf:: roughly 33 minutes, red-orange colors.
+	//this is the primary star we are orbiting, so it's fairly simple
+	var/power=max(0.0,sin(solartime*27.0))
+
+	luma+=0.8*power //red dwarves are weak stars.
+	chroma_r+=0.60*power //they also would give off fuckhuge solar flares.
+	chroma_b-=0.25*power // but that's a problem for silicons to deal with.
+
+
+	//orbit 2: slow, blue giant. more distant, but more power. i hope you brought sunscreen.
+	power=max(0.0,sin(solartime*9.186+12.423)) // about 90 minutes. a bit of offset, too.
+	luma+=1.25*power
+	chroma_r-=0.20*power
+	chroma_b+=0.75*power
+
+
+	luma+=0.02 // minimum light level so it's not pitch black everywhere. atmospheric scattering would cause this.
+	chroma_b-=0.05
+	chroma_r+=0.04 // chroma shift so light appears a bit green to account for shortwave atmospheric absorption.
+
+
+	luma=luma**(1/2.2) //apply gamma correction
+
+	//constants defined by ITU-R BT.2020
+	var/r = luma + 1.659 * chroma_r
+	var/g = luma - (0.396 * chroma_b) - (0.775 * chroma_r)
+	var/b = luma + 2.034 * chroma_b
+
+	/*
+	why do this? because it makes brighter colors look better.
+	Also, because it simulates bright light desaturating colors
+	muh immulsions.
+	*/
+	for(var/n=0,n<3,n++) //3 smoothing passes seems good. This isn't particularly heavy math, anyways.
+		if (r>1)
+			var/redist=(r-1)
+			redist*=0.1
+			r-=2*redist/3
+			g+=redist/3
+			b+=redist/3
+		if (g>1)
+			var/redist=(g-1)
+			redist*=0.1
+			g-=2*redist/3
+			r+=redist/3
+			b+=redist/3
+		if (b>1)
+			var/redist=(b-1)
+			redist*=0.1
+			b-=2*redist/3
+			g+=redist/3
+			r+=redist/3
+
+	r=min(r,1)
+	g=min(g,1)
+	b=min(b,1)
+
+	//convert from 0-1 to 0-255
+	r=floor(r*255)
+	g=floor(g*255)
+	b=floor(b*255)
+
+
+	next_light_power=luma*7.5
+
+	message_admins("Jungle day/night system beginning new phase at [world.time], cycle #[solartime], with light stats of [next_light_power]-[r],[g],[b]")
+
+	current_timeOfDay=rgb(r,g,b)
+
+
+	next_firetime=world.time + 5 MINUTES //station is too big to tick at 2 minutes. not without severe sever raep, at least.
+	solartime++
+
+/datum/subsystem/daynightcycle/play_globalsound()
+	return
 
 ////////////////////////////////////////////////////////////////
 #include "junglestation.dmm"

--- a/maps/junglestation.dm
+++ b/maps/junglestation.dm
@@ -134,9 +134,6 @@
 	next_firetime=world.time + 5 MINUTES //station is too big to tick at 2 minutes. not without severe sever raep, at least.
 	solartime++
 
-
-/datum/subsystem/daynightcycle/get_turflist()
-
 /datum/subsystem/daynightcycle/play_globalsound()
 	return
 

--- a/maps/junglestation.dm
+++ b/maps/junglestation.dm
@@ -46,7 +46,7 @@
 	world.name = "NT Colony Gamma-8"
 	station_name="NT Colony Gamma-8"
 
-	daynight_z_lvls = list(zLevels[1])
+	daynight_z_lvls = list(zMainStation)
 
 /****************************
 **	Day and Night Lighting **

--- a/maps/snaxi.dm
+++ b/maps/snaxi.dm
@@ -45,9 +45,6 @@
 **	Day and Night Lighting **
 **	See: daynightcycle.dm  **
 ****************************/
-/datum/subsystem/daynightcycle
-	flags = SS_FIRE_IN_LOBBY
-
 /datum/map/active/New()
 	. = ..()
 
@@ -57,6 +54,7 @@
 	mining_shuttle.req_access = list()
 	security_shuttle.name = "Northeast Station Shuttle"
 	security_shuttle.req_access = list()
+	daynight_z_lvls = list(zLevels[1])
 
 /datum/map/active/special_ui(var/obj/abstract/screen/S, mob/user)
 	if(!user)

--- a/maps/snaxi.dm
+++ b/maps/snaxi.dm
@@ -54,7 +54,7 @@
 	mining_shuttle.req_access = list()
 	security_shuttle.name = "Northeast Station Shuttle"
 	security_shuttle.req_access = list()
-	daynight_z_lvls = list(zLevels[1])
+	daynight_z_lvls = list(zMainStation)
 
 /datum/map/active/special_ui(var/obj/abstract/screen/S, mob/user)
 	if(!user)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Refactors the Day/Night Subsystem:
- Created a 'process_lighting()' proc which is overwritten in map files to provide map-specific lighting behavior. Snaxi lighting scheme is default.
- Modified the system to allow for multiple zLevels to run day-night cycles.
- Killed the separate Jungle Daynight Subsystem.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
- Makes the subsystem follow OOP standards better.
- Allows for easy use in future maps.
- Enables this subsystem on multiple zLevels (this will be good for procgen).

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
- Tested the day/night cycle on both Snaxi and Jungle while modifying the vars to force lighting changes and confirmed they work without any issues.
- Tested Box to ensure the subsystem does not run on maps that should not have a day/night cycle.


Backend change - no CL.
