### PR TITLE
Nerfs Supermatter 

### DIFF
--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -285,6 +285,8 @@
 		if(damage > explosion_point)
 			for(var/mob/living/mob in living_mob_list)
 				var/turf/T = get_turf(mob)
+				if(!T) // Mob is in nullspace
+					continue
 				if(T.z != src.z)//only make it effect mobs on the current Z level.
 					continue
 				if(istype(mob, /mob/living/carbon/human))
@@ -299,20 +301,20 @@
 
 	//Ok, get the air from the turf
 	var/datum/gas_mixture/env = L.return_air()
-	
+
 	//Remove gas from surrounding area
 	var/datum/gas_mixture/removed = env.remove_volume(gasefficency * CELL_VOLUME)
 
 	var/radonenergyfactor=1.0+removed[GAS_RADON]*RADON_EXCITATION_FACTOR //wowza power. prepare your butts for delams.
-	
+
 	power+=emitterpower*radonenergyfactor //radon affects emitter power (as well as temp+atmos related power gen.)
-	
+
 	if(!removed || !removed.total_moles)
 		damage += max((power-1600)/10, 0)
 		power = min(power, 1600)
 		return 1
 
-	
+
 
 	damage_archived = damage
 	damage = max( damage + ( (removed.temperature - 800) / 150 ) , 0 )


### PR DESCRIPTION
Unfortunately it had to be done for the sake of the game's balance. This PR drastically reduces the supermatter shard's potential power output in a bid to put it more in line with other engines. Its power production can be incredibly high and this is just one way to nerf it. You can attain gigawatts of energy while other engines can barely attain anything at all in comparison, unless you take your time to build a R-UST engine. The supermatter is also relatively easy to set up, it looks more intimidating to build than to actually build it, and you can make the engine generate plenty of power for a very, very long time. The gas the shard produces will not really affect the incredibly low temperatures you can set the engine at if you build the space heat exchangers, and you can always make a custom script to vent the gases inside the vents if they have too much pressure. All in all, the shard is too easy of a power source for how much power it produces, and this PR fixes it.

:cl:
 * bugfix: Fixed a bug where if a mob was somehow nullspaced while still alive a shard would never explode from instability. This bug happened because it was trying to get a value out of a mob's turf, which did not exist because it was nullspaced.