### PR TITLE
Cargo Console Central Request Paperwork Changes

### DIFF
--- a/code/controllers/subsystem/supply_shuttle.dm
+++ b/code/controllers/subsystem/supply_shuttle.dm
@@ -534,7 +534,6 @@ var/datum/subsystem/supply_shuttle/SSsupply_shuttle
 
 /datum/subsystem/supply_shuttle/proc/add_centcomm_order(var/datum/centcomm_order/C)
 	centcomm_orders.Add(C)
-	var/name = "External order form - [C.name] order number [C.id]"
 	var/info = {"<h3>Central Command supply requisition form</h3><hr>
 	 			INDEX: #[C.id]<br>
 	 			REQUESTED BY: [C.name]<br>
@@ -547,10 +546,7 @@ var/datum/subsystem/supply_shuttle/SSsupply_shuttle
 		return
 	for(var/obj/machinery/computer/supplycomp/S in supply_consoles)
 		if(S.printccrequests)
-			var/obj/item/weapon/paper/reqform = new /obj/item/weapon/paper(S.loc)
-			reqform.name = name
-			reqform.info = info
-			reqform.update_icon()
+			C.generate_form(S.loc)
 		S.say("New Central Command request available!")
 		playsound(S, 'sound/machines/twobeep.ogg', 50, 1)
 

--- a/code/datums/centcomm_orders/centcomm_orders.dm
+++ b/code/datums/centcomm_orders/centcomm_orders.dm
@@ -244,6 +244,21 @@ var/global/current_centcomm_order_id=124901
 	. = ..()
 	Pay(.)
 
+//Returns a paper request form
+/datum/centcomm_order/proc/generate_form(var/target)
+	var/obj/item/weapon/paper/reqform = new /obj/item/weapon/paper(target)
+	reqform.name = "External order form - [name] order number [id]"
+	reqform.info = {"<h3>Central Command supply requisition form</h3><hr>
+	 			INDEX: #[id]<br>
+	 			REQUESTED BY: [name]<br>
+	 			MUST BE IN CRATE(S): [must_be_in_crate ? "YES" : "NO"]<br>
+	 			REQUESTED ITEMS:<br>
+	 			[getRequestsByName(1)]
+	 			WORTH: [worth] credits TO [acct_by_string]
+	 			"}
+	reqform.update_icon()
+	return reqform
+
 ///////////////////////////////
 
 /proc/create_random_orders(var/num_orders)//This one is used at roundstart to add a couple random orders immediately

--- a/code/datums/centcomm_orders/centcomm_orders.dm
+++ b/code/datums/centcomm_orders/centcomm_orders.dm
@@ -246,6 +246,8 @@ var/global/current_centcomm_order_id=124901
 
 //Returns a paper request form
 /datum/centcomm_order/proc/generate_form(var/target)
+	if(!target)
+		return //target required, or it winds up in nullspace!
 	var/obj/item/weapon/paper/reqform = new /obj/item/weapon/paper(target)
 	reqform.name = "External order form - [name] order number [id]"
 	reqform.info = {"<h3>Central Command supply requisition form</h3><hr>

--- a/code/game/machinery/computer/cargo.dm
+++ b/code/game/machinery/computer/cargo.dm
@@ -592,7 +592,7 @@ For vending packs, see vending_packs.dm*/
 			if(O.id == text2num(href_list["printreq"]))
 				O.generate_form(loc)
 				last_print = world.time
-				say("Printed request number [O.id].")
+				say("Printed request #[O.id].")
 				break
 		return 1
 	else if (href_list["close"])

--- a/code/game/machinery/computer/cargo.dm
+++ b/code/game/machinery/computer/cargo.dm
@@ -127,7 +127,7 @@ For vending packs, see vending_packs.dm*/
 	var/list/current_acct
 	var/list/current_acct_override
 	var/screen = SCR_MAIN
-	var/printccrequests = TRUE
+	var/printccrequests = FALSE
 	var/printordermanifests = TRUE
 	var/printshuttlemanifests = TRUE
 	var/last_print = 0 //prevent paper flood spam

--- a/code/game/machinery/computer/cargo.dm
+++ b/code/game/machinery/computer/cargo.dm
@@ -130,6 +130,7 @@ For vending packs, see vending_packs.dm*/
 	var/printccrequests = TRUE
 	var/printordermanifests = TRUE
 	var/printshuttlemanifests = TRUE
+	var/last_print = 0 //prevent paper flood spam
 	light_color = LIGHT_COLOR_BROWN
 
 	hack_abilities = list(
@@ -581,6 +582,18 @@ For vending packs, see vending_packs.dm*/
 			screen = result
 		return 1
 	else if (href_list["updateclock"])
+		return 1
+	else if (href_list["printreq"])
+		if(!check_restriction(usr))
+			return
+		if(world.time < last_print+1)
+			return
+		for(var/datum/centcomm_order/O in SSsupply_shuttle.centcomm_orders)
+			if(O.id == text2num(href_list["printreq"]))
+				O.generate_form(loc)
+				last_print = world.time
+				say("Printed request number [O.id].")
+				break
 		return 1
 	else if (href_list["close"])
 		current_acct = null

--- a/nano/css/shared.css
+++ b/nano/css/shared.css
@@ -435,6 +435,11 @@ div.notice {
     float: right;
 }
 
+.floatNone {
+    float: none;
+	width: max-content;
+}
+
 .noOverflow {
 	white-space: nowrap;
 	overflow: hidden;

--- a/nano/templates/supply_console.tmpl
+++ b/nano/templates/supply_console.tmpl
@@ -225,7 +225,7 @@ Permissions Panel
 					<br>
 					{{for data.centcomm_orders}}
 						<div class="line">
-							#{{:value.id}}<br>
+							#{{:value.id}} {{:helper.link('Print', 'document', {'printreq' : value.id}, null)}}<br>
 							Requested:<br>
 								{{:value.requested}}<br>
 								{{if value.extra}}

--- a/nano/templates/supply_console.tmpl
+++ b/nano/templates/supply_console.tmpl
@@ -225,7 +225,7 @@ Permissions Panel
 					<br>
 					{{for data.centcomm_orders}}
 						<div class="line">
-							#{{:value.id}} {{:helper.link('Print', 'document', {'printreq' : value.id}, null)}}<br>
+							{{:helper.link('#' + value.id, 'document', {'printreq' : value.id}, null,'floatNone')}}
 							Requested:<br>
 								{{:value.requested}}<br>
 								{{if value.extra}}


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
This PR changes the default option of printing Central Command orders when they're issued to off. In exchange, it adds a button that allows you to print individual requests on demand.

## Why it's good
No more 200 piles of paper on a cargo computer because you went to go visit the bar for a minute.

## How it was tested
<img width="217" height="234" alt="image" src="https://github.com/user-attachments/assets/c722a6e5-b822-48d8-aafd-7394aadd88d5" />
<img width="601" height="736" alt="image" src="https://github.com/user-attachments/assets/584d1968-2102-4521-b070-fdf7775c0378" />
<img width="488" height="84" alt="image" src="https://github.com/user-attachments/assets/89d48266-c63c-4359-a336-222adc088134" />
<img width="170" height="171" alt="image" src="https://github.com/user-attachments/assets/7f804bff-77df-45bc-943f-15919e3bf38a" />


## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Cargo computers no longer print Central Command requests by default. Instead, you can print them individually on the Requests menu.
