### PR TITLE
Fixes Upgraded Welders

### DIFF
--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -346,14 +346,10 @@
 	switch(welding)
 		//If off
 		if(0)
-			if(icon_state != "welder") //Check that the sprite is correct, if it isnt, it means toggle() was not called
-				setWelding(FALSE)
 			processing_objects.Remove(src)
 			return
 		//Welders left on now use up fuel, but lets not have them run out quite that fast
 		if(1)
-			if(icon_state != "welder1") //Check that the sprite is correct, if it isnt, it means toggle() was not called
-				setWelding(TRUE)
 			if(prob(5))
 				remove_fuel(1)
 


### PR DESCRIPTION

## What this does
This PR fixes upgraded, gatling, etc welding tools from exponentially using up all their fuel when turned on. This is caused by a bugfix that allowed an old failsafe to start working again, except it was made for just the original welder and not the cool new ones we have.

Fixes #38145 

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Working better welding tools!

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Because my PC fried, it wasn't. But this seems like a serious enough issue to make a web edit PR for!

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Advanced welders no longer go though their fuel super quickly.
