### PR TITLE
Minor Robust Tournament Changes

### DIFF
--- a/code/datums/outfit/special_outfits/special.dm
+++ b/code/datums/outfit/special_outfits/special.dm
@@ -994,3 +994,36 @@
 
 /datum/outfit/special/tribalfemale/equip_backbag(var/mob/living/carbon/human/H)
 	return FALSE
+
+
+/datum/outfit/special/robust_tournament_red
+	outfit_name = "Robust Tournament Team Red"
+	items_to_spawn = list(
+		"Default" = list(
+			slot_w_uniform_str = /obj/item/clothing/under/color/red,
+			slot_shoes_str = /obj/item/clothing/shoes/jackboots,
+			slot_ears_str = /obj/item/device/radio/headset,
+		),
+		/datum/species/vox = list(
+			slot_w_uniform_str = /obj/item/clothing/under/color/red,
+			slot_shoes_str = /obj/item/clothing/shoes/jackboots,
+			slot_ears_str = /obj/item/device/radio/headset,
+			slot_wear_mask_str =  /obj/item/clothing/mask/breath/vox,
+		),
+	)
+
+/datum/outfit/special/robust_tournament_green
+	outfit_name = "Robust Tournament Team Green"
+	items_to_spawn = list(
+		"Default" = list(
+			slot_w_uniform_str = /obj/item/clothing/under/color/green,
+			slot_shoes_str = /obj/item/clothing/shoes/jackboots,
+			slot_ears_str = /obj/item/device/radio/headset,
+		),
+		/datum/species/vox = list(
+			slot_w_uniform_str = /obj/item/clothing/under/color/green,
+			slot_shoes_str = /obj/item/clothing/shoes/jackboots,
+			slot_ears_str = /obj/item/device/radio/headset,
+			slot_wear_mask_str =  /obj/item/clothing/mask/breath/vox,
+		),
+	)

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -91,12 +91,13 @@
 	var/recharge_rate = 0
 
 	var/nticks=0
+	var/disable_config_sync = FALSE
 
 /obj/item/weapon/card/emag/New(var/loc, var/disable_tuning=0)
 	..(loc)
 
 	// For standardized subtypes, once they're established.
-	if(disable_tuning)
+	if(disable_tuning || disable_config_sync)
 		return
 
 	if(ticker)


### PR DESCRIPTION
Allows for mappers to rig emags to start with alternative charge/recharge values and adds two robust tournament outfits. 