### PR TITLE
Fixes monkey-to-human animation being far longer than it should be.

### DIFF
--- a/__DEFINES/mobs.dm
+++ b/__DEFINES/mobs.dm
@@ -49,3 +49,5 @@
 
 #define SLIME_BABY 1
 #define SLIME_ADULT 2
+
+#define MONKEY_ANIM_TIME 22

--- a/code/modules/dna/genes/monkey.dm
+++ b/code/modules/dna/genes/monkey.dm
@@ -43,7 +43,7 @@
 		animation.master = M
 		var/anim_name = M.get_unmonkey_anim()
 		flick(anim_name, animation)
-		sleep(48)
+		sleep(MONKEY_ANIM_TIME)
 		animation.master = null
 		qdel(animation)
 

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -381,5 +381,3 @@
 		my_appearance.b_facial = my_appearance.b_hair = 5
 		update_hair() //wie zal dat zijn?
 
-
-#undef MONKEY_ANIM_TIME

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -1,5 +1,3 @@
-#define MONKEY_ANIM_TIME 22
-
 // A standardized proc for turning a mob into a monkey
 // ignore_primitive will force the mob to specifically become a monkey and not its primitive type
 // returns the monkey mob


### PR DESCRIPTION
It had a value that translated into 4.8 seconds, 2.6 of which were after the animation had ended which would leave them invisible for far longer than they should be.

:cl:
 * bugfix: Fixed a bug where monkeys turned into humans via genetics took extra time to transform and would be invisible for a few seconds. They should now be properly interacted with after 2.2 seconds.