### PR TITLE
R&D fixes and tweaks

### DIFF
--- a/__DEFINES/__compile_options.dm
+++ b/__DEFINES/__compile_options.dm
@@ -23,7 +23,7 @@
 // roidstation.dm
 //#define MAP_OVERRIDE 4
 // test_tiny.dm:
-#define MAP_OVERRIDE 6
+//#define MAP_OVERRIDE 6
 // tgstation.dm:
 //#define MAP_OVERRIDE 7
 // snaxi.dm

--- a/__DEFINES/__compile_options.dm
+++ b/__DEFINES/__compile_options.dm
@@ -23,7 +23,7 @@
 // roidstation.dm
 //#define MAP_OVERRIDE 4
 // test_tiny.dm:
-//#define MAP_OVERRIDE 6
+#define MAP_OVERRIDE 6
 // tgstation.dm:
 //#define MAP_OVERRIDE 7
 // snaxi.dm

--- a/code/modules/research/fabricators.dm
+++ b/code/modules/research/fabricators.dm
@@ -27,7 +27,6 @@
 	var/list/queue = list()
 	var/processing_queue = 0
 	var/screen = 0
-	var/temp
 	var/list/part_sets = list()
 	var/datum/design/last_made
 	var/start_end_anims = 0
@@ -63,18 +62,32 @@
 	for(var/obj/item/weapon/stock_parts/matter_bin/M in component_parts)
 		T += M.rating - 1
 	max_material_storage = (initial(max_material_storage)+(T * 187500))
+	update_coeff()
 
-	T = 0
-	var/datum/tech/Tech = files.known_tech["materials"]
+//A separate proc for updating the machine's coefficiency ratings
+/obj/machinery/r_n_d/fabricator/update_coeff()
+	// Each material tech level above 1 increases the reduction by 4%, each manipulator increases the reduction by 8% per tier above 1
+	var/manip_rating = 0 //Improves resource efficiency
 	for(var/obj/item/weapon/stock_parts/manipulator/Ma in component_parts)
-		T += Ma.rating - 1
-	resource_coeff = max(round(initial(resource_coeff) - (initial(resource_coeff)*((Tech.level - 1)+(T * 2)))/25,0.01), min_cap_C)
+		manip_rating += Ma.rating - 1 // + 1 per tier above tier 1, adds up with other manipulators
+	var/datum/tech/machine_tech = files.known_tech["materials"].level
+	var/datum/tech/console_tech
+	if(linked_console) //Check to see if there's a linked console to draw research from, otherwise use the machinery's innate research
+		console_tech = linked_console.files.known_tech["materials"].level
+	if(console_tech && (console_tech > machine_tech))
+		machine_tech = console_tech
+	resource_coeff = max(round(initial(resource_coeff) - (initial(resource_coeff)*((machine_tech - 1)+(manip_rating * 2)))/25,0.01), min_cap_C)
 
-	T = 0
-	Tech = files.known_tech["programming"]
+	// Each data tech level above 1 increases the reduction by 4%, each micro-laser increases the reduction by 12% per tier above 1
+	var/laser_rating = 0 //Improves fabrication speed
 	for(var/obj/item/weapon/stock_parts/micro_laser/Ml in component_parts)
-		T += Ml.rating - 1
-	time_coeff = max(round(initial(time_coeff) - (initial(time_coeff)*((Tech.level - 1)+(T * 3)))/25,0.01), min_cap_T)
+		laser_rating += Ml.rating - 1
+	machine_tech = files.known_tech["programming"].level
+	if(linked_console)
+		console_tech = linked_console.files.known_tech["programming"].level
+		if(console_tech > machine_tech)
+			machine_tech = console_tech
+	time_coeff = max(round(initial(time_coeff) - (initial(time_coeff)*((machine_tech - 1)+(laser_rating * 3)))/25,0.01), min_cap_T)
 
 /obj/machinery/r_n_d/fabricator/emag_act()
 	sleep()
@@ -420,44 +433,33 @@
 					i++
 	return i
 
-/obj/machinery/r_n_d/fabricator/proc/update_tech()
+/obj/machinery/r_n_d/fabricator/proc/update_tech(var/datum/tech/old_materials, var/datum/tech/old_programming)
 	if(!files)
 		return
 	var/output
