### PR TITLE
Gun Ammo Casings Fly Out

### DIFF
--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -171,8 +171,15 @@
 			refuse += AC
 		else
 			var/mob/M = get_holder_of_type(src, /mob/)
-			AC.forceMove(ismob(M) ? M.loc : get_turf(src.loc)) //special forceMove because this proc hate user so much it breaks if you try to use mob/user in arg
+			if(ismob(M))
+				AC.forceMove(M.loc)
+				var/target = get_ranged_target_turf(AC, turn(M.dir,pick(-45,-90,-90,-135,-135)), 5)
+				spawn(1)
+					AC.throw_at(target,rand(1,2),2)
+			else
+				AC.forceMove(get_turf(src.loc)) //special forceMove because this proc hate user so much it breaks if you try to use mob/user in arg
 			playsound(AC, casingsound, 25, 1)
+
 	if(AC.BB)
 		in_chamber = AC.BB //Load projectile into chamber.
 		AC.BB.forceMove(src) //Set projectile loc to gun.

--- a/code/modules/projectiles/guns/projectile/minigun.dm
+++ b/code/modules/projectiles/guns/projectile/minigun.dm
@@ -66,7 +66,12 @@
 		update_icon()
 		in_chamber = new gatlingbullet()//We create bullets as we are about to fire them. No other way to remove them.
 		if (casing_type)
-			new casing_type(get_turf(src))
+			var/atom/movable/AC = new casing_type(get_turf(src))
+			var/mob/M = get_holder_of_type(src, /mob/)
+			if(ismob(M))
+				var/target = get_ranged_target_turf(AC, turn(M.dir,pick(-45,-90,-90,-135,-135)), 5)
+				spawn(1)
+					AC.throw_at(target,rand(1,2),2)
 		return 1
 	return 0
 
@@ -126,13 +131,13 @@
 	icon_state = "hornetgun"
 	item_state = "hornetgun0"
 	gatlingbullet = /obj/item/projectile/bullet/beegun/hornet
-	
-	
+
+
 /obj/item/weapon/gun/gatling/beegun/ss_visceratorgun
 	name = "viscerator gun"
 	desc = "THE HAAAAAAACKS!"
 	icon_state = "ss_visceratorgun"
-	item_state = "ss_visceratorgun0"	
+	item_state = "ss_visceratorgun0"
 	gatlingbullet = /obj/item/projectile/bullet/beegun/ss_viscerator
 
 /obj/item/weapon/gun/gatling/batling

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -57,8 +57,13 @@
 		playsound(M, 'sound/weapons/shotgunpump.ogg', 60, 1)
 	pumped = 0
 	if(current_shell)//We have a shell in the chamber
-		current_shell.forceMove(get_turf(src))//Eject casing
-		playsound(current_shell, casingsound, 25, 0.2, 1)
+		var/obj/item/ammo_casing/old_shell = current_shell
+		old_shell.forceMove(get_turf(src))//Eject casing
+		if(ismob(M))
+			var/target = get_ranged_target_turf(old_shell, turn(M.dir,pick(-45,-90,-90,-135,-135)), 5)
+			spawn(1)
+				old_shell.throw_at(target,rand(1,2),2)
+		playsound(old_shell, casingsound, 25, 0.2, 1)
 		current_shell = null
 		if(in_chamber)
 			in_chamber = null
@@ -80,7 +85,7 @@
 	origin_tech = Tc_COMBAT + "=5;" + Tc_MATERIALS + "=2"
 	ammo_type = "/obj/item/ammo_casing/shotgun"
 	silencer_offset = list(28,5)
-	
+
 /obj/item/weapon/gun/projectile/shotgun/pump/combat/empty
 	ammo_type = null
 


### PR DESCRIPTION

## What this does
After seeing a space gunfight, I wondered why the casings weren't flying off into space. This PR fixes this by having casings be tossed out of the gun after being fired.

## Why it's good
Cool space fights

## How it was tested
https://github.com/user-attachments/assets/e14789ed-0e5f-4742-9c82-8cea8bfcc677

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Bullet casings now get tossed out of bullet-using guns that have casings.
