### PR TITLE
Using an empty auto ore loader in hand to toggle autoloading

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -174,9 +174,9 @@
 	to_chat(user, "You turn [src] [handling? "on":"off"].")
 
 	if(handling)
-		user.register_event(/event/moved, T, /obj/item/weapon/storage/bag/ore/auto/proc/mob_moved)
+		user.register_event(/event/moved, src, /obj/item/weapon/storage/bag/ore/auto/proc/mob_moved)
 	else
-		user.unregister_event(/event/moved, T, /obj/item/weapon/storage/bag/ore/auto/proc/mob_moved)
+		user.unregister_event(/event/moved, src, /obj/item/weapon/storage/bag/ore/auto/proc/mob_moved)
 
 /obj/item/weapon/storage/bag/ore/auto/proc/auto_fill(var/mob/holder)
 	var/obj/structure/ore_box/box = null

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -142,6 +142,11 @@
 	actions_types = list(/datum/action/item_action/toggle_auto_handling)
 	var/handling = FALSE
 
+/obj/item/weapon/storage/bag/ore/auto/attack_hand(mob/user)
+	if(!contents.len)
+		toggle_hold(user)
+	. = ..()
+
 /datum/action/item_action/toggle_auto_handling
 	name = "Toggle Ore Loader"
 
@@ -156,19 +161,22 @@
 	if(!istype(T))
 		return
 
-	T.handling = !T.handling
-
-	to_chat(user, "You turn \the [T.name] [T.handling? "on":"off"].")
-
-	if(T.handling == TRUE)
-		user.register_event(/event/moved, T, /obj/item/weapon/storage/bag/ore/auto/proc/mob_moved)
-	else
-		user.unregister_event(/event/moved, T, /obj/item/weapon/storage/bag/ore/auto/proc/mob_moved)
+	T.toggle_hold(user)
 
 /obj/item/weapon/storage/bag/ore/auto/proc/auto_collect(var/turf/collect_loc)
 	for(var/obj/item/stack/ore/ore in collect_loc.contents)
 		preattack(collect_loc, src, TRUE)
 		break
+
+/obj/item/weapon/storage/bag/ore/auto/proc/toggle_hold(var/mob/user)
+	handling = !handling
+
+	to_chat(user, "You turn [src] [handling? "on":"off"].")
+
+	if(handling)
+		user.register_event(/event/moved, T, /obj/item/weapon/storage/bag/ore/auto/proc/mob_moved)
+	else
+		user.unregister_event(/event/moved, T, /obj/item/weapon/storage/bag/ore/auto/proc/mob_moved)
 
 /obj/item/weapon/storage/bag/ore/auto/proc/auto_fill(var/mob/holder)
 	var/obj/structure/ore_box/box = null

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -142,7 +142,7 @@
 	actions_types = list(/datum/action/item_action/toggle_auto_handling)
 	var/handling = FALSE
 
-/obj/item/weapon/storage/bag/ore/auto/attack_hand(mob/user)
+/obj/item/weapon/storage/bag/ore/auto/attack_self(mob/user)
 	if(!contents.len)
 		toggle_hold(user)
 	. = ..()


### PR DESCRIPTION
[qol]

## What this does
Namely, the hotkey Z does this.
As title says, only works if empty.

## Why it's good
One less mouseclick to use this.

## How it was tested
Spawning this, using it in hand, toggling with action button, picking up a piece of iron ore, dumping it out, doing the toggling again.

## Changelog
:cl:
 * tweak: Automatic ore loaders can now have their ore loading state toggled by the item usage hotkey, but only if no ores are loaded.