### PR TITLE
Vampire Nerf: Tweaked vampire screech effects

### DIFF
--- a/code/modules/spells/aoe_turf/screech.dm
+++ b/code/modules/spells/aoe_turf/screech.dm
@@ -49,11 +49,13 @@
 			C.vampire_affected(user.mind)
 			continue
 		to_chat(C, "<span class='danger'><font size='3'>You hear an ear piercing shriek and your senses dull!</font></span>")
-		C.Knockdown(8)
+		var/obj/item/I = C.get_active_hand()
+		if(I)
+			C.drop_item(I)
 		C.ear_deaf = 20
 		C.stuttering = 20
-		C.Stun(8)
 		C.Jitter(20)
+		C.confused += 5
 	for(var/obj/structure/window/W in view(4))
 		W.shatter()
 	for(var/obj/machinery/light/L in view(7))

--- a/code/modules/spells/aoe_turf/screech.dm
+++ b/code/modules/spells/aoe_turf/screech.dm
@@ -52,10 +52,10 @@
 		var/obj/item/I = C.get_active_hand()
 		if(I)
 			C.drop_item(I)
-		C.ear_deaf = 20
+		C.ear_deaf = 30
 		C.stuttering = 20
 		C.Jitter(20)
-		C.confused += 5
+		C.confused += 10
 	for(var/obj/structure/window/W in view(4))
 		W.shatter()
 	for(var/obj/machinery/light/L in view(7))


### PR DESCRIPTION
This is the second PR in a longer string of PRs that will attempt to tone down the vampire's power, as they have been dominating as antagonists for quite a while.

- No longer stuns, instead forces the victims to drop what's in their hands.
- Upped the deafness duration from 40 seconds to 60 seconds.
- Now causes confused movement for 20 seconds.

It's one of the many "get out of a sticky situation" spells that the vampire has (alongside vampire flash, vampire jaunt, vampire blink, summon bats etc), acting as a stun that requires special equipment (muffled headsets or a null rod) to protect against, which is somewhat unsatisfying. This version should allow the vampire to only gain an upper hand in combat by disorienting and impeding opponents by forcing them to drop their active weapons and to end up with barely-controlled movement, which is still good if they want to soften up their targets before running into them or if they want to run away.

:cl:
 * tweak: The vampire's Screech ability no longer stuns. However, it will now cause their targets to drop whatever item is in their active hand and to not be able to control their movement effectively for 20 seconds. The deafness duration has also been increased from 40 seconds to 60 seconds. Remember to wear earmuffs!