### PR TITLE
fixes oversight with metastable mutagen

### DIFF
--- a/code/modules/hydroponics/hydroponics_mutations.dm
+++ b/code/modules/hydroponics/hydroponics_mutations.dm
@@ -47,7 +47,7 @@
 						visible_message("<span class='notice'>\The [seed.display_name] grows an empty gland.</span>")
 					else
 						var/check_success = FALSE
-						if(prob(50) && seed.chems.len > 0)
+						if(prob(50) && seed.chems.len > 1)
 							check_success = seed.remove_random_chemical()
 							if(check_success)
 								visible_message("<span class='notice'>\A gland on the [seed.display_name] withers and dies.</span>")


### PR DESCRIPTION
## What this does
Fixes off by one oversight.
Closes #38091
:cl:
 * bugfix: Untable mutagen should no longer remove the last chemical in a plant.