### PR TITLE
Item printing fix and R&D recycling exploit patch

### DIFF
--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -340,6 +340,7 @@
 
 /obj/item/weapon/storage/lockbox/oneuse
 	desc = "A locked box. When unlocked, the case will fall apart."
+	starting_materials = null // No recycling the one-use lockboxes
 
 /obj/item/weapon/storage/lockbox/AltClick()
 	if(verb_togglelock())
@@ -411,7 +412,7 @@
 /obj/item/weapon/storage/lockbox/diskettebox/large/open
 	icon_state = "map_diskbox_large_open"
 	locked = FALSE
-	
+
 /obj/item/weapon/storage/lockbox/diskettebox/large/nolock
 	startswithelectronics = FALSE
 	locked = FALSE

--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -120,6 +120,7 @@
 	item_state = "laserscalpel2"
 	force = 15.0
 	toolspeed = 0.4
+	starting_materials = list(MAT_IRON = 5000, MAT_GLASS = 2500, MAT_URANIUM = 250)
 
 /obj/item/tool/surgicaldrill
 	name = "surgical drill"
@@ -260,6 +261,7 @@
 	force = 15.0
 	toolspeed = 0.4
 	heat_production = 10000000
+	starting_materials = list(MAT_IRON = 10000, MAT_GLASS = 5000, MAT_URANIUM = 250)
 
 /obj/item/tool/scalpel/laser/tier2/New()
 	..()
@@ -344,7 +346,6 @@
 	flammable = TRUE
 
 	origin_tech = Tc_MATERIALS + "=1;" + Tc_BIOTECH + "=3"
-	var/usage_amount = 10
 	surgerysound = 'sound/items/fixovein.ogg'
 
 /obj/item/tool/FixOVein/clot

--- a/code/game/objects/items/weapons/switchtool.dm
+++ b/code/game/objects/items/weapons/switchtool.dm
@@ -35,6 +35,7 @@
 											"/obj/item/device/multitool:multitool" = null)
 	var/obj/item/deployed //what's currently in use
 	var/can_remove_items = TRUE //if you can remove items with a screwdriver
+	var/spawn_empty = FALSE // In case you want switchtools that do not contain items but can be fitted out later
 
 /obj/item/weapon/switchtool/preattack(atom/target, mob/user, proximity_flag, click_parameters)
 	if(istype(target, /obj/item/weapon/storage) && !istype(target, /obj/item/weapon/storage/pill_bottle)) //we place automatically, but want pill bottles to be meltable
@@ -73,6 +74,8 @@
 
 /obj/item/weapon/switchtool/New()
 	..()
+	if(spawn_empty) //No new modules
+		return
 	for(var/module in stored_modules) //making the modules
 		var/new_type = text2path(get_module_type(module))
 		stored_modules[module] = new new_type(src)
@@ -339,6 +342,9 @@
 						"/obj/item/tool/bonesetter:bone setter" = null,
 						"/obj/item/tool/FixOVein:fixovein" = null,
 						"/obj/item/tool/bonegel:bonegel"= null)
+
+/obj/item/weapon/switchtool/surgery/empty
+	spawn_empty = TRUE
 
 /obj/item/weapon/switchtool/surgery/undeploy(mob/user)
 	playsound(src, undeploy_sound, 10, 1)

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -153,8 +153,12 @@ The required techs are the following:
 //obj/O: The freshly created object
 //obj/machinery/r_n_d/fabricator/F: the machine where the object was just manufactured
 /datum/design/proc/after_craft(var/obj/O, var/obj/machinery/r_n_d/fabricator/F)
-	return
-
+// Reduce the printed item materials accordingly
+	for(var/obj/item/I in O.contents)
+		if(!I.materials)
+			continue
+		for(var/matID in I.materials.storage)
+			I.materials.storage[matID] = F.get_resource_cost_w_coeff_no_design(I.materials.storage[matID], matID)
 ////////////////////////////////////////
 //Disks for transporting design datums//
 ////////////////////////////////////////

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -70,6 +70,7 @@ The required techs are the following:
 	var/locked = 0						//If true it will spawn inside a lockbox with currently sec access
 	var/list/req_lock_access			//Sets the access for the lockbox that a locked item spawns in
 	var/category = "Misc"				//Primarily used for Mech Fabricators, but can be used for anything
