### PR TITLE
Fixes Switchtool Multitool Menus

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -368,12 +368,12 @@
 	//assorted replacements to make text feel "dumb"
 	message = replacetext(message, "he", "eh") //he, she, the -> eh, seh, teh, etc
 	message = replacetext(message, "ies", "is")
-	message = replacetext(message, "you", "u") 
+	message = replacetext(message, "you", "u")
 	message = replacetext(message, "iou", "ou") //delicous
 	message = replacetext(message, "xc", "x") //exited
 	message = replacetext(message, "air", "er") //cher, her
 	message = replacetext(message, "uni", "uin")
-	message = replacetext(message, "dg", "g") //knowlege, 
+	message = replacetext(message, "dg", "g") //knowlege,
 	message = replacetext(message, "tch", "ch") //bich
 	message = replacetext(message, "are", "ar")
 	message = replacetext(message, "pl", "pul")
@@ -411,7 +411,7 @@
 		if(words.len > 0) // Check if the list has any words
 			words[rand(1, words.len)] = pick("um,", "umm,", "uh,", "uhh,")
 		message = jointext(words, " ")
-			
+
 	if(prob(35))
 		message = uppertext(message)
 		if(prob(50))
@@ -605,7 +605,10 @@ var/list/list/zones = list(list(LIMB_HEAD,LIMB_LEFT_ARM,LIMB_LEFT_HAND,LIMB_LEFT
 		var/mob/dead/observer/G=user
 		P = G.ghostMulti
 
-	if(!istype(P))
+	if(!ismultitool(P))
+		if(istype(P,/obj/item/weapon/switchtool)) //Switchtool deployed multitool special case!
+			var/obj/item/weapon/switchtool/ST = P
+			return ST.deployed
 		return null
 	return P
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -608,7 +608,8 @@ var/list/list/zones = list(list(LIMB_HEAD,LIMB_LEFT_ARM,LIMB_LEFT_HAND,LIMB_LEFT
 	if(!ismultitool(P))
 		if(istype(P,/obj/item/weapon/switchtool)) //Switchtool deployed multitool special case!
 			var/obj/item/weapon/switchtool/ST = P
-			return ST.deployed
+			if(ismultitool(ST.deployed))
+				return ST.deployed
 		return null
 	return P
 


### PR DESCRIPTION
## What this does
This PR fixes switchtool multitools not being able to bring up the multitool menu.

## Why it's good
Makes @Eneocho stop yelling at me. Fixes #38234.

## How it was tested
<img width="534" height="548" alt="image" src="https://github.com/user-attachments/assets/ced144f9-60ef-4327-877f-44de5e18ebb3" />

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Switchtool multitools can now access the multitool menu.