### PR TITLE
Lets blueprints create areas on the mine

### DIFF
--- a/code/modules/mining/mine_areas.dm
+++ b/code/modules/mining/mine_areas.dm
@@ -15,6 +15,7 @@
 	name = "Mine"
 	icon_state = "unexplored"
 	holomap_draw_override = HOLOMAP_DRAW_FULL
+	construction_zone = TRUE
 
 //TODO: Make all these types inherit from /area/mining_outpost/ instead.
 /area/mine/lobby


### PR DESCRIPTION
[oversight][bugfix][tweak]

## What this does
Closes #37638.

## Why it's good
hobos and other players can now build things in da mines.

## How it was tested
soon

## Changelog
:cl:
 * rscadd: Blueprints and construction permits can now create rooms on the unexplored parts of the mine.