### PR TITLE
Fixes infinite artifact boulders

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -589,7 +589,7 @@ var/list/icon_state_to_appearance = list()
 			if(!(used_digging.diggables & DIG_SOIL)) //if the pickaxe can't dig soil, we don't
 				to_chat(user, "<span class='rose'>You can't dig soft soil with \the [W].</span>")
 				return
-		
+
 			if (dug)
 				to_chat(user, "<span class='rose'>This area has already been dug.</span>")
 				return
@@ -623,6 +623,7 @@ var/list/icon_state_to_appearance = list()
 		return
 	drop_stack(sand_type, src, 5)
 	dug = 1
+	QDEL_NULL(finddatum)
 	//icon_plating = "asteroid_dug"
 	update_icon()
 

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -603,8 +603,9 @@ var/list/icon_state_to_appearance = list()
 				totaldug += finddatum.excavation_level
 				finddatum.update_excav_level(used_digging)
 			if(totaldug >= 100)
-				if(finddatum && finddatum.spawn_boulder(user))
-					finddatum.large_artifact_fail()
+				if(!dug)
+					if(finddatum && finddatum.spawn_boulder(user))
+						finddatum.large_artifact_fail()
 				playsound(src, 'sound/items/shovel.ogg', 50, 1)
 				gets_dug()
 
@@ -623,7 +624,6 @@ var/list/icon_state_to_appearance = list()
 		return
 	drop_stack(sand_type, src, 5)
 	dug = 1
-	QDEL_NULL(finddatum)
 	//icon_plating = "asteroid_dug"
 	update_icon()
 


### PR DESCRIPTION
[bugfix]

## What this does
Closes #38277.

## How it was tested
digging up a large artifact boulder from a depressed digsite

## Changelog
:cl:
 * bugfix: Depressed digsites no longer spawn infinite large artifacts from digging.