### PR TITLE
Vampire Nerf: Thralls now get affected by being splashed with holy water

### DIFF
--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -595,6 +595,17 @@
 			if (prob(35)) // 35% chance of dethralling
 				Drop(TRUE)
 
+/datum/role/thrall/handle_splashed_reagent(var/reagent_id, var/method, var/volume)
+	switch(reagent_id)
+		if(HOLYWATER, SACREDWATER)
+			var/mob/living/carbon/human/H = antag.current
+			if(!istype(H))
+				return
+			H.eye_blurry = max(H.eye_blurry, 5)
+			H.Dizzy(5)
+			H.stuttering = max(H.stuttering, 5)
+			H.Jitter(5)
+
 /mob/proc/vampire_power(var/required_blood = 0, var/max_stat = 0)
 	var/datum/role/vampire/vampire = isvampire(src)
 


### PR DESCRIPTION
This is the fourth PR in a longer string of PRs that will attempt to tone down the vampire's power, as they have been dominating as antagonists for quite a while.
Thralls are basically indistinguishable from regular crewmembers and don't really have any indication that they ARE thralls, which is quite bad for an antagonist type that can be converted indefinitely by a vampire with no limits. The only way you know they are thralls is when they are already assisting the vampire, not even greytide implanted people are this stealthy.

This PR makes them shake and jitter and get dizzy like cultists do when they are splashed with holy water. It's not perfect but it's better than nothing, considering that thralls can be made indefinitely.

:cl:
 * tweak: Thralls will now become visibly disoriented when splashed with holy water.