### PR TITLE
The space ninja mask now has eye protection

### DIFF
--- a/code/datums/gamemode/role/ninja.dm
+++ b/code/datums/gamemode/role/ninja.dm
@@ -800,7 +800,7 @@ Suit and assorted
 
 /obj/item/clothing/mask/gas/voice/ninja
 	name = "ninja mask"
-	desc = "A close-fitting mask that acts both as an air filter and a post-modern fashion statement."
+	desc = "A close-fitting mask that acts both as an air filter and a post-modern fashion statement. The adaptive lenses protect against bright lights."
 	icon_state = "s-ninja"
 	mode = 2 //Does this even do anything?
 	canstage = 0
@@ -808,6 +808,7 @@ Suit and assorted
 	species_fit = list("Human")
 	species_restricted = list("Human")
 	body_parts_covered = FACE
+	eyeprot = 2
 
 /*******************************************
 ****          WEEABOO VARIANTS          ****

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -697,6 +697,7 @@
 	. = 0
 	var/obj/item/clothing/head/headwear = src.head
 	var/obj/item/clothing/glasses/eyewear = src.glasses
+	var/obj/item/clothing/mask/mask = wear_mask
 	var/datum/organ/internal/eyes/E = src.internal_organs_by_name["eyes"]
 
 	if (istype(headwear))
@@ -704,6 +705,9 @@
 
 	if (istype(eyewear))
 		. += eyewear.eyeprot
+
+	if(istype(mask))
+		. += mask.eyeprot
 
 	for(var/datum/visioneffect/V in huds)
 		. += V.eyeprot


### PR DESCRIPTION
All that high tech and their masks can't even protect against bright lights?

This should also make the ninjas less hard-countered by flashes (which bypass their hologram) and flashbangs (which would stun them for a critical amount of time, but they can still be stunned if they're close enough to the flashbang), and savvy ninjas shouldn't be forced into a mad scramble for sunglasses the moment they get on the station.

Also modified the description of the mask to reflect its new property.
Added support for masks to count for eye protection.

:cl:
 * tweak: The ninja's mask now protects their eyes from bright lights.