+	var/use_design_materials = TRUE		//Determines whether the printed item will have the design's material costs as its materials
 
 //A proc to calculate the reliability of a design based on tech levels and innate modifiers.
 //Input: A list of /datum/tech; Output: The new reliabilty.

--- a/code/modules/research/designs/medical.dm
+++ b/code/modules/research/designs/medical.dm
@@ -7,6 +7,7 @@
 	materials = list(MAT_IRON = 400, MAT_GLASS = 125)
 	category = "Medical"
 	build_path = /obj/item/stack/medical/bruise_pack
+	use_design_materials = FALSE //Cannot be recycled
 
 /datum/design/ointment
 	name = "Ointment"
@@ -17,6 +18,7 @@
 	materials = list(MAT_IRON = 400, MAT_GLASS = 125)
 	category = "Medical"
 	build_path = /obj/item/stack/medical/ointment
+	use_design_materials = FALSE
 
 /datum/design/adv_bruise_pack
 	name = "Advanced trauma kit"
@@ -27,6 +29,7 @@
 	materials = list(MAT_IRON = 600, MAT_GLASS = 250)
 	category = "Medical"
 	build_path = /obj/item/stack/medical/advanced/bruise_pack
+	use_design_materials = FALSE
 
 /datum/design/adv_ointment
 	name = "Advanced burn kit"
@@ -37,6 +40,7 @@
 	materials = list(MAT_IRON = 600, MAT_GLASS = 250)
 	category = "Medical"
 	build_path = /obj/item/stack/medical/advanced/ointment
+	use_design_materials = FALSE
 
 /datum/design/adv_reagent_scanner
 	name = "Advanced Reagent Scanner"

--- a/code/modules/research/designs/robotics.dm
+++ b/code/modules/research/designs/robotics.dm
@@ -82,6 +82,7 @@
 	materials = list(MAT_IRON = 7000, MAT_GLASS = 7000)
 	category = "Robotics"
 	build_path = /obj/item/stack/nanopaste
+	use_design_materials = FALSE // Cannot be recycled because stack code doesn't work well with recycling
 
 /datum/design/robotanalyzer
 	name = "Cyborg Analyzer"

--- a/code/modules/research/designs/surgery.dm
+++ b/code/modules/research/designs/surgery.dm
@@ -4,9 +4,10 @@
 	id = "laserscalpel1"
 	req_tech = list(Tc_MATERIALS = 3, Tc_ENGINEERING = 2, Tc_BIOTECH = 2)
 	build_type = PROTOLATHE
-	materials = list (MAT_IRON = 10000, MAT_GLASS = 5000)
+	materials = list (MAT_IRON = 15000, MAT_GLASS = 7500) //Contains both the scalpel and the cautery
 	category = "Surgery"
 	build_path = /obj/item/tool/scalpel/laser
+	use_design_materials = FALSE //Split between the scalpel and cautery
 
 /datum/design/laserscalpel2
 	name = "High Precision Laser Scalpel"
@@ -14,9 +15,10 @@
 	id = "laserscalpel2"
 	req_tech = list(Tc_MATERIALS = 4, Tc_ENGINEERING = 3, Tc_BIOTECH = 4)
 	build_type = PROTOLATHE
-	materials = list (MAT_IRON = 10000, MAT_GLASS = 5000, MAT_URANIUM = 500)
+	materials = list (MAT_IRON = 15000, MAT_GLASS = 7500, MAT_URANIUM = 500)
 	category = "Surgery"
 	build_path = /obj/item/tool/scalpel/laser/tier2
+	use_design_materials = FALSE
 
 /datum/design/incisionmanager
 	name = "Surgical Incision Manager"

--- a/code/modules/research/designs/surgery.dm
+++ b/code/modules/research/designs/surgery.dm
@@ -96,7 +96,7 @@
 		if(!I.materials)
 			continue
 		for(var/matID in I.materials.storage)
