### PR TITLE
Fixes Sleeper Plugin Bugs

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -457,7 +457,7 @@
 	return ..()
 
 //Handles installing a plugin for the specific machine, checking compatibility and other such functions.
-/obj/machinery/sleeper/install_plugin(obj/item/weapon/obj_used, mob/user)
+/obj/machinery/sleeper/proc/install_plugin(obj/item/weapon/obj_used, mob/user)
 	if(istype(obj_used, /obj/item/device/plugin))
 		if(!panel_open)
 			to_chat(user, "<span class='warning'>You need to open the maintenance panel to install this device.</span>")
@@ -769,6 +769,7 @@
 	var/mob/living/simple_animal/rampagingspacehog/sleeperclown/curse = new(loc)
 	occupant.nobreath = 15
 	occupant.forceMove(curse)
+	icon = null
 	qdel(src)
 
 /obj/machinery/sleeper/upgraded
@@ -780,6 +781,12 @@
 		/obj/item/weapon/stock_parts/manipulator/nano/pico
 	)
 
+/obj/machinery/sleeper/clown
+	name = "clown sleeper"
+
+/obj/machinery/sleeper/clown/New()
+	plugins += new /obj/item/device/plugin/sleeper/clown()
+	..()
 
 /////////////////////////////////////////
 // MANCROWAVE

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -456,7 +456,8 @@
 		return 0
 	return ..()
 
-/obj/machinery/sleeper/attackby(obj/item/weapon/obj_used, mob/user)
+//Handles installing a plugin for the specific machine, checking compatibility and other such functions.
+/obj/machinery/sleeper/install_plugin(obj/item/weapon/obj_used, mob/user)
 	if(istype(obj_used, /obj/item/device/plugin))
 		if(!panel_open)
 			to_chat(user, "<span class='warning'>You need to open the maintenance panel to install this device.</span>")
@@ -501,6 +502,10 @@
 			plugins += obj_used
 			RefreshParts()
 
+/obj/machinery/sleeper/attackby(obj/item/weapon/obj_used, mob/user)
+	if(istype(obj_used, /obj/item/device/plugin))
+		install_plugin(obj_used, user)
+		return
 	if(!istype(obj_used, /obj/item/weapon/grab))
 		return ..()
 	else
@@ -960,6 +965,10 @@
 					H.GALize()
 			go_out()
 		update_icon()
+
+/obj/machinery/sleeper/mancrowave/install_plugin(obj/item/weapon/obj_used, mob/user)
+	//does not accept plugins
+	return
 
 /obj/machinery/sleeper/mancrowave/galo
 	name = "tanning bed"

--- a/code/modules/mob/living/simple_animal/hostile/hog.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hog.dm
@@ -480,6 +480,7 @@ if ungreased adult: l containers
 	hurt_sound = 'sound/items/bikehorn_curaracha.ogg'
 	snort_sound = 'sound/items/bikehorn.ogg'
 	squeal_delay = 4 SECONDS
+	pixel_x = -6
 
 /mob/living/simple_animal/rampagingspacehog/Life()
 	..()
@@ -497,7 +498,7 @@ if ungreased adult: l containers
 			person.heal_organ_damage(0, 2)
 		if(person.getToxLoss())
 			person.adjustToxLoss(-2)
-	if(prob(3)) //life proc 2 seconds, this will give approximately one spiderling a minute
+	if(stat != DEAD && prob(3)) //life proc 2 seconds, this will give approximately one spiderling a minute
 		new /mob/living/simple_animal/hostile/giant_spider/spiderling/clownling(loc)
 
 /mob/living/simple_animal/rampagingspacehog/sleeperclown/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
@@ -518,7 +519,7 @@ if ungreased adult: l containers
 	playsound(src, 'sound/machines/pressurehiss.ogg', 70, 1)
 	for(var/mob/person in contents)
 		person.forceMove(get_turf(src))
-		visible_message("\The [name] releases \the [person] as they die!")
+		visible_message("\The [name] releases \the [person] as it dies!")
 	playsound(src, 'sound/misc/sadtrombone.ogg', 70, 1)
 	..()
 

--- a/code/modules/mob/living/simple_animal/hostile/hog.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hog.dm
@@ -459,6 +459,7 @@ if ungreased adult: l containers
 //This is a new forme of your living nightmares
 /mob/living/simple_animal/rampagingspacehog/sleeperclown
 	name = "overly protective sleeper clownspider"
+	desc = "There are too many legs to count. You can vaguely make out a sleeper inside of the twisted horror."
 	icon = 'icons/mob/clown_mobs.dmi'
 	icon_state = "sleeperclown"
 	icon_living = "sleeperclown"


### PR DESCRIPTION
## What this does
This PR fixes bugs with the new sleeper plugin system, such as being able to install them in a mancrowave.

## Why it's good
No clown galo sengen.

## How it was tested
Spawned some clown sleepers, jumped in to sleep forever.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Can no longer install sleeper plugins in mancrowaves.
