### PR TITLE
Avocados deshittified

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -1060,12 +1060,19 @@ var/list/strange_seed_product_blacklist = subtypesof(/obj/item/weapon/reagent_co
 	..()
 	if(W.sharpness_flags & SHARP_BLADE)
 		if(cut && cant_eat_msg)
-			new /obj/item/seeds/avocadoseed/whole(loc)
-			new /obj/item/weapon/reagent_containers/food/snacks/grown/avocado/cut/pitted(loc)
-			user.create_in_hands(src, /obj/item/weapon/reagent_containers/food/snacks/grown/avocado/cut/pitted, vismsg = "\The [user] removes the pit from \the [src] with \the [W].", msg = "You remove the pit from \the [src] with \the [W].")
+			var/obj/item/seeds/avocadoseed/whole/sneed = new(loc)
+			var/obj/item/weapon/reagent_containers/food/snacks/grown/avocado/cut/pitted/slice = new(get_turf(src))
+			reagents.trans_to(slice, reagents.total_volume)
+			sneed.seed = seed
+			sneed.update_seed()
+			user.create_in_hands(src, slice, vismsg = "\The [user] removes the pit from \the [src] with \the [W].", msg = "You remove the pit from \the [src] with \the [W].")
 		else if(!cut)
-			var/list/halves = list(new /obj/item/weapon/reagent_containers/food/snacks/grown/avocado/cut(get_turf(src)), new /obj/item/weapon/reagent_containers/food/snacks/grown/avocado/cut/pitted(get_turf(src)))
+			var/obj/item/weapon/reagent_containers/food/snacks/grown/avocado/cut/mypit = new(get_turf(src))
+			var/list/halves = list(new /obj/item/weapon/reagent_containers/food/snacks/grown/avocado/cut/pitted(get_turf(src)), mypit)
+			for(var/obj/item/weapon/reagent_containers/food/snacks/grown/avocado/cado in halves)
+				reagents.trans_to(cado, (reagents.total_volume/2))
 			user.create_in_hands(src, pick(halves), vismsg = "\The [user] slices \the [src] in half with \the [W].", msg = "You slice \the [src] in half with \the [W].")
+			mypit.seed = seed
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/avocado/cut
 	name = "avocado half"

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -1060,7 +1060,7 @@ var/list/strange_seed_product_blacklist = subtypesof(/obj/item/weapon/reagent_co
 	..()
 	if(W.sharpness_flags & SHARP_BLADE)
 		if(cut && cant_eat_msg)
-			var/obj/item/seeds/avocadoseed/whole/sneed = new(loc)
+			var/obj/item/seeds/avocadoseed/whole/sneed = new(get_turf(src))
 			var/obj/item/weapon/reagent_containers/food/snacks/grown/avocado/cut/pitted/slice = new(get_turf(src))
 			reagents.trans_to(slice, reagents.total_volume)
 			sneed.seed = seed


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Fixes a few bugs and inconsistencies regarding avocado behavior. Specifically, the fact that:

- One avocado produced three slices
- Avocado pits removed by slicing only spawned with the default genetic information
- Avocado slices would never generate with any reagents

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Fixing bugs is generally good for the game.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Avocados seeds were vended, spliced with chanterelles, then their modified genome was varedited to grow as quickly as possible. One of the products were placed in the seed extractor, the other was pitted. The pitted and extracted seeds had their datums compared and, with this code, will now stack in the seed extractor. Additionally, the slices produced were eaten.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed unusual behaviors related to slicing avocados
