### PR TITLE
The power outage event can no longer happen under 5 players + a fix

### DIFF
--- a/code/modules/events/event_dynamic.dm
+++ b/code/modules/events/event_dynamic.dm
@@ -88,9 +88,10 @@ var/list/possibleEvents = list()
 	active_with_role["Any"] = 0
 
 	for(var/mob/M in player_list)
-		if(!M.mind || !M.client || M.client.inactivity > 10 * 10 * 60) // longer than 10 minutes AFK counts them as inactive
+		if(!M.mind || !M.client || (M.client.inactivity > 10 * 10 * 60)) // longer than 10 minutes AFK counts them as inactive
 			continue
-
+		if(!istype(M, /mob/living)) //No observers nor players in the lobby
+			continue
 		active_with_role["Any"]++
 
 		if(isrobot(M))

--- a/code/modules/events/grid_check.dm
+++ b/code/modules/events/grid_check.dm
@@ -2,7 +2,9 @@
 	announceWhen		= 5
 
 /datum/event/grid_check/can_start()
-	return 20
+	if(active_with_role["Any"] > 4)
+		return 20
+	return 0
 
 /datum/event/grid_check/setup()
 	endWhen = rand(30,120)

--- a/code/modules/events/grid_check.dm
+++ b/code/modules/events/grid_check.dm
@@ -1,7 +1,7 @@
 /datum/event/grid_check	//NOTE: Times are measured in master controller ticks!
 	announceWhen		= 5
 
-/datum/event/grid_check/can_start()
+/datum/event/grid_check/can_start(var/list/active_with_role)
 	if(active_with_role["Any"] > 4)
 		return 20
 	return 0


### PR DESCRIPTION
It really doesn't contribute anything at such low pop numbers.
Also includes a fix that doesn't count observers nor players in the lobby for in-game event player numbers.

:cl:
 * bugfix: Fixed a bug where in-game events would consider both observers and players in the lobby for whether an event has enough players to run it.
 * tweak: The power outage event will no longer have a chance to happen when there are less than 5 players in the game.