### PR TITLE
fission tweaks: the reboot

### DIFF
--- a/code/datums/supply_packs/engineering.dm
+++ b/code/datums/supply_packs/engineering.dm
@@ -440,7 +440,7 @@
 		/obj/item/weapon/storage/box/fissionsupply_fuelmaker,
 	)
 	name = "Fission reactor starter kit"
-	cost = 200 //Includes a lot of plasteel. Fuck you, ask the miners for more you socially inept jobbie.
+	cost = 150 //Includes a lot of plasteel. Fuck you, ask the miners for more you socially inept jobbie.
 	containertype = /obj/structure/closet/crate/secure/large/reinforced/shard/empty
 	containername = "Fission reactor starter kit"
 	group = "Engineering"
@@ -458,7 +458,7 @@
 		/obj/structure/closet/crate/flatpack/configurable/fission_exterior,
 	)
 	name = "Fission reactor expansion pak"
-	cost = 75 //See above.
+	cost = 50 //See above.
 	containertype = /obj/structure/closet/crate/secure/large/reinforced/shard/empty
 	containername = "Fission reactor expansion pak"
 	group = "Engineering"
@@ -470,7 +470,7 @@
 		/obj/item/weapon/fuelrod/large
 	)
 	name = "High-capacity fuel reservoir"
-	cost = 75 //It's a one time purchase, really. somewhat costly, but not that much for a department. watch for meltdowns.
+	cost = 65 //It's a one time purchase, really. somewhat costly, but not that much for a department. watch for meltdowns.
 	containertype = /obj/structure/closet/crate/secure/large/reinforced/shard/empty
 	containername = "Large fuel reservoir"
 	group = "Engineering"
@@ -483,7 +483,7 @@
 		/obj/item/weapon/fuelrod/randomized
 	)
 	name = "Pre-filled fuel reservoir"
-	cost = 50 //expendable item. costs a decent bit because it's the standard size, and comes with materials in it. random materials, too. have fun!
+	cost = 33 //expendable item. costs a decent bit because it's the standard size, and comes with materials in it. random materials, too. have fun!
 	containertype = /obj/structure/closet/crate/secure/large/reinforced/shard/empty
 	containername = "Pre-filled fuel reservoir"
 	group = "Engineering"

--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -1653,7 +1653,7 @@ The design of a nuclear reactor is very important. Build it wrong, and you may f
 
 <h2>Standard Operation</h2>
 To avoid a catastrophic meltdown, a reactor must be monitored periodically to ensure that the temperature does NOT get too high.<br>
-Reactors can withstand temperatures up to 5500K, though the controller will activate a SCRAM protocol if the temperature exceeds 4500K. Once SCRAM is enabled, the control rods will be forced downwards and will remain down until the reactor has dropped below 1000K.<br>
+Reactors can withstand temperatures up to 11000K, though the controller will activate a SCRAM protocol if the temperature exceeds 9000K. Once SCRAM is enabled, the control rods will be forced downwards and will remain down until the reactor has dropped below 2000K.<br>
 <sub>The autoSCRAM routine may be disabled in the controller options menu by an authenticated engineer. However, this practice is not endorsed by NanoTrasen, and the engineer assumes all liability for any damage to the station as a result of this.</sub>
 <br>
 Once your reactor is built, you will need to insert a fuel reservoir (one is provided in the starter kit). A reactor accepts only a single fuel reservoir, so it is encouraged to carefully prepare the fuel mixture beforehand in accordance to the design of the reactor.<br>

--- a/code/modules/fissionreactor/fission_datums.dm
+++ b/code/modules/fissionreactor/fission_datums.dm
@@ -2,9 +2,9 @@
 IN THIS FILE:
 datums for the fission reactor, which includes the fuel and reactor
 */
-#define FISSIONREACTOR_MELTDOWNTEMP 5500 //temp when shit goes wrong
-#define FISSIONREACTOR_DANGERTEMP 4500 //temp to start warning you and to SCRAM
-#define FISSIONREACTOR_SAFEENUFFTEMP 1000 //temp where SCRAM resets
+#define FISSIONREACTOR_MELTDOWNTEMP 11000 //temp when shit goes wrong
+#define FISSIONREACTOR_DANGERTEMP 9000 //temp to start warning you and to SCRAM
+#define FISSIONREACTOR_SAFEENUFFTEMP 2000 //temp where SCRAM resets
 
 /datum/fission_reactor_holder
 	var/list/obj/machinery/fissionreactor/fissionreactor_fuelrod/fuel_rods=list() //phase 0 vars, set upon construction
@@ -337,7 +337,7 @@ datums for the fission reactor, which includes the fuel and reactor
 	coolant.volume=CELL_VOLUME* (sizex-2)*(sizey-2) //sub 2 to make sure there's no casing involved in the internal volume.
 	coolant.volume=max(coolant.volume,1) //atmos code will probably shit itself if this is 0.
 
-	heat_capacity=sizex*sizey*2500 // this scales with area as well.
+	heat_capacity=sizex*sizey*1500 // this scales with area as well.
 	return null
 	
 /datum/fission_reactor_holder/proc/determineexplosionsize()


### PR DESCRIPTION
[balance] [tweak]

## What this does
* lowers the price of all fission-related crates
  * starter kit: 200 -> 150
  * expansion pak: 75 -> 50
  * high cap. fuel rod: 75 -> 65
  * randomized fuel rod: 50 -> 33
* increases the maximum temperature a reactor can get before meltdown by 2x from 5500K to 11000K, and adjusts other temperature thresholds accordingly

## Why it's good
* makes reactors able to have more of their power potential used, and bigger number = better
* also means hotter fuel mixes are more viable to run
* also also means meltdowns will be more catastrophic (hotter gas leaking).
* lowered price opens more people to use it during an actual round, and puts it in the realm of being able to buy a crate without waiting an hour for wages or stealing a department card.

## How it was tested
went in game and verified that increasing the temp really was that easy. also checked that the prices for the orders were properly lowered.

## Changelog
:cl:
 * tweak: NanoTrasen's research into metallurgy has allowed for reactors to withstand temperatures twice as high (up to 11,000K). (Hotter = More power)
 * tweak: NanoTrasen has lowered the price of reactor components again to promote additional crew research.