### PR TITLE
Buffs Chemical Tampering Machines

### DIFF
--- a/code/game/machinery/chemHandC.dm
+++ b/code/game/machinery/chemHandC.dm
@@ -143,6 +143,9 @@
 			if(!had_item)
 				to_chat(user, "<span class='notice'>\The [src] doesn't have a container to work on right now.</span>")
 
+/obj/machinery/chemtemper/get_heat_conductivity() //Chemical machines are perfectly insulated
+	return 0
+
 //Heater//
 
 /obj/machinery/chemtemper/heater
@@ -152,7 +155,7 @@
 	icon_state_open = "heater_open"
 
 	max_temperature = TEMPERATURE_LASER
-	thermal_energy_transfer = 3000
+	thermal_energy_transfer = 27000
 	part_kind = "laser"
 
 /obj/machinery/chemtemper/heater/New()
@@ -174,7 +177,7 @@
 	icon_state_open = "cooler_open"
 
 	max_temperature = 0 //You can make stuff REALLY cold
-	thermal_energy_transfer = -3000
+	thermal_energy_transfer = -27000
 	part_kind = "scanner"
 
 /obj/machinery/chemtemper/cooler/New()


### PR DESCRIPTION
## What this does
This PR double-buffs the Directed Laser Heater and Cryonic Wave Projector such that:
1) They increase/decrease heat 9 times faster than before, equalling a plasma bunsen in terms of base efficiency (increased by upgrading parts).
2) Protect containers inside from Thermal Entropy.

## Why it's good
If you're bothering to actually make these things, they should be good. This makes them good.

## How it was tested
Made soap! It took the expected amount of time with the new values.
<img width="161" height="85" alt="image" src="https://github.com/user-attachments/assets/ce121d21-6c4e-487b-abe2-dd152e2840a9" />
<img width="332" height="51" alt="image" src="https://github.com/user-attachments/assets/80c7ac2e-cbcb-4610-bde4-7381728f65b8" />

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Directed Laser Heaters and Cryonic Wave Projectors are now considerably faster at heating and cooling.
