### PR TITLE
Adds the ability to re-name plants

### DIFF
--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -56,16 +56,19 @@
 
 /obj/item/seeds/attackby(obj/item/weapon/W, mob/user)
 	if(istype(W,/obj/item/weapon/pen))
+		if(seed.immutable)//if the seed cannot be gene edited, like diona nodes
+			return
 		var/n_name = copytext(sanitize(input(user, "What would you like to name this seed variety?", "Plant Renaming", null) as text|null), 1, MAX_NAME_LEN*3)
 		if(n_name && Adjacent(user) && !user.stat)
+			var/newnoun = seed.seed_noun
 			seed = seed.diverge(-1)//creates a new seed datum with a unique identifier. Seed datums are globals, so you don't want to modify every other seed in existence.
 			seed.seed_name = "[n_name]"//the name on the packet
 			seed.display_name = "[n_name]"//the name on the description of the packet and on growing plants
 			seed.add_newline_to_controller()//adds the entry to the plant subsystem
 			seed.roundstart = 1
-			update_appearance()//automagically updates the name and desc to reflect on the seed_name varaible
+			seed.seed_noun = newnoun
+			update_appearance()//automagically updates the name and desc to reflect the seed_name varaible
 			desc += " The words [n_name] are scribbled on it."
-		return
 	..()
 
 //the vegetable/fruit categories are made from a culinary standpoint. many of the "vegetables" in there are technically fruits. (tomatoes, pumpkins...)

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -64,8 +64,6 @@
 			seed.seed_name = "[n_name]"
 			seed.display_name = "[n_name]"
 			seed.roundstart = 1
-			//new_seed_type = SSplant.seeds[F.plantname]
-			//seeds.seed_type = new_seed_type.name
 		return
 	if (..())
 		return

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -58,15 +58,15 @@
 	if(istype(W,/obj/item/weapon/pen))
 		var/n_name = copytext(sanitize(input(user, "What would you like to name this seed variety?", "Plant Renaming", null) as text|null), 1, MAX_NAME_LEN*3)
 		if(n_name && Adjacent(user) && !user.stat)
-			name = "packet of [n_name] seeds"
-			seed = seed.diverge(-1)
-			seed.add_newline_to_controller()
-			seed.seed_name = "[n_name]"
-			seed.display_name = "[n_name]"
+			seed = seed.diverge(-1)//creates a new seed datum with a unique identifier. Seed datums are globals, so you don't want to modify every other seed in existence.
+			seed.seed_name = "[n_name]"//the name on the packet
+			seed.display_name = "[n_name]"//the name on the description of the packet and on growing plants
+			seed.add_newline_to_controller()//adds the entry to the plant subsystem
 			seed.roundstart = 1
+			update_appearance()//automagically updates the name and desc to reflect on the seed_name varaible
+			desc += " The words [n_name] are scribbled on it."
 		return
-	if (..())
-		return
+	..()
 
 //the vegetable/fruit categories are made from a culinary standpoint. many of the "vegetables" in there are technically fruits. (tomatoes, pumpkins...)
 

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -54,6 +54,22 @@
 	seed_type = seed.name
 	..()
 
+/obj/item/seeds/attackby(obj/item/weapon/W, mob/user)
+	if(istype(W,/obj/item/weapon/pen))
+		var/n_name = copytext(sanitize(input(user, "What would you like to name this seed variety?", "Plant Renaming", null) as text|null), 1, MAX_NAME_LEN*3)
+		if(n_name && Adjacent(user) && !user.stat)
+			name = "packet of [n_name] seeds"
+			seed = seed.diverge(-1)
+			seed.add_newline_to_controller()
+			seed.seed_name = "[n_name]"
+			seed.display_name = "[n_name]"
+			seed.roundstart = 1
+			//new_seed_type = SSplant.seeds[F.plantname]
+			//seeds.seed_type = new_seed_type.name
+		return
+	if (..())
+		return
+
 //the vegetable/fruit categories are made from a culinary standpoint. many of the "vegetables" in there are technically fruits. (tomatoes, pumpkins...)
 
 /obj/item/seeds/dionanode


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Adds the ability to re-name plants grown by hydroponics. This will affect the seed packets and the plant itself, **not** the produce picked from it. It will, however, affect any seeds extracted from said produce.

To do so, simply use a pen on a seed packet.
<img width="816" height="461" alt="image" src="https://github.com/user-attachments/assets/6b615d7b-f179-4b85-83b4-618e93c65fbe" />

Plants that cannot be mutated like diona nodes and nofruit cannot be re-named in this way.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
I've wanted a feature like this for years. Hydroponics have a rather extensive genetics system with no obvious way of organizing specific strains. In a given round, you could make two types of blue-space tomatoes with completely different chems inside, but hardly any control over the numbers used to tell them apart. In fact, you cannot view the chemicals they produce until the plant is fully matured and harvested from. This should both make the process a bit easier and allow some silliness in players naming their own varieties.


## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
I would extract a seed from the vendor, give them silly names with a pen, then plant them. Initial tests led to incompatibilities with the seed extractor prior to planting them, which had been fixed by adding a newline to the controller.
Once the plants had matured, I had also extracted seeds from them.


## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Allows players to re-name plants by using pens on their seed packets.

