### PR TITLE
Triples Singularity power output

### DIFF
--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -704,8 +704,13 @@ var/list/obj/machinery/singularity/white_hole_candidates
 			M.dust()
 	return
 
+// Increases the emitted power by that many times.
+#define SINGULARITY_ENERGY_MULTIPLIER 3
+
 /obj/machinery/singularity/proc/pulse()
-	emitted_harvestable_radiation(get_turf(src), energy, range = 15)
+	emitted_harvestable_radiation(get_turf(src), energy * SINGULARITY_ENERGY_MULTIPLIER, range = 15)
+
+#undef SINGULARITY_ENERGY_MULTIPLIER
 
 /obj/machinery/singularity/proc/on_capture()
 	chained = 1


### PR DESCRIPTION
Because the shard outdoes it in almost every single metric except ease of setup.
- Less destructive (one big explosion vs singularity eating through the station)
- Safer to handle (try being near an unshielded singularity compared to a shard)
- More power (Singularity has to be revisited once in a while until it is purple, depending on cooling setup you can leave a shard on with triple emitters for the rest of the shift)

All the talk about "Lord Singuloth" and it is outdone by a mere fragment of a crystal?
This should allow the singularity to remain enticing to experienced engineers as a good power source.

:cl:
 * tweak: The singularity's power output has been tripled.