### PR TITLE
Massive "Heal Other" spell buff

### DIFF
--- a/code/modules/spells/targeted/heal.dm
+++ b/code/modules/spells/targeted/heal.dm
@@ -8,20 +8,28 @@
 
 	school = "transmutation"
 	charge_cooldown_max = 30 SECONDS
-	cooldown_reduc = 7.5 SECONDS
-	cooldown_min = 15 SECONDS
+	cooldown_reduc = 10 SECONDS
+	cooldown_min = 10 SECONDS
 	invocation = "DI TIUB SEEL IM"
 	invocation_type = SP_INV_SHOUT
 	message = "<span class='sinister'>You feel refreshed.<span>"
-	level_max = list(SP_TOTAL = 3, SP_SPEED = 2, SP_POWER = 1, SP_RANGE = 1)
+	level_max = list(SP_TOTAL = 4, SP_SPEED = 2, SP_POWER = 1, SP_RANGE = 1)
 	valid_targets = list(/mob/living)
 
 	max_targets = 1
 
-	amt_dam_fire = -15
-	amt_dam_brute = -15
-	amt_dam_oxy = -15
-	amt_dam_tox = -15
+	amt_dam_fire = -50
+	amt_dam_brute = -50
+	amt_dam_oxy = -50
+	amt_dam_tox = -50
+
+	amt_knockdown = -5
+	amt_paralysis = -5
+	amt_stunned = -5
+
+	amt_dizziness = -10
+	amt_confused = -10
+	amt_stuttering = -10
 
 	spell_flags = WAIT_FOR_CLICK
 
@@ -32,7 +40,7 @@
 		if(spell_levels[SP_RANGE])
 			if(T != user)
 				aoe_heal(T)
-		if(istype(T, /mob/living) && T != user)
+		else if(istype(T, /mob/living) && T != user)
 			var/mob/living/L = T
 			L.vis_contents += new /obj/effect/overlay/heal(L)
 			apply_spell_damage(L)
@@ -48,11 +56,15 @@
 		if(SP_POWER)
 			spell_levels[SP_POWER]++
 			name = "Superior " + name
-			return "The spell now has a chance to mend internal wounds."
+			return "The spell now has a chance to mend internal wounds and will now stop any bleeding, both external and internal."
 		if(SP_RANGE)
 			spell_levels[SP_RANGE]++
 			name = "Splashing " + name
 			return "The spell will now affect a small area around the target."
+
+// All upgrades cost 10 points only
+/spell/targeted/heal/get_upgrade_price(upgrade_type)
+	return 10
 
 /spell/targeted/heal/get_upgrade_info(upgrade_type, level)
 	switch(upgrade_type)
@@ -62,15 +74,15 @@
 			return "Reduce this spell's cooldown by [cooldown_reduc/10] seconds."
 		if(SP_POWER)
 			if(spell_levels[SP_POWER] >= level_max[SP_POWER])
-				return "This spell already has a chance of mending internal injuries!"
-			return "Grants the spell a chance of mending internal injuries in the primary target."
+				return "This spell already has a chance of mending internal injuries and sealing wounds!"
+			return "Grants the spell a chance of mending internal injuries in the primary target and makes it stop all bleeding."
 		if(SP_RANGE)
 			if(spell_levels[SP_RANGE] >= level_max[SP_RANGE])
 				return "This spell already affects a small area around the target!"
 			return "Expands the spell's effects to a small area around the target."
 
 
-//50% chance per organ/limb of healing all its internal injuries
+//50% chance per organ/limb of healing all its internal injuries, and stops all bleeding
 /spell/targeted/heal/proc/strong_heal(var/mob/living/carbon/human/H)
 	for(var/datum/organ/internal/I in H.internal_organs)
 		if(prob(50))
@@ -85,6 +97,9 @@
 			O.status &= ~ORGAN_BROKEN
 			O.status &= ~ORGAN_SPLINTED
 			O.status &= ~ORGAN_BLEEDING
+		for(var/datum/wound/W in O.wounds)
+			if(W.bleed_timer)
+				W.bleed_timer = 0 //Stop any bleeding
 
 /spell/targeted/heal/proc/aoe_heal(var/target)
 	for(var/mob/living/M in range(1, target))
@@ -92,6 +107,8 @@
 			continue
 		M.vis_contents += new /obj/effect/overlay/heal(M)
 		apply_spell_damage(M)
+		if(spell_levels[SP_POWER] && istype(M, /mob/living/carbon/human))
+			strong_heal(M)
 
 /obj/effect/overlay/heal
 	name = "sparkles"

--- a/code/modules/spells/targeted/targeted.dm
+++ b/code/modules/spells/targeted/targeted.dm
@@ -193,9 +193,9 @@ Targeted spells have two useful flags: INCLUDEUSER and SELECTABLE. These are exp
 	target.adjustOxyLoss(amt_dam_oxy)
 	target.adjustBrainLoss(amt_dam_brain)
 	//disabling
-	target.Knockdown(amt_knockdown)
-	target.Paralyse(amt_paralysis)
-	target.Stun(amt_stunned)
+	target.AdjustKnockdown(amt_knockdown)
+	target.AdjustParalysis(amt_paralysis)
+	target.AdjustStunned(amt_stunned)
 	if(amt_knockdown || amt_paralysis || amt_stunned)
 		target.unlock_from()
 	target.eye_blind += amt_eye_blind


### PR DESCRIPTION
I interacted with it during a round, decided to look at the code and then found out that it's really bad.
It heals 15 brute, burn, toxin and oxygen damage with every cast, at a base cooldown of 30 seconds. This spell barely even gets used because most wizards are solitary. I decided to improve it to actually make it useful for wizards to get in case they get apprentices via the Apprentice Contract or they want to heal their minions. Or worse, heal the crew.
I must emphasize that wizards CANNOT use this on themselves. At all. They do NOT benefit from this spell, they can only benefit others with it, which is why I have gone with some more extreme buffs.

- Increased healing from 15 to 50.
- Reduced minimum cooldown to 10 seconds and the cooldown reduction per upgrade to 10 seconds.
- Now reduces stuns by 10 seconds.
- Made the additional non-quickening upgrades cost 10 points instead of 20.
- Reduces disorienting effects (confused, dizziness, stuttering) by 20 seconds.
- Allowed it to be fully upgraded instead of only allowing 3 out of 4 upgrades.
- Empowered version now stops all bleeding too.
- Fixed a bug where targeting someone while having the splash upgrade would heal them twice.
- Fixed a bug where the AoE heal would not apply the empowered healing to users in its AoE, only to the target.

For something that can only be used on others this should make it MUCH more appealing. It costs 60 points to fully upgrade the spell. This should maybe even encourage Civil War of Casters wizards to stick together and heal each other instead of causing station-ruining mayhem separately. It should also make it much more appealing for wizards wanting to keep their apprentices alive, or minion-making wizards that control constructs or zombies.
Also tweaked the spell code a bit to allow for negative values on the damage types to do something.

:cl:
 * bugfix: Fixed a bug where the "Heal Other" spell would apply its healing twice to a target if it had the splashing upgrade.
 * bugfix: Fixed a bug where the "Heal Other" spell would not apply its empowered healing to targets in an AoE.
 * tweak: The "Heal Other" spell has been greatly buffed. Its healing is now slightly more than tripled, the cooldown reduction per cooldown upgrade is an additional 2.5 seconds, it now reduces stun durations by 10 seconds and disorienting effects by 20 seconds, can now be fully upgraded instead of only being upgraded 3 times out of 4, had its empowerment and range upgrade costs reduced to 10 points, and the empowered version now also stops bleeding.