### PR TITLE
Adds Mecha Clamps Crate Shelf Functionality

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -113,7 +113,8 @@
 		return
 //	to_chat(world, "next_attack is [next_attack] and world.time is [world.time]")
 	if(istype(loc,/obj/mecha))
-		if(!locate(/turf) in list(A,A.loc)) // Prevents inventory from being drilled
+		// Prevents inventory from being drilled and handles a crate shelf special case
+		if((!locate(/turf) in list(A,A.loc)) && !istype(A.loc,/obj/structure/rack/crate_shelf))
 			return
 		var/obj/mecha/M = loc
 		return M.click_action(A,src)

--- a/code/game/objects/structures/crateshelf.dm
+++ b/code/game/objects/structures/crateshelf.dm
@@ -98,15 +98,11 @@
 /obj/structure/rack/crate_shelf/destroy(dropParts = TRUE)
 	var/turf/dump_turf = get_turf(src)
 	for(var/obj/structure/closet/crate/crate in shelf_contents)
-		crate.plane = initial(crate.plane)
-		crate.layer = initial(crate.layer) // Reset the crates back to default visual state
-		crate.pixel_y = initial(crate.pixel_y)
-		crate.forceMove(dump_turf)
+		force_unload(crate, dump_turf)
 		step(crate, pick(cardinal)) // Shuffle the crates around as though they've fallen down.
 		if(prob(5)) // Open the crate!
 			if(crate.open())
 				crate.visible_message("<span class='warning'>[crate]'s lid falls open!</span>")
-		shelf_contents[shelf_contents.Find(crate)] = null
 	if(trapping)
 		unlock_atom(trappeduser)
 		trappeduser = null
@@ -133,28 +129,40 @@
 	vis_contents = contents // It really do be that shrimple.
 	return
 
+// Used when a mob attempts to put a crate on the rack.
 /obj/structure/rack/crate_shelf/proc/load(obj/structure/closet/crate/crate, mob/user)
 	var/next_free = shelf_contents.Find(null) // Find the first empty slot in the shelf.
 	if(!next_free) // If we don't find an empty slot, return early.
 		to_chat(user, "<span class='warning'>\The [src] is full!</span>")
 		return FALSE
 	if(do_after(user, use_delay, target = crate))
-		if(shelf_contents[next_free] != null)
-			return FALSE // Something has been added to the shelf while we were waiting, abort!
-		if(crate.opened) // If the crate is open, try to close it.
-			if(!crate.close())
-				return FALSE // If we fail to close it, don't load it into the shelf.
-		shelf_contents[next_free] = crate // Insert a reference to the crate into the free slot.
-		crate.forceMove(src) // Insert the crate into the shelf.
-		crate.pixel_y = DEFAULT_SHELF_VERTICAL_OFFSET * (next_free - 1) // Adjust the vertical offset of the crate to look like it's on the shelf.
-		crate.plane = FLOAT_PLANE
-		if(next_free >= 3) // If we're at or above three, we'll be on the way to going off the tile we're on. This allows mobs to be below the crate when this happens.
-			crate.plane = HUMAN_PLANE
-		crate.layer = BELOW_OBJ_LAYER + 0.02 * (next_free - 1) // Adjust the layer of the crate to look like it's in the shelf.
-		handle_visuals()
-		return TRUE
+		return force_load(crate, next_free)
 	return FALSE // If the do_after() is interrupted, return FALSE!
 
