### PR TITLE
Fixes RPEDs not being able to hold borg components

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -449,7 +449,7 @@ var/global/list/plantbag_colour_choices = list("plantbag", "green red stripe", "
 	storage_slots = 50;
 	max_combined_w_class = 200
 	w_class = W_CLASS_TINY
-	can_only_hold = list("/obj/item/weapon/stock_parts", "/obj/item/weapon/reagent_containers/glass/beaker", "/obj/item/weapon/cell", "/obj/item/weapon/circuitboard")
+	can_only_hold = list("/obj/item/weapon/stock_parts", "/obj/item/weapon/reagent_containers/glass/beaker", "/obj/item/weapon/cell", "/obj/item/weapon/circuitboard", "/obj/item/robot_parts/robot_component")
 	display_contents_with_number = TRUE
 
 /obj/item/weapon/storage/bag/gadgets/mass_remove(atom/A)


### PR DESCRIPTION
[bugfix]

## What this does
see title

## How it was tested
spawning an advanced borg component, picking it up with a bluespace RPED, putting it in a borg

## Changelog
:cl:
 * bugfix: Part replacers and gadget bags can now actually hold borg components for upgrades.