### PR TITLE
Wizard robes can now carry a few more items

### DIFF
--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -187,7 +187,7 @@
 	gas_transfer_coefficient = 0.01 // IT'S MAGICAL OKAY JEEZ +1 TO NOT DIE
 	permeability_coefficient = 0.01
 	armor = list(melee = 30, bullet = 20, laser = 20,energy = 20, bomb = 20, bio = 20, rad = 20)
-	allowed = list(/obj/item/weapon/teleportation_scroll,/obj/item/weapon/gun/energy/staff)
+	allowed = list(/obj/item/weapon/teleportation_scroll,/obj/item/weapon/gun/energy/staff,/obj/item/weapon/staff)
 	siemens_coefficient = 0.8
 	clothing_flags = ONESIZEFITSALL|COLORS_OVERLAY
 	wizard_garb = 1


### PR DESCRIPTION
The notable items are:
- Staff of Necromancy
- Prop wizard staves
- Brooms

:cl:
 * bugfix: Fixed a bug where the Staff of Necromancy couldn't be placed in the wizard's robes.
 * tweak: Wizard robes can now carry fake wizard staves and brooms.