### PR TITLE
Disable OD UnsupportedAccess warning

### DIFF
--- a/tools/ci/od_lints.dm
+++ b/tools/ci/od_lints.dm
@@ -23,6 +23,7 @@
 #pragma DanglingVarType error
 #pragma MissingInterpolatedExpression error
 #pragma AmbiguousResourcePath error
+#pragma UnsupportedAccess disabled
 
 //3000-3999
 #pragma EmptyBlock disabled


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Silences an OpenDream linter regarding IsByondMember().

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Less annoying lint warnings on every PR. While our codebase does compile in OD, it is still entirely unplayable. We can implement an actual fix for this if we ever intend to make our server fully OD-compatible.

## How it was tested
0%

Non-player-facing; no CL