### PR TITLE
Vampire Nerf: Disables Diseased Touch from the vampire's list of powers

### DIFF
--- a/code/datums/gamemode/powers/vampire.dm
+++ b/code/datums/gamemode/powers/vampire.dm
@@ -33,10 +33,10 @@
 	granttext = "Your vampiric vision has improved."
 	store_in_memory = TRUE
 
-/datum/power/vampire/disease
-	cost = 150
-	spellpath = /spell/targeted/disease
-	granttext = "You have gained the Diseased Touch ability which causes those you touch to die shortly after unless treated medically."
+// /datum/power/vampire/disease
+// 	cost = 150
+// 	spellpath = /spell/targeted/disease
+// 	granttext = "You have gained the Diseased Touch ability which causes those you touch to die shortly after unless treated medically."
 
 /datum/power/vampire/cloak
 	cost = 150


### PR DESCRIPTION
This is the first PR in a longer string of PRs that will attempt to tone down the vampire's power, as they have been dominating as antagonists for quite a while.
Diseased Touch is one of the more unfun aspects of vampires, as the vampire secretly prepares someone to be stuck in Medbay's wild ride for the next 15 or 20 minutes minimum and there is an out-of-way method or two to force others to be infected with the same disease despite it being meant to be against one target only. Anecdotally (I have not tested this yet) the limbs that get paralyzed by the disease do not get healed when the disease is cured, which requires even more time spent replacing limbs.

:cl:
 * rscdel: Vampires no longer have Diseased Touch.