### PR TITLE
Ups the base engineering hardsuit radiation resistance to 80%

### DIFF
--- a/code/modules/clothing/spacesuits/rig_subtypes/rig_subtypes.dm
+++ b/code/modules/clothing/spacesuits/rig_subtypes/rig_subtypes.dm
@@ -4,7 +4,7 @@
 	desc = "A special helmet designed for work in a hazardous, low-pressure environment. Has radiation shielding."
 	icon_state = "rig0-engineering"
 	item_state = "eng_helm"
-	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 50)
+	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 80)
 	_color = "engineering"
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	pressure_resistance = 200 * ONE_ATMOSPHERE
@@ -17,7 +17,7 @@
 	desc = "A special suit that protects against hazardous, low pressure environments. Has radiation shielding."
 	icon_state = "rig-engineering"
 	item_state = "eng_hardsuit"
-	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 50)
+	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 80)
 	allowed = list(/obj/item/device/flashlight, /obj/item/weapon/tank, /obj/item/weapon/storage/bag/ore, /obj/item/device/t_scanner, /obj/item/weapon/pickaxe, /obj/item/device/rcd, /obj/item/tool/wrench/socket)
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	pressure_resistance = 200 * ONE_ATMOSPHERE


### PR DESCRIPTION
Because they still get hit pretty hard by radiation poisoning in most cases even with half the radiation reduced. This should protect engineers a lot better against radiation sources, and it makes it look more like the radiation absorption device causes "radiation leaks" into the suit.
This also brings the hardsuit back to its old 80% radiation resistance value, which it used to have before it gained the radiation absorption patch.

:cl:
 * tweak: Engineering hardsuits (and the advanced hardsuit) now reduce radiation damage taken by 80% instead of 50%.