### PR TITLE
Freezers/heaters now cool/heat faster with better stock parts.

### DIFF
--- a/code/game/machinery/Freezer.dm
+++ b/code/game/machinery/Freezer.dm
@@ -40,10 +40,9 @@
 	for(var/obj/item/weapon/stock_parts/SP in component_parts)
 		if(istype(SP, /obj/item/weapon/stock_parts/micro_laser))
 			lasercount += SP.rating-1
-	temp_offset = initial(temp_offset) - 5*lasercount
-	current_heat_capacity = 1000 + (1000 * lasercount) //Allows it to cool the gas faster
-	if(lasercount >= 6) //Tier 3 parts minimum, give it a nice boost
-		current_heat_capacity += 10000
+	var/laser_modifier = (lasercount >= 9) ? 8 : 5 //Upgrading the parts to tier 4 allows it to cool the gas to 1.15K (temp_offset = -72)
+	temp_offset = initial(temp_offset) - laser_modifier * lasercount
+	current_heat_capacity = 1000 + (500 * lasercount) //Makes it cool the gas faster when upgraded, with tier 3 parts each freezer will have the cooling power of 4 freezers
 
 /obj/machinery/atmospherics/unary/cold_sink/freezer/update_icon()
 	if(node1)
@@ -213,10 +212,9 @@
 	for(var/obj/item/weapon/stock_parts/SP in component_parts)
 		if(istype(SP, /obj/item/weapon/stock_parts/micro_laser))
 			lasercount += SP.rating-1
-	temp_offset = initial(temp_offset) + 5*lasercount
-	current_heat_capacity = 1000 + (1000 * lasercount)
-	if(lasercount >= 6)
-		current_heat_capacity += 10000
+	var/laser_modifier = (lasercount >= 9) ? 100 : 5 //Tier 4 parts allow it to heat the gas up to 1453.15K
+	temp_offset = initial(temp_offset) + laser_modifier * lasercount
+	current_heat_capacity = 1000 + (500 * lasercount)
 
 /obj/machinery/atmospherics/unary/heat_reservoir/heater/update_icon()
 	if(node1)

--- a/code/game/machinery/Freezer.dm
+++ b/code/game/machinery/Freezer.dm
@@ -41,6 +41,7 @@
 		if(istype(SP, /obj/item/weapon/stock_parts/micro_laser))
 			lasercount += SP.rating-1
 	temp_offset = initial(temp_offset) - 5*lasercount
+	current_heat_capacity = 1000 + (3000 * lasercount) //Allows it to cool the gas faster
 
 /obj/machinery/atmospherics/unary/cold_sink/freezer/update_icon()
 	if(node1)
@@ -211,6 +212,7 @@
 		if(istype(SP, /obj/item/weapon/stock_parts/micro_laser))
 			lasercount += SP.rating-1
 	temp_offset = initial(temp_offset) + 5*lasercount
+	current_heat_capacity = 1000 + (3000 * lasercount)
 
 /obj/machinery/atmospherics/unary/heat_reservoir/heater/update_icon()
 	if(node1)

--- a/code/game/machinery/Freezer.dm
+++ b/code/game/machinery/Freezer.dm
@@ -41,7 +41,9 @@
 		if(istype(SP, /obj/item/weapon/stock_parts/micro_laser))
 			lasercount += SP.rating-1
 	temp_offset = initial(temp_offset) - 5*lasercount
-	current_heat_capacity = 1000 + (3000 * lasercount) //Allows it to cool the gas faster
+	current_heat_capacity = 1000 + (1000 * lasercount) //Allows it to cool the gas faster
+	if(lasercount >= 6) //Tier 3 parts minimum, give it a nice boost
+		current_heat_capacity += 10000
 
 /obj/machinery/atmospherics/unary/cold_sink/freezer/update_icon()
 	if(node1)
@@ -212,7 +214,9 @@
 		if(istype(SP, /obj/item/weapon/stock_parts/micro_laser))
 			lasercount += SP.rating-1
 	temp_offset = initial(temp_offset) + 5*lasercount
-	current_heat_capacity = 1000 + (3000 * lasercount)
+	current_heat_capacity = 1000 + (1000 * lasercount)
+	if(lasercount >= 6)
+		current_heat_capacity += 10000
 
 /obj/machinery/atmospherics/unary/heat_reservoir/heater/update_icon()
 	if(node1)


### PR DESCRIPTION
Makes stock parts affect the current_heat_capacity variable of freezers and heaters, allowing them to influence a pipe network's gas much faster when upgraded. With tier 3 parts each freezer and heater will have the power/speed of 4 freezers and heaters respectively.
Upgrading a machine with tier 4 parts (only available through Xenoarchaeology and sometimes traders, requiring phazon if replicated through Mechanics) will allow it to influence the temperatures much more; freezers will be able to reach 1.15K and heaters will be able to reach 1453.15K. 

:cl:
 * tweak: Freezers and heaters will now cool/heat gases faster when upgraded with components. In addition, their possible minimum/maximum temperatures will become much more extreme when upgraded with rare tier 4 parts.