-	var/diff
-	var/datum/tech/T = files.known_tech["materials"]
-	if(T && T.level > 1)
-		var/pmat = 0//Calculations to make up for the fact that these parts and tech modify the same thing
-		for(var/obj/item/weapon/stock_parts/manipulator/Ma in component_parts)
-			pmat += Ma.rating - 1
-		diff = max(round(initial(resource_coeff) - (initial(resource_coeff)*((T.level - 1)+(pmat*2)))/25,0.01), min_cap_C)
-		if(resource_coeff!=diff)
-			resource_coeff = diff
-			output+="Production efficiency increased.<br>"
-	T = files.known_tech["programming"]
-	if(T && T.level > 1)
-		var/ptime = 0
-		for(var/obj/item/weapon/stock_parts/micro_laser/Ml in component_parts)
-			ptime += Ml.rating - 1
-		diff = max(round(initial(time_coeff) - (initial(time_coeff)*((T.level - 1)+(ptime*3)))/25,0.1), min_cap_T)
-		if(time_coeff!=diff)
-			time_coeff = diff
-			output+="Production routines updated.<br>"
+	var/datum/tech/T = files.known_tech["materials"].level
+	if(T && (T > old_materials))
+		output += "Production efficiency increased."
+	T = files.known_tech["programming"].level
+	if(T && (T > old_programming))
+		if(output)
+			output += " " //Add one space.
+		output += "Production routines improved."
 	return output
 
-
-/obj/machinery/r_n_d/fabricator/proc/sync(silent=null)
-	var/new_data=0
-	var/found = 0
-	var/obj/machinery/computer/rdconsole/console
+/obj/machinery/r_n_d/fabricator/proc/sync()
 	if(busy)
 		visible_message("[bicon(src)] <b>[src]</b> beeps, \"Please wait for completion of current operation.\"")
 		return
+	var/new_data = 0
+	var/obj/machinery/computer/rdconsole/console
 	if(linked_console)
 		console = linked_console
 	else
 		visible_message("[bicon(src)] <b>[src]</b> beeps, \"Not connected to a server. Please connect from a local console first.\"")
 	if(console)
+		var/datum/tech/old_materials = files.known_tech["materials"].level
+		var/datum/tech/old_programming = files.known_tech["programming"].level
 		for(var/ID in console.files.known_tech)
 			var/datum/tech/T = console.files.known_tech[ID]
 			if(T)
@@ -467,19 +469,14 @@
 				files.AddDesign2Known(D)
 		files.RefreshResearch()
 		var/i = convert_designs()
-		var/tech_output = update_tech()
-		if(!silent)
-			temp = "Processed [i] equipment designs.<br>"
-			temp += tech_output
-			temp += "<a href='?src=\ref[src];clear_temp=1'>Return</a>"
-			updateUsrDialog()
+		var/tech_output = update_tech(old_materials, old_programming)
 		if(i || tech_output)
 			new_data=1
-	if(new_data)
-		visible_message("[bicon(src)] <b>[src]</b> beeps, \"Successfully synchronized with R&D server. New data processed.\"")
-	if(!silent && !found)
-		temp = "Unable to connect to local R&D Database.<br>Please check your connections and try again.<br><a href='?src=\ref[src];clear_temp=1'>Return</a>"
-	updateUsrDialog()
+		if(new_data)
+			visible_message("[bicon(src)] <b>[src]</b> beeps, \"Successfully synchronized with R&D server. New data processed.\"")
+		if(tech_output)
+			visible_message("[bicon(src)] <b>[src]</b> beeps, \"[tech_output]\"")
+		update_coeff()
 
 /obj/machinery/r_n_d/fabricator/kick_act(mob/living/H)
 	..()
@@ -618,7 +615,6 @@
 
 	if(href_list["sync"])
 		queue = list()
-		temp = "Updating local R&D database..."
 		updateUsrDialog()
 		spawn(30)
 			sync()
@@ -694,4 +690,8 @@
 	return 0
 
 /obj/machinery/r_n_d/fabricator/proc/update_buffer_size()
+	return
+
+//Mainly used by fabricators in fabricators.dm
+/obj/machinery/r_n_d/proc/update_coeff()
 	return

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -146,7 +146,6 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		linked_lathe					= null
 
 /obj/machinery/computer/rdconsole/proc/Maximize()
-	files.known_tech = tech_list.Copy()
 	for(var/ID in files.known_tech)
 		var/datum/tech/KT = files.known_tech[ID]
 		if(KT.level < KT.max_level)
@@ -222,7 +221,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 					linked_imprinter = D
 	if(linked_lathe)
 		linked_lathe.part_sets = part_sets
-	return
+	updated_research()
 
 //Have it automatically push research to the centcomm server so wild griffins can't fuck up R&D's work --NEO
 /obj/machinery/computer/rdconsole/proc/griefProtection()
@@ -250,6 +249,14 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 /obj/machinery/computer/rdconsole/process()
 	griefProtection()
 */