+// Directly inserts a crate into the rack.
+// next_free: Used for if you're trying to insert a crate into a specific position. Default: next available slot
+// Returns FALSE if the crate can't be forced on for whatever reason.
+/obj/structure/rack/crate_shelf/proc/force_load(obj/structure/closet/crate/crate, next_free)
+	if(!next_free)
+		next_free = shelf_contents.Find(null) // Find the first empty slot in the shelf.
+		if(!next_free)
+			return FALSE //No slots open!
+	if(shelf_contents[next_free] != null)
+		return FALSE // Can't load if no room.
+	if(crate.opened) // If the crate is open, try to close it.
+		if(!crate.close())
+			return FALSE // If we fail to close it, don't load it into the shelf.
+	shelf_contents[next_free] = crate // Insert a reference to the crate into the free slot.
+	crate.forceMove(src) // Insert the crate into the shelf.
+	crate.pixel_y = DEFAULT_SHELF_VERTICAL_OFFSET * (next_free - 1) // Adjust the vertical offset of the crate to look like it's on the shelf.
+	crate.plane = FLOAT_PLANE
+	if(next_free >= 3) // If we're at or above three, we'll be on the way to going off the tile we're on. This allows mobs to be below the crate when this happens.
+		crate.plane = HUMAN_PLANE
+	crate.layer = BELOW_OBJ_LAYER + 0.02 * (next_free - 1) // Adjust the layer of the crate to look like it's in the shelf.
+	handle_visuals()
+	return TRUE
+
+// Used when a mob attempts take a crate off the rack.
 /obj/structure/rack/crate_shelf/proc/unload(obj/structure/closet/crate/crate, mob/user, turf/unload_turf)
 	if(!unload_turf)
 		unload_turf = get_turf(user) // If a turf somehow isn't passed into the proc, put it at the user's feet.
@@ -164,16 +172,24 @@
 		to_chat(user,"<span class='warning'>There is already a crate here.</span>")
 		return
 	if(do_after(user, use_delay, target = crate))
-		if(!shelf_contents.Find(crate))
-			return FALSE // If something has happened to the crate while we were waiting, abort!
-		crate.plane = initial(crate.plane)
-		crate.layer = initial(crate.layer) // Reset the crate back to having the default layer, otherwise we might get strange interactions.
-		crate.pixel_y = initial(crate.pixel_y) // Reset the crate back to having no offset, otherwise it will be floating.
-		crate.forceMove(unload_turf)
-		shelf_contents[shelf_contents.Find(crate)] = null // We do this instead of removing it from the list to preserve the order of the shelf.
-		handle_visuals()
-		return TRUE
+		return force_unload(crate, unload_turf)
 	return FALSE  // If the do_after() is interrupted, return FALSE!
+
+// Directly removes a specific crate from the rack.
+// unload_turf: Used to specify where the crate will be dropped. default: get_turf(src)
+// Returns FALSE if the crate does not exist on the rack.
+/obj/structure/rack/crate_shelf/proc/force_unload(obj/structure/closet/crate/crate, turf/unload_turf)
+	if(!shelf_contents.Find(crate))
+		return FALSE // If something has happened to the crate while we were waiting, abort!
+	if(!unload_turf)
+		unload_turf = get_turf(src)
+	crate.plane = initial(crate.plane)
+	crate.layer = initial(crate.layer) // Reset the crate back to having the default layer, otherwise we might get strange interactions.
+	crate.pixel_y = initial(crate.pixel_y) // Reset the crate back to having no offset, otherwise it will be floating.
+	crate.forceMove(unload_turf)
+	shelf_contents[shelf_contents.Find(crate)] = null // We do this instead of removing it from the list to preserve the order of the shelf.
+	handle_visuals()
+	return TRUE
 
 /obj/structure/rack/crate_shelf/Bumped(atom/movable/AM)
 	..()
@@ -304,16 +320,11 @@
 	plane = HUMAN_PLANE
 
 	for(var/obj/structure/closet/crate/crate in shelf_contents)
-		crate.plane = initial(crate.plane)
-		crate.layer = initial(crate.layer)
-		crate.pixel_y = initial(crate.pixel_y)
-		crate.forceMove(fallturf)
+		force_unload(crate, fallturf)
 		step(crate, pick(cardinal))
 		if(prob(50))
 			if(crate.open())
 				crate.visible_message("<span class='warning'>[crate]'s lid falls open!</span>")
-		shelf_contents[shelf_contents.Find(crate)] = null
-		handle_visuals()
 
 	for(var/mob/living/carbon/human/H in fallturf)
 		if(made_in_china)

--- a/code/modules/mecha/equipment/tools/tools.dm
+++ b/code/modules/mecha/equipment/tools/tools.dm
@@ -79,6 +79,9 @@
 					if(oh_shit_new_living_in_target.len)
 						return
 					if(T == chassis.loc && src == chassis.selected)
