### PR TITLE
Restores the Fission Reactor's plasma into phazon reaction.

### DIFF
--- a/code/modules/reagents/fission.dm
+++ b/code/modules/reagents/fission.dm
@@ -21,8 +21,9 @@
 /datum/reagent/thorium/irradiate(var/list/current_reagents=null) //purpose: generates uranium, as well as some byproducts
 	return list(URANIUM=0.55, RADON=0.25, LEAD=0.1, THALLIUM=0.1)
 
+/datum/reagent/plasma/irradiate(var/list/current_reagents=null) //primary purpose: a very lossy way to get phazon via plasma. powergaymers rejoice.
+	return list(PHAZON=0.05) //fun fact. 1 sheet of plas = 20 units. 1 sheet of phaz = 1 unit. funny, huh?
 
-	
 /datum/reagent/degeneratecalcium/irradiate(var/list/current_reagents=null)
 	return list(REGENERATECALCIUM=1.0)
 

--- a/code/modules/reagents/reagents/reagents_material.dm
+++ b/code/modules/reagents/reagents/reagents_material.dm
@@ -79,6 +79,8 @@
 	description = "Plasma in its liquid form."
 	reagent_state = REAGENT_STATE_LIQUID
 	color = "#500064" //rgb: 80, 0, 100
+	fission_time=18000 //5 hours.
+	fission_absorbtion=8333.333
 
 /datum/reagent/plasma/New()
 	..()


### PR DESCRIPTION
## What this does
Fission reactors can once again turn plasma into phazon, at the original lossy rate (20u of Plasma per 1u of Phazon). Literally copypastes the original line pre-removal.
## Why it's good
Gives you another source of Phazon that isn't slimes, and it is balanced by the fact that to get 3u of phazon it takes like 40 minutes, not counting the reactor setup time.
:cl:
 * rscadd: Nanotrasen Engineers patched a faulty sensor on Fission Reactor controllers, letting them turn Plasma into Phazon once again, at the original rate (20u Plasma per 1u Phazon, at a heavy time investment).