### PR TITLE
AI can now be a traitor

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -200,8 +200,8 @@
 	name = "Syndicate Sleeper Agent"
 	role_category = /datum/role/traitor
 	protected_from_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain","Head of Personnel",
-							"Cyborg", "Merchant", "Chief Engineer", "Chief Medical Officer", "Research Director", "Brig Medic")
-	restricted_from_jobs = list("AI","Mobile MMI")
+							"AI", "Cyborg", "Merchant", "Chief Engineer", "Chief Medical Officer", "Research Director", "Brig Medic")
+	restricted_from_jobs = list("Mobile MMI")
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
 	weight_category = "Traitor"

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -29,7 +29,7 @@
 	role_category = /datum/role/traitor
 	protected_from_jobs = list("Security Officer", "Merchant", "Warden", "Head of Personnel", "Cyborg", "Detective",
 							"Head of Security", "Captain", "Chief Engineer", "Chief Medical Officer", "Research Director", "Brig Medic")
-	restricted_from_jobs = list("AI","Mobile MMI")
+	restricted_from_jobs = list("Mobile MMI")
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
 	weight_category = "Traitor"

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -27,7 +27,7 @@
 /datum/dynamic_ruleset/roundstart/traitor
 	name = "Syndicate Traitors"
 	role_category = /datum/role/traitor
-	protected_from_jobs = list("Security Officer", "Merchant", "Warden", "Head of Personnel", "Cyborg", "Detective",
+	protected_from_jobs = list("Security Officer", "Merchant", "Warden", "Head of Personnel", "AI", "Cyborg", "Detective",
 							"Head of Security", "Captain", "Chief Engineer", "Chief Medical Officer", "Research Director", "Brig Medic")
 	restricted_from_jobs = list("Mobile MMI")
 	required_candidates = 1


### PR DESCRIPTION
Moved the AI from the "restricted" list to the "protected" list for both the roundstart version and the midround version, which means they will have a chance (although a smaller chance) to become Syndicate-aligned.

:cl:
 * tweak: AIs now have a lower-than-average chance to be traitors instead of zero chance.