### PR TITLE
Vampire Nerf: Thralls are deconverted on death

### DIFF
--- a/__DEFINES/span.dm
+++ b/__DEFINES/span.dm
@@ -3,3 +3,4 @@
 #define span_info(str) ("<span class='info'>" + str + "</span>")
 #define span_notice(str) ("<span class='notice'>" + str + "</span>")
 #define span_warning(str) ("<span class='warning'>" + str + "</span>")
+#define span_big_warning(str) ("<span class='big warning'>" + str + "</span>")

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -560,6 +560,7 @@
 	ForgeObjectives()
 	AnnounceObjectives()
 	OnPostSetup()
+	register_event(/event/death, src, nameof(src::Drop(killed = TRUE)))
 
 /datum/role/thrall/Greet(var/you_are = TRUE)
 	var/dat
@@ -575,7 +576,7 @@
 	P.set_target(master.antag)
 	AppendObjective(P)
 
-/datum/role/thrall/Drop(var/deconverted = FALSE)
+/datum/role/thrall/Drop(var/deconverted = FALSE, var/killed = FALSE)
 	var/mob/M = antag.current
 	message_admins("[key_name(M)] was dethralled, his master was [key_name(master.antag)]. [formatJumpTo(get_turf(antag.current))]")
 	log_admin("[key_name(M)] was dethralled, his master was [key_name(master.antag)]. [formatJumpTo(get_turf(antag.current))]")
@@ -583,7 +584,10 @@
 		M.visible_message("<span class='big danger'>[M] suddenly becomes calm and collected again, \his eyes clear up.</span>",
 		"<span class='warning'><b>Your blood cools down and you are inhabited by a sensation of untold calmness.</b></span>")
 		to_chat(M, "<span class='big warning'>You are no longer a slave to [master.antag.current]'s whims, having <b>escaped your thralldom.<b></span>")
+	if(killed)
+		to_chat(M, span_big_warning("Due to being killed you are no longer a slave to [master.antag.current]'s whims, having <b>escaped your thralldom.<b>"))
 	update_faction_icons()
+	unregister_event(/event/death, src, nameof(src::Drop()))
 	return ..()
 
 /datum/role/thrall/handle_reagent(var/reagent_id)


### PR DESCRIPTION
This is the fifth PR in a longer string of PRs that will attempt to tone down the vampire's power, as they have been dominating as antagonists for quite a while.
Sometimes a station may not have a convenient access to holy water, and aside from the holy water there's no way to deconvert a thrall, which is bad. Since thralls are far more easily acquired and generally more "disposable" as an antagonist type I have taken the liberty of making this PR, which makes killing a thrall a viable alternative compared to forced holy water drinks. This should also encourage vampires to be a little bit more protective of their thralls due to being a blood investment that they can lose more easily.
This also fixes UI-related bugs related to when thralls come back, because either the vampire or the thrall don't see each other's HUDs and that used to create problems. Now that thralls are no longer thralled on death this bug is fixed.

To-do: Test this

:cl:
 * tweak: A vampire's thralls will now be deconverted upon the thrall's death.