### PR TITLE
Grues will now only spawn on Snaxi when it's night

### DIFF
--- a/maps/snaxi.dm
+++ b/maps/snaxi.dm
@@ -194,10 +194,10 @@
 	// Grues will only spawn during certain times of the day to avoid getting into a very disadvantageous position where there's light everywhere outside
 	if(ispath(DR.role_category,/datum/role/grue))
 		if(SSDayNight) // Double-check to avoid runtimes
-			// The night should come within 5 minutes after they have spawned. They just have to be patient.
+			// The night should come within 6 minutes after they have spawned. They just have to be patient.
 			if((SSDayNight.current_timeOfDay == TOD_AFTERNOON) && (SSDayNight.next_firetime <= (world.time + 3 MINUTES)))
 				return TRUE
-			// By the time they will spawn during sunset it will be within 2 minutes.
+			// By the time they will spawn during sunset it will be within 3 minutes.
 			else if(SSDayNight.current_timeOfDay == TOD_SUNSET)
 				return TRUE
 			// If night ends within 5 minutes they can't do much.

--- a/maps/snaxi.dm
+++ b/maps/snaxi.dm
@@ -191,6 +191,21 @@
 /datum/map/active/map_ruleset(var/datum/dynamic_ruleset/DR)
 	if(ispath(DR.role_category,/datum/role/blob_overmind))
 		return FALSE
+	// Grues will only spawn during certain times of the day to avoid getting into a very disadvantageous position where there's light everywhere outside
+	if(ispath(DR.role_category,/datum/role/grue))
+		if(SSDayNight) // Double-check to avoid runtimes
+			// The night should come within 5 minutes after they have spawned. They just have to be patient.
+			if((SSDayNight.current_timeOfDay == TOD_AFTERNOON) && (SSDayNight.next_firetime <= (world.time + 3 MINUTES)))
+				return TRUE
+			// By the time they will spawn during sunset it will be within 2 minutes.
+			else if(SSDayNight.current_timeOfDay == TOD_SUNSET)
+				return TRUE
+			// If night ends within 5 minutes they can't do much.
+			else if((SSDayNight.current_timeOfDay == TOD_NIGHTTIME) && (SSDayNight.next_firetime >= (world.time + 5 MINUTES)))
+				return TRUE
+			else // Snaxi has a 71 minute day cycle, the grue can spawn in a span of 37 minutes.
+				return FALSE
+
 
 	return ..()
 


### PR DESCRIPTION
Technically they can spawn:
- In the afternoon 6 minutes before night arrives
- At sunset
- During the night but not within 5 minutes before the night ends.

This will make them rarer but also generally less disadvantaged by the day-night cycle.

:cl:
 * tweak: Grues on Snaxi will now only have a chance to appear when it's night or about to be night.