### PR TITLE
Fix sound_emitter destruction behaviour and nullref runtimes

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -141,7 +141,7 @@
 		body += "<option value='?_src_=vars;toggle_aliasing=\ref[D]'>Toggle Transform Aliasing</option>"
 	if(istype(D,/obj/item/weapon/gun))
 		body += "<option value='?_src_=vars;projectile_edit=\ref[D]'>Edit Projectile Variables</option>"
-	if(has_initialized_sound_emitter(D))
+	if(istype(D, /atom/movable))
 		body += "<option value='?_src_=vars;halt_sound=\ref[D]'>Stop Sound</option>"
 
 
@@ -997,9 +997,9 @@ function loadPage(list) {
 		if (!check_rights(R_DEBUG))
 			return
 
-		var/atom/A = locate(href_list["halt_sound"])
-		if(!istype(A) || !has_initialized_sound_emitter(A))
-			to_chat(src, "This can only be done to atoms that have an initialized sound emitter")
+		var/atom/movable/A = locate(href_list["halt_sound"])
+		if(!istype(A) || (A.sound_emitter == null))
+			to_chat(src, "This can only be done to atom/movables that have an initialized sound emitter")
 			return
 
 		A.sound_emitter.stop()

--- a/code/modules/sound/sound_emitter.dm
+++ b/code/modules/sound/sound_emitter.dm
@@ -14,6 +14,10 @@
 /atom
 	var/datum/sound_emitter/sound_emitter
 
+/atom/Destroy()
+	qdel(sound_emitter)
+	return ..()
+
 /atom/proc/setup_sound()
 	return
 
@@ -91,7 +95,7 @@
 /datum/sound_emitter/Destroy()
 	sound_emitter_collection.remove(src)
 	sound_zone_manager.unregister_emitter(src)
-	deactivate();
+	deactivate()
 	if (sounds)
 		sounds.Cut()
 		sounds = null
@@ -219,7 +223,7 @@
 // halt sounds to clients, unregister from dynamic updates
 /datum/sound_emitter/proc/deactivate()
 	active_sound = null
-  
+
 	INVOKE_EVENT(src, /event/sound_stopped, "emitter" = src)
 
 /datum/sound_emitter/proc/update_env_effect()

--- a/code/modules/sound/sound_emitter.dm
+++ b/code/modules/sound/sound_emitter.dm
@@ -11,10 +11,10 @@
 	  The subscription is driven by the SZM, which maintains a hashmap of sound_emitter locations.
 */
 
-/atom
+/atom/movable
 	var/datum/sound_emitter/sound_emitter
 
-/atom/Destroy()
+/atom/movable/Destroy()
 	qdel(sound_emitter)
 	return ..()
 

--- a/code/modules/sound/sound_listener_context/sound_listener_context.dm
+++ b/code/modules/sound/sound_listener_context/sound_listener_context.dm
@@ -54,6 +54,7 @@
 	var/mob/proxy = null
 	var/list/current_channels_by_emitter = list()
 	var/list/free_channels = list()
+	var/list/audible_emitters = list()
 	var/range = null
 
 /datum/sound_listener_context/New(client/C, mob/P, hearing_range = world.view)
@@ -61,6 +62,7 @@
 	proxy = P
 	current_channels_by_emitter = list()
 	free_channels = list()
+	audible_emitters = list()
 	for (var/i = CHANNEL_RESERVABLE_MIN, i <= CHANNEL_RESERVABLE_MAX, i++)
 		free_channels += i
 	range = hearing_range
@@ -69,6 +71,9 @@
 /datum/sound_listener_context/Destroy()
 	for (var/datum/sound_emitter/E in current_channels_by_emitter)
 		release(E)
+	for (var/datum/sound_emitter/E in audible_emitters)
+		unsubscribe_from(E)
+	audible_emitters.Cut()
 	free_channels.Cut()
 	current_channels_by_emitter.Cut()
 	sound_zone_manager.unregister_listener(src)
@@ -96,7 +101,7 @@
 	// which channel this client is using for this emitter
 	var/chan = current_channels_by_emitter[E]
 	if (!chan)
-		CRASH("listener_context attempted to release [E] with no channel, possible double-release or other fuckery")
+		return //no channel to release, no sound to stop (hopefully)
 	// flush it
 	var/sound/nullsound = sound(file = null)
 	nullsound.channel = chan
@@ -105,8 +110,6 @@
 
 	current_channels_by_emitter -= E
 	free_channels += chan
-
-	unsubscribe_from(E)
 
 /datum/sound_listener_context/proc/reset_proxy(mob/P)
 	sound_zone_manager.unregister_listener(src)
@@ -130,7 +133,6 @@
 	E.register_event(/event/sound_started, src, nameof(src::start_hearing()))
 	E.register_event(/event/sound_stopped, src, nameof(src::stop_hearing()))
 	E.register_event(/event/sound_pushed, src, nameof(src::hear_once()))
-
 
 /datum/sound_listener_context/proc/unsubscribe_from(datum/sound_emitter/E)
 	E.unregister_event(/event/sound_updated, src, nameof(src::on_sound_update()))
@@ -178,6 +180,9 @@
 /datum/sound_listener_context/proc/on_enter_range(datum/sound_emitter/E)
 	start_hearing(E) // this can throw if channel reservation fails, subscribe after its safe
 	subscribe_to(E)
+	audible_emitters |= E
 
 /datum/sound_listener_context/proc/on_exit_range(datum/sound_emitter/E)
-	release(E)
+	stop_hearing(E)
+	unsubscribe_from(E)
+	audible_emitters -= E

--- a/code/modules/sound/sound_listener_context/sound_listener_context.dm
+++ b/code/modules/sound/sound_listener_context/sound_listener_context.dm
@@ -161,13 +161,7 @@
 	client << S
 
 /datum/sound_listener_context/proc/stop_hearing(datum/sound_emitter/emitter)
-	var/chan = current_channels_by_emitter[emitter]
-	if (!chan)
-		return // already can't hear it (probably)
-	var/sound/nullsound = sound(file = null)
-	nullsound.channel = chan
-	nullsound.status = SOUND_UPDATE | SOUND_MUTE
-	client << nullsound
+	release(emitter)
 
 /datum/sound_listener_context/proc/on_sound_update(datum/sound_emitter/emitter)
 	var/chan = current_channels_by_emitter[emitter]

--- a/code/modules/sound/sound_zone_manager.dm
+++ b/code/modules/sound/sound_zone_manager.dm
@@ -114,7 +114,7 @@ var/global/datum/sound_zone_manager/sound_zone_manager = new
 				CRASH("Found a listener with no client or endpoint client")
 			var/datum/sound_listener_context/context = client.listener_context
 
-			if (E in context.current_channels_by_emitter)
+			if (E in context.audible_emitters)
 				if (!E.contains(listener))
 					context.on_exit_range(E)
 				else
@@ -197,7 +197,7 @@ var/global/datum/sound_zone_manager/sound_zone_manager = new
 	var/datum/sound_listener_context/context = receive_client.listener_context
 
 	var/list/current = list()
-	for (var/datum/sound_emitter/E in context.current_channels_by_emitter)
+	for (var/datum/sound_emitter/E in context.audible_emitters)
 		current[E] = TRUE
 	var/list/fresh = list()
 


### PR DESCRIPTION
## What this does
- Adds missing cleanup for `sound_emitter` when `atom` is destroyed
- Moves `sound_emitter` onto `atom/movable` from `atom`
- Tidies up emitter channel reservation on client when `/event/sound_stopped` is raised rather than relying on movement checks later
- Adds a list to `sound_listener_context` to track which emitters are currently audible at all. This fixes an issue where emitters that weren't playing a looping sound at the time they were subscribed to (eg. entering range of an air alarm) would result in the emitter becoming subscribed to but never being possible to unsubscribe, as no reference was retained in `current_channels_by_emitter` (so `sound_zone_manager` never fired an `on_exit_range` to unsubscribe it) and there was no way for the SLC to unsubscribe on `Destroy()` either

## Why it's good
Fixes #38284
Fixes (minor) mustard gas

## How it was tested
In local, spawned a cryo_tube, turned it on then rightclick deleted it -> Sound stopped but runtimes appeared and confirmed `sound_emitter` wasn't being cleaned up properly
After fix confirmed `sound_emitter` is cleaned up and client state is tidy
Tracked SLC subscriptions on emitters in local while moving in and out of range and ghosting

## Changelog
:cl:
 * bugfix: Cryo bubbles should no longer get stuck audible when cryo is destroyed
 * bugfix: Clean up some nullref retentions when moving near sound emitters
