### PR TITLE
Gym Rat (and children) standing up / laying down tweak

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/gym_rats.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gym_rats.dm
@@ -208,20 +208,25 @@
 	else
 		..()
 
-/mob/living/simple_animal/hostile/retaliate/gym_rat/verb/stand_up() // Allows the gym rat to toggle poses. They can stand upright, or walk around like a typical mouse
+/mob/living/simple_animal/hostile/retaliate/gym_rat/verb/stand_up() //Allows the gym rat to toggle poses. They can stand upright, or walk around like a typical mouse.
 	set name = "Stand Up / Lie Down"
-	set desc = "Stand up and show off your guns, or walk on all fours to not embarrass the nerds."
+	set desc = "Stand up and punch harder, or walk on all fours and run faster."
 	set category = "GymRat"
 
 	if(all_fours == TRUE)
 		all_fours = FALSE
 		to_chat(src, text("<span class='notice'>You are now standing upright.</span>"))
 		update_icon()
-
+		speed = 1.1
+		melee_damage_lower = ceil(melee_damage_lower*2)
+		melee_damage_upper = ceil(melee_damage_upper*2)
 	else
 		all_fours = TRUE
 		to_chat(src, text("<span class='notice'>You are now moving on all fours.</span>"))
 		update_icon()
+		speed = 0.7
+		melee_damage_lower = ceil(melee_damage_lower*0.5)
+		melee_damage_upper = ceil(melee_damage_upper*0.5)
 
 /mob/living/simple_animal/hostile/retaliate/gym_rat/verb/info() // Tells the gym rat how to gym rat
 	set name = "How 2 Gainz"

--- a/code/modules/mob/living/simple_animal/hostile/gym_rats.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gym_rats.dm
@@ -34,6 +34,8 @@
 	melee_damage_lower = 1
 	melee_damage_upper = 5
 
+	var/meleelowerdata = null //simplest way to remember the actual value so it doesn't go into a loop of ever decreasing numbers as you toggle standing up and on all fours
+	var/meleeupperdata = null
 	var/health_cap = 100 // Eating protein can pack on a whopping 233% increase in max health. GAINZ
 	var/icon_eat = "gymrat-eat"
 	var/obj/my_wheel
@@ -143,10 +145,14 @@
 	if(maxHealth < 60)
 		melee_damage_lower = 1
 		melee_damage_upper = 5
+		meleelowerdata = 1
+		meleeupperdata = 5
 		environment_smash_flags &= ~OPEN_DOOR_STRONG
 	else
 		melee_damage_lower = 5
 		melee_damage_upper = 10
+		meleelowerdata = 5
+		meleeupperdata = 10
 		environment_smash_flags |= OPEN_DOOR_STRONG
 
 /mob/living/simple_animal/hostile/retaliate/gym_rat/Life() // Copied from hammy wheel running code
@@ -208,7 +214,7 @@
 	else
 		..()
 
-/mob/living/simple_animal/hostile/retaliate/gym_rat/verb/stand_up() //Allows the gym rat to toggle poses. They can stand upright, or walk around like a typical mouse.
+/mob/living/simple_animal/hostile/retaliate/gym_rat/verb/stand_up() // Allows the gym rat to toggle poses. They can stand upright, or walk around like a typical mouse
 	set name = "Stand Up / Lie Down"
 	set desc = "Stand up and punch harder, or walk on all fours and run faster."
 	set category = "GymRat"
@@ -217,16 +223,16 @@
 		all_fours = FALSE
 		to_chat(src, text("<span class='notice'>You are now standing upright.</span>"))
 		update_icon()
-		speed = 1.1
-		melee_damage_lower = ceil(melee_damage_lower*2)
-		melee_damage_upper = ceil(melee_damage_upper*2)
+		speed = 1.35
+		melee_damage_lower = ceil(meleelowerdata*1.5)
+		melee_damage_upper = ceil(meleeupperdata*1.5)
 	else
 		all_fours = TRUE
 		to_chat(src, text("<span class='notice'>You are now moving on all fours.</span>"))
 		update_icon()
 		speed = 0.7
-		melee_damage_lower = ceil(melee_damage_lower*0.5)
-		melee_damage_upper = ceil(melee_damage_upper*0.5)
+		melee_damage_lower = ceil(meleelowerdata*0.5)
+		melee_damage_upper = ceil(meleeupperdata*0.5)
 
 /mob/living/simple_animal/hostile/retaliate/gym_rat/verb/info() // Tells the gym rat how to gym rat
 	set name = "How 2 Gainz"
@@ -269,6 +275,8 @@
 /mob/living/simple_animal/hostile/retaliate/gym_rat/New() // speaks mouse
 	..()
 	languages += all_languages[LANGUAGE_MOUSE]
+	meleelowerdata = melee_damage_lower
+	meleeupperdata = melee_damage_upper
 
 /mob/living/simple_animal/hostile/retaliate/gym_rat/mothership // Mothership faction version, so it doesn't get attacked by the vault dwellers
 	faction = "mothership"
@@ -309,10 +317,14 @@
 	if(maxHealth < 80)
 		melee_damage_lower = 1
 		melee_damage_upper = 6
+		meleelowerdata = 1
+		meleeupperdata = 6
 		environment_smash_flags &= ~OPEN_DOOR_STRONG
 	else
 		melee_damage_lower = 6
 		melee_damage_upper = 12
+		meleelowerdata = 6
+		meleeupperdata = 12
 		environment_smash_flags |= OPEN_DOOR_STRONG
 
 /mob/living/simple_animal/hostile/retaliate/gym_rat/pompadour_rat/Life()
@@ -452,10 +464,14 @@
 	if(maxHealth < 200)
 		melee_damage_lower = 10
 		melee_damage_upper = 20
+		meleelowerdata = 10
+		meleeupperdata = 20
 		environment_smash_flags &= ~SMASH_WALLS
 	else
 		melee_damage_lower = 20
 		melee_damage_upper = 30
+		meleelowerdata = 20
+		meleeupperdata = 30
 		environment_smash_flags |= SMASH_WALLS
 
 /mob/living/simple_animal/hostile/retaliate/gym_rat/roid_rat/Life() // Copied from hammy wheel running code


### PR DESCRIPTION
## What this does
Gym Rats, Pompadour Rats and ROID RATS all have a stand up/lay down verb that does nothing other than changing your standing (or laying down) sprite. 
This changes it so standing up lets the rats punch HARDER but move SLOWER. Likewise, going on all fours lets the rats move way faster, but they lose a fair bit of heft to their attacks.
## Why it's good
Gives an actual use to the stand up/lay down verb the gym rats have, balanced around speed vs power, so you have to choose one or the other depending on the situation.
## How it was tested
Spawned as a roid rat, gym rat and pompadour rat. VV'd the variables to see if the melee and speed changed when I stood up or laid down, and they changed accordingly. Ate meat to get BUFF and inspected the thing again, they changed properly. Stood up and laid down afterwards and it remembered the updated value.
:cl:
 * rscadd: Gym Rats, Pompadour Rats and ROID RATS will now notice that standing up lets them punch a fair bit harder at the cost of slower walking speed, and viceversa when laying down on all fours, with faster movement but weaker hits.