### PR TITLE
Fixes skull capture objective on low populations

### DIFF
--- a/code/datums/gamemode/objectives/target/syndicate/skulls.dm
+++ b/code/datums/gamemode/objectives/target/syndicate/skulls.dm
@@ -15,7 +15,7 @@
 		for(var/mob/new_player/N in player_list)
 			if(N.ready)
 				living_player_amt++
-	amount = min(rand(2,5),living_player_amt)
+	amount = clamp(rand(2,5),1,living_player_amt)
 	explanation_text = format_explanation()
 	return 1
 

--- a/code/datums/gamemode/objectives/target/syndicate/skulls.dm
+++ b/code/datums/gamemode/objectives/target/syndicate/skulls.dm
@@ -6,7 +6,11 @@
 	return "Capture [amount] trophy skulls (decapitated heads). They must be from NT employees."
 
 /datum/objective/target/skulls/find_target()
-	amount = rand(2,5)
+	var/living_player_amt = player_list.len
+	if (istype(ticker.mode, /datum/gamemode/dynamic))
+		var/datum/gamemode/dynamic/D = ticker.mode
+		living_player_amt = D.living_players.len
+	amount = min(rand(2,5),living_player_amt)
 	explanation_text = format_explanation()
 	return 1
 

--- a/code/datums/gamemode/objectives/target/syndicate/skulls.dm
+++ b/code/datums/gamemode/objectives/target/syndicate/skulls.dm
@@ -7,9 +7,14 @@
 
 /datum/objective/target/skulls/find_target()
 	var/living_player_amt = player_list.len
-	if (istype(ticker.mode, /datum/gamemode/dynamic))
+	if (ticker.current_state >= GAME_STATE_PLAYING && istype(ticker.mode, /datum/gamemode/dynamic))
 		var/datum/gamemode/dynamic/D = ticker.mode
 		living_player_amt = D.living_players.len
+	else if(ticker.current_state < GAME_STATE_PLAYING)
+		living_player_amt = 0
+		for(var/mob/new_player/N in player_list)
+			if(N.ready)
+				living_player_amt++
 	amount = min(rand(2,5),living_player_amt)
 	explanation_text = format_explanation()
 	return 1


### PR DESCRIPTION
[oversight]

## What this does
Closes #38241.

## How it was tested
Forcing syndicate traitor ruleset at roundstart until this showed up, generating it midround in the role panel.

## Changelog
:cl:
 * bugfix: The "capture skulls" antag objective no longer asks for more than the player population at time of assignment.