### PR TITLE
Ninja can now block flashes with the hologram

### DIFF
--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -15,6 +15,7 @@
 	origin_tech = Tc_MAGNETS + "=2;" + Tc_COMBAT + "=1"
 	min_harm_label = 15 //Multiple layers?
 	harm_label_examine = list("<span class='info'>A label is on the bulb, but doesn't cover it.</span>", "<span class='warning'>A label covers the bulb!</span>")
+	ignore_blocking = IGNORE_SOME_SHIELDS
 
 	var/times_used = 0 //Number of times it's been used.
 	var/broken = 0     //Is the flash burnt out?
@@ -92,6 +93,8 @@
 
 	if(iscarbon(M))
 		var/mob/living/carbon/Subject = M
+		if(Subject.check_shields(0, src)) //Will trigger a ninja's hologram protection
+			flashfail = TRUE
 
 		if(Subject.eyecheck() > 0 || flashfail)
 			user.visible_message("<span class='notice'>[user] fails to blind [M] with the flash!</span>")


### PR DESCRIPTION
I have been made aware that at least a few more people would be receptive to this approach instead. As an alternative to #38150 this merely makes the flash trigger the ninja's hologram. This means that
A) The ninja is no longer helpless against flashes (but they are still affected by the AoE flash effect and flashbangs)
B) The flashes are still useful by forcing the ninja to teleport away when used on them.

![smokebomb](https://github.com/user-attachments/assets/9c4676c4-d8d1-4165-b74d-e08d69a58b3a)


:cl:
 * tweak: The ninja's holograms now block flashes.