### PR TITLE
Sanity check on list pointers

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -45,10 +45,12 @@
 			*pointer_to_var = null
 		if (pointer_to_list)
 			var/list/L = *pointer_to_list
-			L -= src
+			if (islist(L))
+				L -= src
 		if (pointer_to_secondary_list)
 			var/list/L = *pointer_to_secondary_list
-			L -= src
+			if (islist(L))
+				L -= src
 	catch (var/exception/E)
 		log_debug("Error in handling screen objects pointers. [E.name] at file [E.file] and [E.line]")
 


### PR DESCRIPTION
@west3436 helpfully pointed out that sometimes those pointers *exist* but point to a null list. This doesn't crash the full Destroy proc but it does clog the file with runtimes. I am not sure *why* those get nulled - maytbe `hud/Destroy()` gets called before the actual screen obj does ?

The proper fix was, is, and will likely remain for the forseeable to rewrite screenobjs from the ground up but this should silence this runtime. This is obviously not ideal but the pointers are basically an admission of defeat that we don't know exactly where those objects live anyway.

Should this prove to not work, I'll just revert the pointers thingy. A shame, I had hoped it would work.