### PR TITLE
People who are being arrested are no longer valid candidates for head revolutionaries

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -736,6 +736,9 @@ Assign your candidates in choose_candidates() instead.
 		if(A && istype(A, /area/security)) // We also don't want people who are arrested to become headrevs
 			candidates.Remove(P)
 			continue
+		if(P.is_loyalty_implanted()) // No turning loyalty implanted people into headrevs, in case they were implanted shortly after game start
+			candidates.Remove(P)
+			continue
 
 /datum/dynamic_ruleset/roundstart/delayed/revs/choose_candidates()
 	var/max_canditates = 4

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -725,6 +725,18 @@ Assign your candidates in choose_candidates() instead.
 			head_check++
 	return (head_check >= required_heads)
 
+// Removes headrev candidates that are at an extreme risk of being outed as headrevs
+/datum/dynamic_ruleset/roundstart/delayed/revs/trim_candidates()
+	..()
+	for(var/mob/living/carbon/human/P in candidates) //required_type in the parent proc already filters non-humans
+		if(P.handcuffed) // We don't want people who are being dragged to the brig to become headrevs
+			candidates.Remove(P)
+			continue
+		var/area/A = get_area(P)
+		if(A && istype(A, /area/security)) // We also don't want people who are arrested to become headrevs
+			candidates.Remove(P)
+			continue
+
 /datum/dynamic_ruleset/roundstart/delayed/revs/choose_candidates()
 	var/max_canditates = 4
 	for(var/i = 1 to max_canditates)


### PR DESCRIPTION
Because I have observed a round where one assistant was arrested and then he became a head revolutionary while being processed (but I didn't see the actual moment so I could be wrong)
This PR prevents candidates that are in handcuffs or inside Security areas from being eligible for head revolutionary, because they will immediately get outed and that's bad.
Also adds a sanity check for loyalty implants, so that there's no possibility of loyalty-implanted head revolutionaries just in case a would-be candidate has been implanted very early in the round.

:cl:
 * bugfix: Fixed an oversight where an implanted person could become a head revolutionary. This could happen if a candidate was implanted within the first few minutes of the round.
 * tweak: People who are being arrested should no longer be valid for being head revolutionaries.