### PR TITLE
Fixes HOGs Spawning Clownlings

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hog.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hog.dm
@@ -482,7 +482,7 @@ if ungreased adult: l containers
 	squeal_delay = 4 SECONDS
 	pixel_x = -6
 
-/mob/living/simple_animal/rampagingspacehog/Life()
+/mob/living/simple_animal/rampagingspacehog/sleeperclown/Life()
 	..()
 	for(var/mob/living/person in contents)
 		//weird nullspace can't breet problem, this fixes it


### PR DESCRIPTION
## What this does
Stops regular Rampaging Space HOGs from spawning clownlings by adding a few characters to a single line.

## Why it's good
No more clownlings from your regular feral space HOGs.

## How it was tested
Like how I forgot to test the original HOGs when making the cursed thing that is based off of them, it wasn't.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: HOGs no longer birth clownlings.
