### PR TITLE
Makes deff and roid's engi secure storage blast doors start closed

### DIFF
--- a/maps/RoidStation.dmm
+++ b/maps/RoidStation.dmm
@@ -55879,17 +55879,14 @@
 /turf/simulated/floor,
 /area/engineering/engine)
 "caV" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "Secure Storage";
-	name = "secure storage";
-	opacity = 0
-	},
 /obj/machinery/door/firedoor/border_only{
 	name = "Firelock South"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/poddoor{
+	id_tag = "Secure Storage";
+	name = "Engineering Secure Storage"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "brownold";
@@ -55897,13 +55894,6 @@
 	},
 /area/engineering/engine_storage)
 "caW" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "Secure Storage";
-	name = "secure storage";
-	opacity = 0
-	},
 /obj/machinery/door/firedoor/border_only{
 	name = "Firelock South"
 	},
@@ -55913,6 +55903,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/poddoor{
+	id_tag = "Secure Storage";
+	name = "Engineering Secure Storage"
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "brownold";

--- a/maps/defficiency.dmm
+++ b/maps/defficiency.dmm
@@ -35449,11 +35449,12 @@
 /area/engineering/engine_storage)
 "bnB" = (
 /obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
 	id_tag = "Secure Storage";
-	name = "secure storage";
-	opacity = 0
+	name = "Engineering Secure Storage"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1;
+	name = "Firelock North"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_storage)


### PR DESCRIPTION
[defficiency][roid][consistency]

## What this does
makes these consistent with how it is on every other map, including firelocks on deffs ones

## Changelog
:cl:
 * tweak: The engineering secure storage blast doors on Defficiency and Asteroid stations now start closed, in line with other maps.
 * tweak: Defficiency's engineering secure storage blast doors now properly have firelocks.