-			I.materials.storage[matID] = F.get_resource_cost_w_coeff(src, matID)
+			I.materials.storage[matID] = F.get_resource_cost_w_coeff_no_design(I.materials.storage[matID], matID)
 
 /datum/design/empty_switchtool
 	name = "Surgeon's Switchtool (Empty)"

--- a/code/modules/research/designs/surgery.dm
+++ b/code/modules/research/designs/surgery.dm
@@ -79,14 +79,34 @@
 	build_path = /obj/item/tool/surgicaldrill/diamond
 
 /datum/design/switchtool
-	name = "Surgeon's Switchtool"
+	name = "Surgeon's Switchtool (Full)"
 	desc = "A switchtool containing most of the necessary items for impromptu surgery. For the surgeon on the go."
 	id = "switchtool"
 	req_tech = list(Tc_MATERIALS = 5, Tc_BLUESPACE = 3, Tc_BIOTECH = 3)
 	build_type = PROTOLATHE
-	materials = list (MAT_IRON = 10000, MAT_GLASS = 5000)
+	materials = list (MAT_IRON = 90000, MAT_GLASS = 40000) //Contains tools worth 75000 metal and 40000 glass, the switchtool itself has 15000 metal
 	category = "Surgery"
 	build_path = /obj/item/weapon/switchtool/surgery
+	use_design_materials = FALSE //So that the switchtool doesn't contain 90000 metal and 40000 glass
+
+// Reduce the printed item materials accordingly
+/datum/design/switchtool/after_craft(obj/O, obj/machinery/r_n_d/fabricator/F)
+	..()
+	for(var/obj/item/I in O.contents)
+		if(!I.materials)
+			continue
+		for(var/matID in I.materials.storage)
+			I.materials.storage[matID] = F.get_resource_cost_w_coeff(src, matID)
+
+/datum/design/empty_switchtool
+	name = "Surgeon's Switchtool (Empty)"
+	desc = "An empty switchtool, ready to be fitted with surgery tools. For the surgeon on the go."
+	id = "empty_switchtool"
+	req_tech = list(Tc_MATERIALS = 5, Tc_BLUESPACE = 3, Tc_BIOTECH = 3)
+	build_type = PROTOLATHE
+	materials = list(MAT_IRON = 15000)
+	category = "Surgery"
+	build_path = /obj/item/weapon/switchtool/surgery/empty
 
 /datum/design/surgery_rollerbed
 	name = "Mobile Operating Table"

--- a/code/modules/research/fabricators.dm
+++ b/code/modules/research/fabricators.dm
@@ -342,7 +342,8 @@
 				being_built.materials.addAmount(matID, get_resource_cost_w_coeff(part,matID)) //slap in what we built with - matching the cost
 		else if(being_built.materials) // Check if it has materials, and if so reduce them accordingly
 			for(var/matID in being_built.materials.storage)
-				being_built.materials.storage[matID] = get_resource_cost_w_coeff_no_design(being_built.materials.storage[matID], matID)
+				if(being_built.materials.storage[matID]) // Only do this for materials that the printed item actually has
+					being_built.materials.storage[matID] = get_resource_cost_w_coeff_no_design(being_built.materials.storage[matID], matID)
 		if(part.locked && research_flags &LOCKBOXES)
 			var/obj/item/weapon/storage/lockbox/L
 			//if(research_flags &TRUELOCKS)

--- a/code/modules/research/fabricators.dm
+++ b/code/modules/research/fabricators.dm
@@ -340,6 +340,9 @@
 					continue
 				being_built.materials.storage[matID] = 0 // Reset the item's resource cost and use the design's.
 				being_built.materials.addAmount(matID, get_resource_cost_w_coeff(part,matID)) //slap in what we built with - matching the cost
+		else if(being_built.materials) // Check if it has materials, and if so reduce them accordingly
+			for(var/matID in being_built.materials.storage)
+				being_built.materials.storage[matID] = get_resource_cost_w_coeff_no_design(being_built.materials.storage[matID], matID)
 		if(part.locked && research_flags &LOCKBOXES)
 			var/obj/item/weapon/storage/lockbox/L
 			//if(research_flags &TRUELOCKS)
