### PR TITLE
Reverts Powercreep "Ups the base engineering hardsuit radiation resistance to 80%" Due to Unpopularity

### DIFF
--- a/code/modules/clothing/spacesuits/rig_subtypes/rig_subtypes.dm
+++ b/code/modules/clothing/spacesuits/rig_subtypes/rig_subtypes.dm
@@ -4,7 +4,7 @@
 	desc = "A special helmet designed for work in a hazardous, low-pressure environment. Has radiation shielding."
 	icon_state = "rig0-engineering"
 	item_state = "eng_helm"
-	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 80)
+	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 50)
 	_color = "engineering"
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	pressure_resistance = 200 * ONE_ATMOSPHERE
@@ -17,7 +17,7 @@
 	desc = "A special suit that protects against hazardous, low pressure environments. Has radiation shielding."
 	icon_state = "rig-engineering"
 	item_state = "eng_hardsuit"
-	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 80)
+	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 50)
 	allowed = list(/obj/item/device/flashlight, /obj/item/weapon/tank, /obj/item/weapon/storage/bag/ore, /obj/item/device/t_scanner, /obj/item/weapon/pickaxe, /obj/item/device/rcd, /obj/item/tool/wrench/socket)
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	pressure_resistance = 200 * ONE_ATMOSPHERE


### PR DESCRIPTION
Reverts vgstation-coders/vgstation13#38144

After waiting the two week period required to test PRs, I see no point for this powercreeping PR. We have suits for radiation, no need to promote further "always in hardsuit" behavior. Additionally, just upgrade your science at science.
In addition, the original should have never been merged at all. Testmerges are for actual features and changes, not pick-and-chosen balance tweaks that have a negative reception.

:cl:
 * tweak: Engineering suit rad resistance reduced from 80% to 50%, pre-change value.