### PR TITLE
Small Somatoray QoL

### DIFF
--- a/code/modules/hydroponics/floral_somatoray.dm
+++ b/code/modules/hydroponics/floral_somatoray.dm
@@ -46,6 +46,10 @@
 	playsound(user, 'sound/weapons/egun_toggle_noammo.ogg', 50, 1)
 	flick("floral_somatoray-modechange", src)
 
+/obj/item/floral_somatoray/examine(var/mob/user)
+	..()
+	to_chat(user, "It's set to modify [genes[mode]] traits.")
+
 /obj/item/floral_somatoray/update_icon()
 	overlays.len = 0
 	var/current_gene = genes[mode]
@@ -90,7 +94,7 @@
 		desc += " It seems to have it's safety features de-activated."
 		playsound(user, 'sound/effects/sparks4.ogg', 50, 1)
 		update_icon()
-	
+
 
 /obj/item/floral_somatoray/attack(var/mob/living/M, var/mob/living/user, var/def_zone, var/originator=null)
 	return


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->
[tweak][qol][tested]
<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Tiny tweak. Adds the current mode of the Floral Somatoray to the examine description.
## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Small QoL for the Botanist. I want to be able to check the active mode without memorizing colour codes.
## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Spawned a somatoray, switched through all modes and examined each one, works.
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: You can now see the active mode of the somatoray by examining it.