@@ -499,6 +502,10 @@
 
 /obj/machinery/r_n_d/fabricator/proc/get_resource_cost_w_coeff(var/datum/design/part as obj,var/resource as text, var/roundto=1)
 	return max(1,round(part.materials[resource]*resource_coeff, roundto))
+
+// When you just want to convert a value directly into a resource cost without relying on the design
+/obj/machinery/r_n_d/fabricator/proc/get_resource_cost_w_coeff_no_design(var/value, var/resource, var/roundto = 1)
+	return max(1, round(value*resource_coeff, roundto))
 
 //produces the adjusted time taken to build a component
 //different fabricators have different modifiers

--- a/code/modules/research/fabricators.dm
+++ b/code/modules/research/fabricators.dm
@@ -332,13 +332,14 @@
 	if(start_end_anims)
 		flick("[base_state]_end",src)
 	if(being_built)
-		if(!being_built.materials)
-			being_built.materials = new /datum/materials(being_built)
-		for(var/matID in part.materials)
-			if(copytext(matID, 1, 2) != "$") //it's not a material, let's ignore it
-				continue
-			being_built.materials.storage = initial_materials.Copy()
-			being_built.materials.addAmount(matID, get_resource_cost_w_coeff(part,matID)) //slap in what we built with - matching the cost
+		if(part.use_design_materials) // Determines whether the printed item will use the design's resource costs for its materials
+			if(!being_built.materials)
+				being_built.materials = new /datum/materials(being_built)
+			for(var/matID in part.materials)
+				if(copytext(matID, 1, 2) != "$") //it's not a material, let's ignore it
+					continue
+				being_built.materials.storage[matID] = 0 // Reset the item's resource cost and use the design's.
+				being_built.materials.addAmount(matID, get_resource_cost_w_coeff(part,matID)) //slap in what we built with - matching the cost
 		if(part.locked && research_flags &LOCKBOXES)
 			var/obj/item/weapon/storage/lockbox/L
 			//if(research_flags &TRUELOCKS)


### PR DESCRIPTION
- Fixed a 10 year old bug where items that were printed at a fabricator would only have one material because the code would repeatedly wipe the list with each material that was being cycled through. For instance an item that costs 5 sheets of metal and 10 sheets of glass to produce would only have 10 sheets of glass as its materials because it was next on the list and it wiped the list of resources as it did so.
- Massively increased the surgeon switchtool's cost to compensate for the material costs of the items included in it, which also prevents an exploit where you could get far more metal and glass out of a switchtool by recycling each individual item in it. Also made the surgeon switchtool's tools actually have their material amounts reduced by the fabricator, which is part of preventing the exploit.
- Added an empty variant of the surgeon switchtool to the Protolathe for those that just want to get on with adding the cool upgraded tools without having to wait a lot of time for the full item to be printed.
- Increased the laser scalpel's price to compensate for the cautery it contains, and added uranium to the upgraded scalpels and cauteries that contain them.
- Added support for designs to have their printed item's material components not be replaced by the design's material costs, which is mostly meant for designs that contain multiple items.
- Can no longer recycle stack-based designs such as the nanopaste or medical kits at a fabricator because stack code doesn't work well with recycling code and neither of those have any starting materials.
- Added a proc for fabricators that's similar to getting the discounted resource cost of an item but without using the design itself, instead it just takes a value for input.
- Can no longer recycle lockboxes because they contain plasma that could be recycled.
- Removed unused "usage_amount" variable for the FixOVein.
- Added support for empty switchtools.

:cl:
 * tweak: Drastically increased the surgeon switchtool's price in the Protolathe to compensate for the material costs of the surgery tools it contains. To compensate for this a second empty variant has been added which doesn't contain any item, which should be printed faster than the full variant.
 * tweak: Nanopaste, medical kits and lockboxes printed from fabricators can no longer be recycled.
 * bugfix: Fixed a decade-old bug where items printed at fabricators would only contain one material. This happened because as the code went through each material to readjust it when printed it would reset the list of materials each time.
 * bugfix: Contents of printed items at fabricators such as the Protolathe will now also have their materials adjusted.
 * bugfix: The high-precision laser scalpel and high-precision laser cautery now contain uranium.