### PR TITLE
Random events will no longer fire when there are 0 players online

### DIFF
--- a/code/modules/events/event_manager.dm
+++ b/code/modules/events/event_manager.dm
@@ -5,6 +5,12 @@ var/eventTimeUpper = 40
 var/scheduledEvent = null
 
 /proc/checkEvent()
+	if(!player_list.len) //Don't start any events while the server is empty
+		return
+	var/datum/gamemode/dynamic/D = ticker.mode
+	if(istype(D)) //Now check for living, active players, if there are no living players then don't call events
+		if(!D.living_players.len)
+			return
 	if(!scheduledEvent)
 		//The more players, the merrier
 		var/playercount_modifier = 1


### PR DESCRIPTION
Because having to come to a completely depowered station with hornets in Arrivals and slimes in Botany isn't exactly fun.
Adds a check that prevents random events from firing if either:
A) There are no players online, at all.
B) There are no active living players, so that it doesn't count lobby idling for random events firing.

:cl:
 * tweak: The game will no longer fire random events if the server has either no players online or no living players.