### PR TITLE
Juke Update 1: Eclipse: Hit West With Hammers Edition

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult.dm
@@ -91,6 +91,7 @@
 			eclipse_trigger_cult()
 			for(var/obj/structure/cult/spire/S in cult_spires)
 				S.upgrade(3)
+			ticker.StartThematic("eclipse")
 		if (BLOODCULT_STAGE_MISSED)
 			for (var/datum/role/cultist in members)
 				var/mob/M = cultist.antag.current
@@ -98,6 +99,7 @@
 					to_chat(M, "<span class='sinister'>The Eclipse has passed. You won't be able to tear reality aboard this station anymore. Escape the station alive with your fellow cultists so you may try again another day.</span>")
 			for(var/obj/structure/cult/spire/S in cult_spires)
 				S.upgrade(1)
+			ticker.StopThematic()
 		if (BLOODCULT_STAGE_ECLIPSE)
 			update_all_parallax()
 			var/datum/zLevel/ZL = map.zLevels[map.zMainStation]

--- a/code/modules/media/jukebox.dm
+++ b/code/modules/media/jukebox.dm
@@ -9,7 +9,7 @@ var/global/global_playlists = list()
 	set waitfor = 0//tentative fix so the proc stops hanging if it takes too long
 	if(!config.media_base_url)
 		return
-	for(var/playlist_id in list("lilslugger", "bar", "jazzswing", "bomberman", "depresso", "echoes", "electronica", "emagged", "endgame", "filk", "funk", "folk", "IDM", "malfdelta", "medbay", "metal", "muzakjazz", "nukesquad", "rap", "rock", "shoegaze", "security", "shuttle", "thunderdome", "upbeathypedancejam", "vidya", "SCOTLANDFOREVER", "halloween", "christmas"))
+	for(var/playlist_id in list("bar", "jazzswing", "bomberman", "depresso", "eclipse", "electronica", "emagged", "endgame", "filk", "funk", "folk", "malfdelta", "medbay", "metal", "muzakjazz", "nukesquad", "rap", "rock", "shoegaze", "security", "shuttle", "thunderdome", "upbeathypedancejam", "vidya", "SCOTLANDFOREVER", "halloween", "christmas"))
 		var/url="[config.media_base_url]/index.php?playlist=[playlist_id]"
 		log_debug("Begin updating playlist: [playlist_id]...")
 
