### PR TITLE
Fixes Ethereal Jaunt a bit

### DIFF
--- a/code/datums/hud/hud.dm
+++ b/code/datums/hud/hud.dm
@@ -170,3 +170,18 @@ Helper procs and procs used in mobs
 			if(C.body_alphas[i] <= 1)
 				return FALSE
 	return TRUE
+
+//Since HUD images are on the viewer's side it's a little bit tricky to force the HUDs to be updated immediately
+//So instead we go through HUD user lists, get their distances from the target and if they're in range we update their HUDs
+//This is useful such as for instant invisibility effects like Ethereal Jaunt
+//Since this is a heavier proc (going through all users in range to update their clientside images) it should not be attached to something spammable
+/proc/update_HUD_in_range(var/target)
+	var/list/hud_users = list()
+	hud_users |= (med_hud_users + sec_hud_users + diagnostic_hud_users + wage_hud_users)
+	for(var/mob/M in hud_users)
+		if(!M.client)
+			continue
+		var/client/C = M.client
+		if(get_dist(get_turf(M), get_turf(target)) <= (C.view + DATAHUD_RANGE_OVERHEAD))
+			M.clean_up_hud()
+			M.handle_hud_vision_updates()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -2135,7 +2135,6 @@ Use this proc preferably at the end of an equipment loadout
 	alphas[source_define] = alpha_value
 	handle_alpha()
 	regenerate_icons()
-	handle_regular_hud_updates()
 	if(time > 0)
 		spawn(time)
 			make_visible(source_define)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -2135,6 +2135,7 @@ Use this proc preferably at the end of an equipment loadout
 	alphas[source_define] = alpha_value
 	handle_alpha()
 	regenerate_icons()
+	handle_regular_hud_updates()
 	if(time > 0)
 		spawn(time)
 			make_visible(source_define)

--- a/code/modules/spells/targeted/ethereal_jaunt.dm
+++ b/code/modules/spells/targeted/ethereal_jaunt.dm
@@ -12,7 +12,7 @@
 	range = SELFCAST
 	max_targets = 1
 	cooldown_min = 10 SECONDS //5 SECONDS reduction per rank
-	duration = 5 SECONDS 
+	duration = 5 SECONDS
 	level_max = list(SP_TOTAL = 5, SP_SPEED = 4, SP_POWER = 1)
 
 	hud_state = "wiz_jaunt"
@@ -50,6 +50,9 @@
 	if(target.incorporeal_move) //they're already jaunting, we have another fix for this but this is sane
 		return
 	target.unlock_from()
+	target.flags |= INVULNERABLE //Moved these up here to hopefully reduce incidents where someone can be attacked while jaunting.
+	var/old_density = target.density
+	target.setDensity(FALSE)
 	//Begin jaunting with an animation
 	anim(location = mobloc, a_icon = 'icons/mob/mob.dmi', flick_anim = enteranim, direction = target.dir, name = target.name,lay = target.layer+1,plane = target.plane)
 	if(mist)
@@ -57,16 +60,13 @@
 		var/datum/effect/system/steam_spread/steam = new /datum/effect/system/steam_spread()
 		steam.set_up(10, 0, mobloc)
 		steam.start()
-
 	//Turn on jaunt incorporeal movement, make him invincible and invisible
 	if(empowered)
 		target.incorporeal_move = INCORPOREAL_ETHEREAL_IMPROVED
 	else
 		target.incorporeal_move = INCORPOREAL_ETHEREAL
 	target.make_invisible(ETHEREAL, 0, TRUE, 125, INVISIBILITY_LEVEL_TWO)
-	target.flags |= INVULNERABLE
-	var/old_density = target.density
-	target.setDensity(FALSE)
+	update_HUD_in_range(target) //This will do a lot of redundant calculations with mass jaunting, could probably be optimized.
 	target.candrop = 0
 	for(var/obj/abstract/screen/movable/spell_master/SM in target.spell_masters)
 		SM.silence_spells(duration+25)


### PR DESCRIPTION
- Will now properly delete the HUD elements of the Ethereal Jaunt user when activated instead of allowing the user's HUD elements to be tracked for a brief period when wearing glasses such as the SecHUD or the MedHUD
- Moved some invincibility-related code a bit up in hopes of preventing a supposed bug where someone could be shot while jaunted.

Added a new HUD proc for forcibly updating every HUD user's HUD in range. It is, however, not well-optimized in its current application, which may make group jaunting pretty heavy, but not as heavy as a single Life() tick.

:cl:
 * bugfix: Fixed a bug where HUDs could track ethereal jaunting wizards for a brief period of time.