+
+//This will get called whenever techs are changed so that it goes through some of its linked machines and updates them
+//Currently only covers the Protolathe and Circuit Imprinter, because they do not have dedicated procs for updating their tech level
+/obj/machinery/computer/rdconsole/proc/updated_research()
+	if(linked_lathe)
+		linked_lathe.update_coeff()
+	if(linked_imprinter)
+		linked_imprinter.update_coeff()
 
 /obj/machinery/computer/rdconsole/attackby(var/obj/item/weapon/D as obj, var/mob/user as mob)
 	if(..())
@@ -302,6 +309,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 					var/list/temp_tech = linked_destroy.ConvertReqString2List(linked_destroy.loaded_item.origin_tech)
 					for(var/T in temp_tech)
 						files.UpdateTech(T, temp_tech[T])
+						updated_research()
 				if(linked_destroy.loaded_item.reliability < 100 && linked_destroy.loaded_item.crit_fail)
 					files.UpdateDesign(linked_destroy.loaded_item.type)
 
@@ -364,6 +372,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 							server_processed = 1
 						if(!istype(S, /obj/machinery/r_n_d/server/centcom) && server_processed)
 							S.produce_heat(100)
+					updated_research()
 					screen = CONSOLE_SETTINGS_MENU
 					updateUsrDialog()
 
@@ -390,6 +399,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				part_sets[t_disk.stored.new_category] = list()
 				if(linked_lathe)
 					linked_lathe.part_sets = part_sets
+			updated_research()
 			updateUsrDialog()
 			griefProtection() //Update centcomm too
 
@@ -402,6 +412,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		spawn(50)
 			Maximize()
 			screen = CONSOLE_MENU
+			updated_research()
 			updateUsrDialog()
 			griefProtection() //Update centcomm too
 
@@ -420,6 +431,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				t_disk.stored = create_tech(T.id)
 				t_disk.stored.level = T.level
 				break
+		updated_research()
 		screen = CONSOLE_DISK_TECH_MENU
 
 	else if(href_list["updt_design"]) //Updates the research holder with design data from the design disk.
@@ -655,6 +667,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			screen = DATABASE_UPDATE
 			qdel(files)
 			files = new /datum/research(src)
+			updated_research()
 			spawn(20)
 				screen = CONSOLE_SETTINGS_MENU
 				updateUsrDialog()

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -53,7 +53,7 @@ var/global/list/hidden_tech = list(
 	)
 
 /datum/research								//Holder for all the existing, archived, and known tech. Individual to console.
-	var/list/known_tech = list()			//List of locally known tech.
+	var/list/datum/tech/known_tech = list()			//List of locally known tech. Called with /datum/tech to be able to call tech variables directly
 	var/list/known_designs = list()			//List of available designs (at base reliability).
 	var/alphabetsort = FALSE				//Is it sorted alphabetically?
 


### PR DESCRIPTION
- Fixed a bug that has been active since at least #20587 where material and data research did not affect Protolathes and Circuit Imprinters. This was because they were only checking for the tech levels they had, which they never acquired. Now they will check the linked console's levels if there's any. Each level in Materials above 1 will reduce material costs by 4%, and each level in Data above 1 will reduce the time it takes for something to be produced by 4%. Exosuit Fabricators and Pod Fabricators are unaffected because it worked as intended on their end. This change is facilitated by a new proc called updated_research() that has been appended to multiple lines of code that change tech levels. Also added support so that a machine with a higher stored research level that is linked to a console with a lower research level does not have its tech overridden by the console. Thanks Kvistor for helping with in-game testing!
- Repurposed some non-functional code, now the Exosuit Fabricators and Pod Fabricators will tell you if the research they have gained have improved their production capabilities.

<img src="https://github.com/user-attachments/assets/1170ed55-d958-4a96-ada1-e9902efa957e" />

- Fixed a bug where if an admin used the MAXIMIZE button on an R&D console it would cause all subsequent R&D machinery to be spawned with high tech levels. This happened because tech_list, a list of all default non-hidden techs in the game, contains datums and those datums were copied over to a new list in the process, but it does not clone the datums, it merely makes the list they were cloned to reference them, so what happened to the new list affected tech_list and thus the default state of techs that new local techs would reference and paste, and the new list had its techs increased to a higher level. This fix also enables Nanotrasen research to be maximized by an admin, if it has been unlocked in the machine.
- Removed the "temp" variable on fabricators because it didn't do anything, was likely rendered non-functional at some point in the past.
- Changed known_tech into a different type of list that supports calling tech variables (ie: known_tech[materials].level) directly and switched a few procs for slightly cleaner code. Thanks @Exxion for providing step-by-step guidance!

:cl:
 * rscadd: Exosuit Fabricators and Spacepod Fabricators will now provide feedback messages after syncing over whether the research they have acquired has improved them. 
 * bugfix: Fixed a 7 year old bug where Materials and Data research did not affect the Protolathe nor the Circuit Imprinter. Now they will both benefit from reduced material costs and faster production granted by research.