### PR TITLE
Quiets Some World Log Server Start Messages

### DIFF
--- a/code/__HELPERS/datum.dm
+++ b/code/__HELPERS/datum.dm
@@ -3,6 +3,15 @@
 	var/list/active_timers
 	var/list/open_uis
 
+/**
+ * Called on all objects at round start when the Objects subsystem loads after the map and vaults are loaded in.
+ *
+ * Vital notes:
+ * When using this proc, set flags |= ATOM_INITIALIZED or call the /atom/ level parent somehow. Otherwise, things may get initialized twice in vaults.
+ * This proc is called only by the objects subsystem itself (during pregame), unless manually called (by New() usually).
+ * If you include this in New(), check for SSobj && SSobj.initialized so that you don't initialize whatever you're spawning in twice.
+ * if(ticker) isn't good enough, vaults can spawn in after the ticker is started but before the Objects subsystem is started.
+ */
 /datum/proc/initialize()
 	return TRUE
 

--- a/code/datums/shuttle.dm
+++ b/code/datums/shuttle.dm
@@ -834,17 +834,17 @@
 					warning("Invalid or missing starting area for [S.name] ([S.type]) [msg]")
 				else
 					var/msg = S.linked_area ? "- \"[S.linked_area]\" was given as a starting area." : ""
-					world.log << "Invalid or missing starting area for [S.name] ([S.type]) [msg]"
+					log_debug("Invalid or missing starting area for [S.name] ([S.type]) [msg]")
 			if(INIT_NO_PORT)
 				if(S.is_special())
 					warning("Couldn't find a shuttle docking port for [S.name] ([S.type]).")
 				else
-					world.log << "Couldn't find a shuttle docking port for [S.name] ([S.type])."
+					log_debug("Couldn't find a shuttle docking port for [S.name] ([S.type]).")
 			if(INIT_NO_START)
 				if(S.is_special())
 					warning("[S.name] ([S.type]) couldn't connect to a destination port on init - unless this is intended, there might be problems.")
 				else
-					world.log << "[S.name] ([S.type]) couldn't connect to a destination port on init - unless this is intended, there might be problems."
+					log_debug("[S.name] ([S.type]) couldn't connect to a destination port on init - unless this is intended, there might be problems.")
 
 
 	//THE MOST IMPORTANT PIECE OF CODE HERE

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -28,7 +28,7 @@ var/list/discounted_items_of_the_round = list()
 		var/picked = pick(possible_picks)
 		possible_picks -= picked
 		item_list += picked
-		world.log << "Picked: [picked]"
+		//world.log << "Picked: [picked]" //this lasted 19 months before getting silenced
 
 	discounted_items_of_the_round = item_list
 

--- a/code/modules/food/cooking_machines.dm
+++ b/code/modules/food/cooking_machines.dm
@@ -92,12 +92,13 @@ var/global/ingredientLimit = 10
 	..()
 
 /obj/machinery/cooking/New()
-	if (ticker)
+	if(SSobj && SSobj.initialized)
 		initialize()
 
 	return ..()
 
 /obj/machinery/cooking/initialize()
+	..()
 	if (foodChoices)
 		var/obj/item/food
 

--- a/code/modules/migrations/migration_controller.dm
+++ b/code/modules/migrations/migration_controller.dm
@@ -40,7 +40,7 @@
 			var/list/pack[prepack.len]
 			for(var/datum/migration/M in newpacks[pkgID])
 				pack[M.id] = M
-				world.log << "\[Migrations] [pkgID]#[M.id] = [M.type] - [M.name]"
+				log_debug("\[Migrations] [pkgID]#[M.id] = [M.type] - [M.name]")
 			packages[pkgID]=pack
 			log_debug("\[Migrations] Loaded [pack.len] [id] DB migrations from package [pkgID].", FALSE)
 		//VersionCheck()


### PR DESCRIPTION
<img width="383" height="193" alt="image" src="https://github.com/user-attachments/assets/767ff2c5-e2e6-456b-8623-e5e8c9adc7b0" />

## What this does
This PR removes a few common server round start messages in world.log, This is mainly to clean up the immediate world log when running a local server for testing.
* A runtime with deepfryers double initing was fixed, and the cause located. This individual case was fixed, but there may be considerably more issues with vault generation and calling initialize() under the surface that currently remain unfixed. It's non-trivial, involving a large number of objects. I've left some documentation on initialize() for best practices for future coders.
* The three Picked discounted items no longer show up in the world.log.
* Common Migration info is now dumped to the debug log.
* Shuttle issues are reported to the debug log unless the shuttle is labeled important. Box doesn't seem to have a docking port for escape shuttle 4 or the vox skipjack.

## Why it's good
Less annoying messages when testing a funny lil guy in a ripley.

## How it was tested
Several hours of cursed initialize bug hunting, then reverted to a nice clean state.

## Changelog
No CL, backend change only.
