### PR TITLE
Tetris in all maps

### DIFF
--- a/maps/RoidStation.dmm
+++ b/maps/RoidStation.dmm
@@ -61267,6 +61267,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/machinery/computer/tetris,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -133366,6 +133367,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/tcomms_control_room)
+"xtw" = (
+/obj/machinery/computer/tetris,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/prison/cell_block/A)
 "xCq" = (
 /obj/structure/window/reinforced/plasma{
 	dir = 8
@@ -334675,7 +334682,7 @@ dSQ
 ptc
 ptc
 dUp
-dSH
+xtw
 dVj
 dSH
 dVF

--- a/maps/defficiency.dmm
+++ b/maps/defficiency.dmm
@@ -35127,6 +35127,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/computer/tetris,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -110263,6 +110264,12 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor,
 /area/engineering/break_room)
+"lOW" = (
+/obj/machinery/computer/tetris,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/security/prison)
 "lWt" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/stack/rods,
@@ -250025,7 +250032,7 @@ ciO
 cey
 cly
 eRl
-cnX
+lOW
 cpa
 cqd
 crm

--- a/maps/lowfatbagel.dmm
+++ b/maps/lowfatbagel.dmm
@@ -73338,6 +73338,7 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
+/obj/machinery/computer/tetris,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -107164,10 +107165,10 @@
 /turf/simulated/floor/plating,
 /area/research_outpost/hallway)
 "xPB" = (
-/obj/machinery/computer/arcade,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/computer/tetris,
 /turf/simulated/floor/arcade,
 /area/security/perma)
 "xPM" = (

--- a/maps/metaclub.dmm
+++ b/maps/metaclub.dmm
@@ -120003,6 +120003,12 @@
 	icon_state = "grimy"
 	},
 /area/security/interrogation)
+"ovq" = (
+/obj/machinery/computer/tetris,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/prison/rec_room)
 "ovF" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -120550,6 +120556,13 @@
 /area/medical/medbay2{
 	name = "Medbay Storage"
 	})
+"qrw" = (
+/obj/machinery/computer/tetris,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "whitepurple"
+	},
+/area/science/lab)
 "qsF" = (
 /obj/structure/rack,
 /obj/item/weapon/gun/energy/gun{
@@ -236522,7 +236535,7 @@ cgo
 cgB
 cje
 cks
-clG
+qrw
 cmO
 cnY
 cpq
@@ -1251067,7 +1251080,7 @@ eww
 ewQ
 exj
 exz
-ewr
+ovq
 eyh
 eyF
 etQ

--- a/maps/packedstation.dmm
+++ b/maps/packedstation.dmm
@@ -6612,10 +6612,10 @@
 	},
 /area/security/perma)
 "alu" = (
-/obj/machinery/computer/arcade,
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
+/obj/machinery/computer/tetris,
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},
@@ -12011,6 +12011,7 @@
 	pixel_x = -27;
 	pixel_y = 3
 	},
+/obj/machinery/computer/tetris,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "whitepurple"

--- a/maps/snaxi.dmm
+++ b/maps/snaxi.dmm
@@ -16157,6 +16157,12 @@
 /area/hallway/primary/fore{
 	name = "\improper Taxi Civilian Dock"
 	})
+"aKB" = (
+/obj/machinery/computer/tetris,
+/turf/simulated/floor{
+	icon_state = "purple"
+	},
+/area/science/lab)
 "aKD" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/engine,
@@ -90188,6 +90194,12 @@
 	icon_state = "white"
 	},
 /area/medical/chemistry)
+"yiJ" = (
+/obj/machinery/computer/tetris,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/security/perma)
 "yja" = (
 /obj/machinery/computer/communications,
 /turf/simulated/floor/shuttle,
@@ -120941,7 +120953,7 @@ boY
 bqb
 tca
 qez
-brG
+aKB
 brW
 bss
 bsP
@@ -128828,7 +128840,7 @@ lRT
 xmY
 ssu
 bMt
-bDc
+yiJ
 qGY
 sRS
 bMt

--- a/maps/synergy.dmm
+++ b/maps/synergy.dmm
@@ -7584,6 +7584,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/computer/tetris,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "whitered"
@@ -50861,6 +50862,7 @@
 	icon_state = "warning";
 	tag = "icon-warning (WEST)"
 	},
+/obj/machinery/computer/tetris,
 /turf/simulated/floor{
 	icon_state = "dark vault full"
 	},

--- a/maps/tgstation.dmm
+++ b/maps/tgstation.dmm
@@ -582,6 +582,7 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
 	},
+/obj/machinery/computer/tetris,
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},

--- a/maps/waystation.dmm
+++ b/maps/waystation.dmm
@@ -31058,6 +31058,12 @@
 	},
 /turf/simulated/floor,
 /area/science/chargebay)
+"hve" = (
+/obj/machinery/computer/tetris,
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/science/lab)
 "hvf" = (
 /obj/structure/shuttle/diag_wall/smooth{
 	dir = 4
@@ -39271,6 +39277,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/computer/tetris,
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},
@@ -197146,7 +197153,7 @@ bdS
 bDR
 bSF
 vou
-cRZ
+hve
 dks
 usk
 xZL


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Adds tetris to every map, in science and in perma. The perma machines don't generate research points.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
It's fun.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
I only checked box station.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Tetris was added to every map, in science and in perma.