@@ -878,7 +878,6 @@ var/global/list/loopModeNames=list(
 	playlist_id="bar"
 	// Must be defined on your server.
 	playlists=list(
-		"lilslugger" = "Battle of Lil Slugger",
 		"bar"  = "Bar Mix",
 		"jazzswing" = "Jazz & Swing",
 		"depresso" ="Depresso",
@@ -914,7 +913,6 @@ var/global/list/loopModeNames=list(
 		"filk" = "Filk",
 		"funk" = "Funk",
 		"folk" = "Folk",
-		"IDM" = "90's IDM",
 		"medbay" = "Medbay",
 		"metal" = "Heavy Metal",
 		"muzakjazz" = "Muzak",
@@ -944,7 +942,6 @@ var/global/list/loopModeNames=list(
 	playlist_id="bar"
 	// Must be defined on your server.
 	playlists=list(
-		"lilslugger" = "Battle of Lil' Slugger",
 		"bar"  = "Bar Mix",
 		"jazzswing" = "Jazz & Swing",
 		"depresso" ="Depresso",
@@ -952,7 +949,6 @@ var/global/list/loopModeNames=list(
 		"filk" = "Filk",
 		"funk" = "Funk",
 		"folk" = "Folk",
-		"IDM" = "90's IDM",
 		"medbay" = "Medbay",
 		"metal" = "Heavy Metal",
 		"muzakjazz" = "Muzak",
@@ -973,7 +969,7 @@ var/global/list/loopModeNames=list(
 		"malfdelta"= "Silicon Assault",
 		"bomberman" = "Bomberman",
 		"SCOTLANDFOREVER"= "Highlander",
-		"echoes" = "Echoes"
+		"eclipse" = "Eclipse"
 	)
 
 /obj/machinery/media/jukebox/superjuke/New()
@@ -1170,10 +1166,11 @@ var/global/list/loopModeNames=list(
 	unformatted = "depresso"
 	formatted = "Depresso"
 	mask = "#000000"//black
-/obj/item/weapon/vinyl/echoes
-	name = "nanovinyl - echoes"
-	unformatted = "echoes"
-	formatted = "Echoes"
+/obj/item/weapon/vinyl/eclipse
+	name = "nanovinyl - Vague Threat"
+	unformatted = "eclipse"
+	formatted = "Eclipse"
+	desc = "For when a vague threat plagues the station."
 /obj/item/weapon/vinyl/electronica
 	name = "nanovinyl - electronic"
 	unformatted = "electronica"
@@ -1199,10 +1196,6 @@ var/global/list/loopModeNames=list(
 	name = "nanovinyl - folk"
 	unformatted = "folk"
 	formatted = "Folk"
-/obj/item/weapon/vinyl/idm
-	name = "nanovinyl - 90's IDM"
-	unformatted = "IDM"
-	formatted = "90's IDM"
 /obj/item/weapon/vinyl/jazz
 	name = "nanovinyl - jazz & swing"
 	unformatted = "jazzswing"
@@ -1273,11 +1266,6 @@ var/global/list/loopModeNames=list(
 	name = "nanovinyl - halloween"
 	unformatted = "halloween"
 	formatted = "Halloween"
-/obj/item/weapon/vinyl/slugger
-	name = "nanovynil - slugger"
-	desc = "A go-to for bars all over the sector. Every time you walk in one, you can almost bet it's playing."
-	unformatted = "lilslugger"
-	formatted = "Battle of Lil Slugger"
 /obj/item/weapon/vinyl/christmas
 	name = "nanovynil - christmas"
 	unformatted = "christmas"

--- a/code/modules/trader/crates/shoaljunk.dm
+++ b/code/modules/trader/crates/shoaljunk.dm
@@ -9,7 +9,6 @@ var/global/list/shoal_stuff = list(
 	/obj/item/clothing/accessory/wristwatch/black,/obj/item/clothing/accessory/wristwatch/black,/obj/item/clothing/accessory/wristwatch/black,
 	//1 of a kind
 	/obj/item/weapon/reagent_containers/food/snacks/borer_egg,
-	/obj/item/weapon/vinyl/echoes,
 	/obj/item/fish_eggs/seadevil,
 	/obj/structure/bed/therapy,
 	/obj/item/weapon/grenade/station/discount,

--- a/code/modules/trader/crates/zincsaucier.dm
+++ b/code/modules/trader/crates/zincsaucier.dm
@@ -7,7 +7,6 @@ var/global/list/chef_stuff = list(
 	/obj/item/fish_eggs/seadevil,/obj/item/fish_eggs/seadevil, //fish_items.dm
 	/obj/item/apiary/langstroth,/obj/item/apiary/langstroth,
 	//one of a kind
-	/obj/item/weapon/vinyl/echoes, //media/jukebox.dm
 	/obj/item/sushimat,
 	/obj/structure/dishwasher,
 	/obj/item/cricketfarm,


### PR DESCRIPTION
#38025 followup, adds an eclipse playlist and tweaks medical primarily. This one will surely not be merged early while I commune with the great pomf.
Overall aim is to add a tension playlist in eclipse, and move some of the rock pieces to other playlists from medbay and solidify it as a lobby/elevator music esque playlist.

Changelog WIP:
move Phazon Mines, hitchcocks-music-psycho, Turanic_battle, & Prelude_(Vertigo) from endgame to eclipse
move Lil Slugger from Lil Slugger to Bar, delete Lil Slugger folder
Delete Echoes (I still have never seen it fully play and I never will.
Delete IDM (buggy piece of shit FUCK YOU)
delete metropolis zone from rock
move scary monsters from rock to halloween
Move west end girls from electronica to bar

Medbay:
Move (Green & Purple) and (Help me Dr. Dick) to emagged
Move Bad Medicine, Hot Blooded, Kickstart my Heart, bad case of loving you to rock
Move Move your Dead Bones to Halloween
move baroque_virus from endgame to malfdelta (on the fence about it)

Adds:
Medbay: Elevatorstuck, Gentle_breeze, Hospital(earthbound), pokemon_center_night, Main theme another mix (trauma team), welcome to the green room
emagged: invisible, pickle rock anthem
eclipse: wip :)
Apocalypse: Tenbre Rosso Sangue, deoxyribose
Bar: Whirling-in-Rags 8pm

Dupes:
Rock: Lil Slugger, Tame Impala - Elephant
Endgame: bernard-herrmann-vertigo-theme

Stuff to look at if we're tight on space:
Comfortably Numb, Cozy in the Rocket, I wanna be Sedated, How to Save A Life, superman, witch doctor in medbay, otherwise move elsewhere (talk to pomf, go through later)
[dnm][sound]

 * rscadd: Added Eclipse playlist to cult eclipse, and rearranged some jukebox songs.
