### PR TITLE
The round will no longer end after one hour of no players online

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -45,7 +45,6 @@ var/stacking_limit = 90
 	var/list/living_antags = list()
 	var/list/dead_players = list()
 	var/list/list_observers = list()
-	var/last_time_of_population = 0
 
 	var/latejoin_injection_cooldown = 0
 	var/midround_injection_cooldown = 0
@@ -672,11 +671,6 @@ var/stacking_limit = 90
 					living_players.Add(M)//yes we're adding a ghost to "living_players", so make sure to properly check for type when testing midround rules
 					continue
 			dead_players.Add(M)//Players who actually died (and admins who ghosted, would be nice to avoid counting them somehow)
-
-	if(living_players.len) //if anybody is around and alive in the current round
-		last_time_of_population = world.time
-	else if(last_time_of_population && world.time - last_time_of_population > 1 HOURS) //if enough time has passed without it
-		ticker.station_nolife_cinematic()
 
 /datum/gamemode/dynamic/proc/GetInjectionChance()
 	var/chance = 0

--- a/code/datums/gamemode/gamemode.dm
+++ b/code/datums/gamemode/gamemode.dm
@@ -247,7 +247,7 @@
 	for(var/datum/role/R in orphaned_roles)
 		if (R.check_win())
 			return 1
-	if(emergency_shuttle.location==2 || ticker.station_was_nuked || ticker.no_life_on_station)
+	if(emergency_shuttle.location==2 || ticker.station_was_nuked)
 		return 1
 	return 0
 

--- a/code/datums/gamemode/sandbox.dm
+++ b/code/datums/gamemode/sandbox.dm
@@ -21,5 +21,5 @@
 	. = ..()
 	if(player_list.len) //if anybody is in the current round
 		last_time_of_players = world.time
-	if(last_time_of_players && world.time - last_time_of_players > 1 HOURS) //if enough time has passed without them
+	if(last_time_of_players && ((world.time - last_time_of_players) > 1 HOURS)) //if enough time has passed without them
 		world.Reboot()

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -41,7 +41,6 @@ var/datum/controller/gameticker/ticker
 
 	var/explosion_in_progress
 	var/station_was_nuked
-	var/no_life_on_station
 	var/revolutionary_victory //If on, Castle can be voted if the conditions are right
 	var/malfunctioning_AI_victory //If on, will play a different credits song
 
@@ -471,33 +470,6 @@ var/datum/controller/gameticker/ticker
 
 	if(cinematic)
 		qdel(cinematic)		//end the cinematic
-
-/datum/controller/gameticker/proc/station_nolife_cinematic(var/override = null)
-	if( cinematic )
-		return	//already a cinematic in progress!
-
-	for (var/datum/html_interface/hi in html_interfaces)
-		hi.closeAll()
-
-	//initialise our cinematic screen object
-	cinematic = new(src)
-	cinematic.icon = 'icons/effects/station_explosion.dmi'
-	cinematic.icon_state = "station_nolife"
-	cinematic.plane = HUD_PLANE
-	cinematic.mouse_opacity = 0
-	cinematic.screen_loc = "1,0"
-
-	//actually turn everything off
-	power_failure(0)
-
-	//If its actually the end of the round, wait for it to end.
-	//Otherwise if its a verb it will continue on afterwards.
-	sleep(300)
-
-	if(cinematic)
-		qdel(cinematic)		//end the cinematic
-
-	no_life_on_station = TRUE
 
 /datum/controller/gameticker/proc/process()
 	if(current_state != GAME_STATE_PLAYING)


### PR DESCRIPTION
This is turning out to be a problem for a bunch of reasons:
- Bars stations from benefiting from long-term power production for later lowpop players to play because the round ends and everything gets reset, discourages players from setting anything up in the first place
- Randomly cycles the map between different stations because it picks a map at random
- Any minimum activity prevents this measure from doing its intended purpose, which makes this more detrimental than anything because the 0-power rounds can be extended by people AFKing in the lobby 

Keeps the cinematic in the code because it's cool, and the sandbox gamemode on the test server will still restart the station after an hour.

:cl:
 * tweak: The round will no longer end automatically after one hour of not having any players.