### PR TITLE
Pompadour Rat & ROID RAT chance tweak

### DIFF
--- a/code/modules/reagents/reagents/reagents_drug.dm
+++ b/code/modules/reagents/reagents/reagents_drug.dm
@@ -75,11 +75,11 @@
 						dehulk(H)
 					else if(prob(1))
 						H.say(pick("YOU TRYIN' BUILD SUM MUSSLE?", "TOO SWOLE TO CONTROL", "HEY MANG", "HEY MAAAANG"))
-			if(ismouse(M)) //If mouse, become a gym rat. With a 1 in 20 chance of becoming a roid rat
+			if(ismouse(M)) //If mouse, become a gym rat. With a 1 in 10 chance of becoming a roid rat
 				if(has_mouse_bulked == 0)
-					if(prob(95))
+					if(prob(90))
 						has_mouse_bulked = 1
-						if(prob(95))
+						if(prob(90))
 							M.visible_message("<span class='warning'>[M] suddenly grows significantly in size, the color draining from its fur as its muscles expand!</span>")
 							M.transmogrify(/mob/living/simple_animal/hostile/retaliate/gym_rat)
 						else


### PR DESCRIPTION
## What this does
Raises the chances of becoming a pompadour rat or a ROID RAT from 1 in 20 to 1 in 10.
## Why it's good
The Pompadour and ROID rats are very fun to see, but the odds are so low you RARELY get to see them. This helps by making them slightly more available.
:cl:
 * tweak: Dosing a rat with creatine now has DOUBLE the chance of creating a ROID RAT (1 in 10). If they DON'T become a roid rat, they have DOUBLE the chance of becoming a Pompadour Rat instead (1 in 10 as well).