### PR TITLE
Optimizes sparks to somewhat impede lag

### DIFF
--- a/code/game/machinery/antiquemattersynth.dm
+++ b/code/game/machinery/antiquemattersynth.dm
@@ -179,7 +179,7 @@ list("category" = "machinery", "name" = "MSGS", "path" = /obj/machinery/atmosphe
 		new O(get_turf(src))
 	else
 		playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 0)
-	spark(src, 10, FALSE)
+	spark(src, 8, FALSE)
 
 
 /obj/machinery/power/antiquesynth/wrenchAnchor(var/mob/user, var/obj/item/I)

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -144,6 +144,7 @@ steam.start() -- spawns the effect
 /////////////////////////////////////////////
 
 #define SPARK_TEMP 500
+#define SPARK_TURF_LIMIT 8
 
 /obj/effect/sparks
 	name = "sparks"
@@ -228,11 +229,17 @@ steam.start() -- spawns the effect
   */
 /proc/spark(var/atom/loc, var/amount = 3, var/cardinals = TRUE, var/surfaceburn = FALSE, var/silent = FALSE)
 	loc = get_turf(loc)
+	var/tally = -1 //Prevent the sparks from starting if there are already too many sparks on the same tile. -1 to exclude itself
+	for(var/obj/effect/sparks/S in loc.contents)
+		tally++
+	if(tally >= SPARK_TURF_LIMIT)
+		return
 	var/datum/effect/system/spark_spread/S = new
 	S.set_up(amount, cardinals, loc)
 	S.start(surfaceburn, silent)
 
 #undef SPARK_TEMP
+#undef SPARK_TURF_LIMIT
 
 /////////////////////////////////////////////
 //// SMOKE SYSTEMS

--- a/code/game/objects/structures/electricchair.dm
+++ b/code/game/objects/structures/electricchair.dm
@@ -68,11 +68,11 @@
 			if(istype(target) && target.locked_to == src)
 				target.electrocute_act(34, src, incapacitation_duration = 24 SECONDS)
 				to_chat(target, "<span class='danger'>You feel a deep shock course through your body!</span>")
-			spark(src, 12, FALSE)
+			spark(src, 8, FALSE)
 			sleep(10)
 
 		A.power_light = light
 		A.updateicon()
 	else
-		spark(src, 12, FALSE) //just something to let them know it works
+		spark(src, 8, FALSE) //just something to let them know it works
 	return


### PR DESCRIPTION
If you put 25 bodies on a conveyor belt that leads directly into a powered grille and you turn it on you will end up lagging the server immensely with tons of unnecessary spark creation and spark movement code as hundreds and hundreds get spawned and processed.
This PR adds a check that prevents more than 8 sparks at a time from being on the same tile

Before:
<img src="https://github.com/user-attachments/assets/3a4c9ce9-2fc9-42d9-8de4-6bbc8f91dc27" />

After:
<img src="https://github.com/user-attachments/assets/5f6d40be-c127-4cf5-bdd8-e31b8ed11b41" />

Also reduces the spark count related to two objects to the maximum.

:cl:
 * bugfix: Reduced the lag caused by creating too many sparks on one tile.