### PR TITLE
Admin fax reply presets

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1105,23 +1105,23 @@ var/list/admin_verbs_mod = list(
 
 var/list/fax_presets = list(
 	"Centcomm" = {"<!DOCTYPE html>
-	<html>
-	<body style="background-color:darkblue;">
+<html>
+<body style="background-color:darkblue;">
 
-	<h1><center><font color="white">NANOTRASEN CENTRAL COMMAND</font></center></h1>
-	<center><img src="http://ss13.moe/wiki/images/1/17/NanoTrasen_Logo.png"  alt="Nanotrasen" height="50" width="110"></center>
-	<p><center><font color="white">\[MESSAGE BODY GOES HERE\]</center></font></p>
-	<p><center><font color="white">\[MESSAGE BODY GOES HERE\]</center></font></p>
+<h1><center><font color="white">NANOTRASEN CENTRAL COMMAND</font></center></h1>
+<center><img src="http://ss13.moe/wiki/images/1/17/NanoTrasen_Logo.png"  alt="Nanotrasen" height="50" width="110"></center>
+<p><center><font color="white">\[MESSAGE BODY GOES HERE\]</center></font></p>
+<p><center><font color="white">\[MESSAGE BODY GOES HERE\]</center></font></p>
 
-	</body>
-	</html>"},
+</body>
+</html>"},
 	"Internal Affairs" = {"<html><style>body {color: #000000; background: #ccffff;}
-	h1 {color: #000000; font-size:30px;}
-	fieldset {width:140px;}
-	</style><body><center><img src="http://ss13.moe/wiki/images/1/17/NanoTrasen_Logo.png"> <h1>ATTN: Internal Affairs</h1></center><BR>
-	\[MESSAGE BODY GOES HERE\]
-	<BR><BR><I>Central Command</I>
-	</body></html>"},
+h1 {color: #000000; font-size:30px;}
+fieldset {width:140px;}
+</style><body><center><img src="http://ss13.moe/wiki/images/1/17/NanoTrasen_Logo.png"> <h1>ATTN: Internal Affairs</h1></center><BR>
+\[MESSAGE BODY GOES HERE\]
+<BR><BR><I>Central Command</I>
+</body></html>"},
 	"Blank" = ""
 )
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1103,12 +1103,35 @@ var/list/admin_verbs_mod = list(
 
 	stop_all_media()
 
+var/list/fax_presets = list(
+	"Centcomm" = {"<!DOCTYPE html>
+	<html>
+	<body style="background-color:darkblue;">
+
+	<h1><center><font color="white">NANOTRASEN CENTRAL COMMAND</font></center></h1>
+	<center><img src="http://ss13.moe/wiki/images/1/17/NanoTrasen_Logo.png"  alt="Nanotrasen" height="50" width="110"></center>
+	<p><center><font color="white">\[MESSAGE BODY GOES HERE\]</center></font></p>
+	<p><center><font color="white">\[MESSAGE BODY GOES HERE\]</center></font></p>
+
+	</body>
+	</html>"},
+	"Internal Affairs" = {"<html><style>body {color: #000000; background: #ccffff;}
+	h1 {color: #000000; font-size:30px;}
+	fieldset {width:140px;}
+	</style><body><center><img src="http://ss13.moe/wiki/images/1/17/NanoTrasen_Logo.png"> <h1>ATTN: Internal Affairs</h1></center><BR>
+	\[MESSAGE BODY GOES HERE\]
+	<BR><BR><I>Central Command</I>
+	</body></html>"},
+	"Blank" = ""
+)
+
 /client/proc/SendCentcommFax()
 	set	category = "Fun"
 	set name = "Send Fax"
 	set desc = "Sends a fax to all fax machines."
 
-	var/sent = input(src, "Please enter a message send via secure connection. NOTE: BBCode does not work, but HTML tags do! Use <br> for line breaks.", "Outgoing message from Centcomm", "") as message|null
+	var/preset = input(src,"Which preset to use?","Preset formatting") as null|anything in fax_presets
+	var/sent = input(src, "Please enter a message send via secure connection. NOTE: BBCode does not work, but HTML tags do! Use <br> for line breaks.", "Outgoing message from Centcomm", fax_presets[preset]) as message|null
 	if(!sent)
 		return
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1109,7 +1109,7 @@ var/list/fax_presets = list(
 <body style="background-color:darkblue;">
 
 <h1><center><font color="white">NANOTRASEN CENTRAL COMMAND</font></center></h1>
-<center><img src="http://ss13.moe/wiki/images/1/17/NanoTrasen_Logo.png"  alt="Nanotrasen" height="50" width="110"></center>
+<center><img src="http://ss13.moe/wiki/images/1/17/NanoTrasen_Logo.png"></center>
 <p><center><font color="white">\[MESSAGE BODY GOES HERE\]</center></font></p>
 <p><center><font color="white">\[MESSAGE BODY GOES HERE\]</center></font></p>
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -3095,7 +3095,8 @@
 
 		output_to_msay("<span class = 'bold'>[key_name_admin(src.owner)] is replying to a fax message from [key_name_admin(H)].</span>")
 
-		var/sent = input(src.owner, "Please enter a message to reply to [key_name(H)] via secure connection. NOTE: BBCode does not work, but HTML tags do! Use <br> for line breaks.", "Outgoing message from Centcomm", "") as message|null
+		var/preset = input(src.owner,"Which preset to use?","Preset formatting") as null|anything in fax_presets
+		var/sent = input(src.owner, "Please enter a message to reply to [key_name(H)] via secure connection. NOTE: BBCode does not work, but HTML tags do! Use <br> for line breaks.", "Outgoing message from Centcomm", fax_presets[preset]) as message|null
 		if(!sent)
 			return
 


### PR DESCRIPTION
[administration]

## What this does
Allows admins to reply to faxes with preset formatting from this wiki page: https://ss13.moe/wiki/index.php?title=Adminbus#Sending_Well-Formatted_Faxes

## Why it's good
No more needing to look at the page to format the faxes

## How it was tested
"Send Fax" admin fun verb, replying to a fax sent with the machine as an admin.

## Changelog
:cl:
 * rscadd: Admin fax reponses can now come with preset formatting, or blank if they prefer.