### PR TITLE
Fixes character slots not saving properly

### DIFF
--- a/code/modules/client/preferences/preferences.dm
+++ b/code/modules/client/preferences/preferences.dm
@@ -161,6 +161,7 @@ var/const/MAX_SAVE_SLOTS = 16
 		if(!IsGuestKey(thekey))
 			var/load_pref = try_load_preferences(theckey, C.mob)
 			var/default_slot = get_pref(/datum/preference_setting/numerical/default_slot)
+			slot = default_slot
 			if(load_pref)
 				to_chat(C, "Successfully loaded preferences.")
 				while(!SS_READY(SShumans))


### PR DESCRIPTION
[bugfix]
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
what it says on the tin, the issue was caused by this:
basically if you’re not using character slot 1 when the game starts and you try saving your character, the game still thinks you are using slot 1, so it doesn’t save your changes and it overwrites slot 1 instead
this should fix it

Fixes #38076

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
bugfix

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Opened the game, see if I could save my character without changing slot and without overwriting slot 1
It works

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Character slots now save properly again.

