### PR TITLE
Fix only AI being able to hear sound system

### DIFF
--- a/code/modules/sound/sound_listener_context/sound_listener_context.dm
+++ b/code/modules/sound/sound_listener_context/sound_listener_context.dm
@@ -32,7 +32,7 @@
 		var/slc = client.listener_context
 		qdel(slc) // dont ask me why its like this. i wont tell you (i dont know)
 		client.listener_context = null
-		client.listener_context = new /datum/sound_listener_context(client, src, world.view)
+	client.listener_context = new /datum/sound_listener_context(client, src, world.view)
 	return ..()
 
 /mob/living/silicon/ai/Login()


### PR DESCRIPTION
A rogue tab was preventing anything that wasn't an AI getting a `sound_listener_context` created

## How it was tested
- Observed live round non-AI have a `null` `listener_context` on their `client`
- Confirmed in local
- Confirmed removing tab creates the SLC as expected

## Changelog
:cl:
 * bugfix: Fixed a bug that resulted in non-AI being unable to hear sound system sounds