### PR TITLE
Vampire Nerf: Somewhat increased burn damage from sun exposure and being smitten.

### DIFF
--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -406,6 +406,7 @@
 				to_chat(H, "<span class='danger'>Your skin catches fire!</span>")
 			else if(prob(35))
 				to_chat(H, "<span class='danger'>The holy flames continue to burn your flesh!</span>")
+			H.adjustFireLoss(5)
 			H.fire_stacks += 5
 			H.ignite()
 

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -528,15 +528,15 @@
 				else
 					to_chat(src, "<span class='danger'>You continue to burn!</span>")
 				fire_stacks += 5
+				adjustFireLoss(2) //For a total of 8 burn damage per tick.
 				ignite()
-				adjustFireLoss(5)
 		audible_scream()
 	else
 		switch(health)
 			if((-INFINITY) to 60)
 				fire_stacks++
 				ignite()
-	adjustFireLoss(3)
+	adjustFireLoss(6)
 
 /*
  -- Thralls --

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -529,6 +529,7 @@
 					to_chat(src, "<span class='danger'>You continue to burn!</span>")
 				fire_stacks += 5
 				ignite()
+				adjustFireLoss(5)
 		audible_scream()
 	else
 		switch(health)


### PR DESCRIPTION
This is the third PR in a longer string of PRs that will attempt to tone down the vampire's power, as they have been dominating as antagonists for quite a while.
It turns out vampires can survive in space. Yeah. The code lets the fire stacks take over when it comes to dealing burn damage but fires are immediately extinguished while in space, so they effectively do not take a lot of damage.
This PR fixes it by adding a flat 5 burn damage per tick taken when exposed to the sun at low enough health (with a base of 3 extra burn damage at all stages), hopefully stopping vampires from out-regenerating it.
Also increased the base burn damage from smiting because it'd suffer from a similar problem when it involved space.

This one does need to be tested more, since the main interaction problem is with the ability to revive cleansing all the burn damage and being able to just spam it the whole journey through space.

:cl:
 * tweak: Vampires now take somewhat more extra heat damage from being smitten and from sun exposure, which should fix an edge case where a vampire could survive in space.