+						if(istype(O.loc,/obj/structure/rack/crate_shelf)) //Loading a crate from a crate shelf
+							var/obj/structure/rack/crate_shelf/shelf = O.loc
+							shelf.force_unload(O)
 						W.cargo += O
 						O.forceMove(chassis)
 						if(!W.ore_box && istype(O, /obj/structure/ore_box))
@@ -92,7 +95,50 @@
 			else
 				occupant_message("<span class='red'>Not enough room in cargo compartment.</span>")
 		else
-			occupant_message("<span class='red'>[target] is firmly secured.</span>")
+			if(!istype(O,/obj/structure/rack/crate_shelf)) //To avoid another tab, we exit here if we're not an anchored crate shelf!
+				occupant_message("<span class='red'>[target] is firmly secured.</span>")
+				return
+			//Crate shelf direct unloading
+			if(!W.cargo.len) //Nothing in the cargo bay? No unloading needed!
+				return
+			var/total_crates = 0
+			var/obj/crate_to_load
+			var/list/crate_list = list()
+			for(var/obj/structure/closet/crate/counted_crate in W.cargo) //Count the amount of crates in the mech cargo
+				total_crates++
+				var/name_attempt = counted_crate.name //Brace yourself for the 6 roundstart "crate" crates on box!
+				var/exists = crate_list[name_attempt]
+				if(exists) //If a crate already exists with the same name, generate a number for it so they don't stack in one list entry
+					var/count_trial = 2
+					while(crate_list[name_attempt])
+						name_attempt = "[counted_crate.name] #[count_trial]"
+						count_trial++
+				crate_list[name_attempt] = counted_crate
+				crate_to_load = counted_crate
+			if(!total_crates) //No crates found in the mech cargo
+				return
+			if(total_crates >= 2) //If there's more than one crate, pick the one to unload
+				var/response = input(chassis.occupant,"Which crate to unload?", "[src]", "Cancel") as null|anything in crate_list
+				if(response == "Cancel" || !response)
+					return
+				if(!W.Adjacent(O)) //Moved away somehow
+					return
+				crate_to_load = crate_list[response]
+			occupant_message("You lift [crate_to_load] and start to load it into [O].")
+			chassis.visible_message("[chassis] lifts [crate_to_load] and starts to load it into [O].")
+			playsound(chassis, 'sound/mecha/hydraulic.ogg', 100, 1)
+			set_ready_state(0)
+			chassis.use_power(energy_drain)
+			if(do_after_cooldown(target))
+				if(W != crate_to_load.loc) //Protection against hitting the unload button while unloading
+					return
+				if(!W.Adjacent(O)) //Moved away somehow
+					return
+				var/obj/structure/rack/crate_shelf/shelf = O
+				shelf.force_load(crate_to_load) //Force the crate into the shelf
+				W.cargo -= crate_to_load //Remove the shelf from the cargo hold list
+				W.log_message("Unloaded [crate_to_load]. Cargo compartment capacity: [W.cargo_capacity - W.cargo.len]")
+				occupant_message("<span class='notice'>[crate_to_load] successfully unloaded.</span>")
 
 	else if(istype(target,/mob/living))
 		var/mob/living/M = target


### PR DESCRIPTION
<img width="353" height="325" alt="image" src="https://github.com/user-attachments/assets/c629b488-b337-4065-8922-dce642056cb4" />

## What this does
This PR allows mecha hydraulic clamps to load and unload crates directly to and from crate shelves.

* Loading a crate is simple, you just click the crate and it will load it into your robot as normal.
* If you have a single crate, clicking a crate shelf will attempt to unload that crate into the shelf.
* Multiple crates? A prompt appears asking you which crate you would like to unload.

## Why it's good
<img width="552" height="450" alt="image" src="https://github.com/user-attachments/assets/4fcd3781-fcf4-4c55-914b-6db5a476e8e4" />

## How it was tested
Cleaned up the cargo bay and uncleaned up the cargo bay. Grabbed crates from random spots, unloaded them. Threw a mouse in a crate and tried to see if I could load or unload mousecrate.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Mecha clamps can load and unload crate shelves.
