### PR TITLE
Makes wire connection check verb look for cableless terminals

### DIFF
--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -421,7 +421,7 @@ var/global/movement_disabled_exception //This is the client that calls the proc,
 		if(!neighbour || neighbour.get_powernet() != C.get_powernet())
 			error_str += "<span class = 'warning'>Disconnected wire at [formatJumpTo(get_turf(C))]</span><br>"
 	error_str += "<h1>Terminal connections on current Z Level [z]</h1>"
-	for(var/obj/machinery/power/terminal/T in power_machines)
+	for(var/obj/machinery/power/terminal/T in terminals)
 		var/turf/T2 = get_turf(T)
 		if(!T2.get_cable_node())
 			error_str += "<span class = 'warning'>Disconnected terminal at [formatJumpTo(T2)]</span><br>"

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -420,7 +420,12 @@ var/global/movement_disabled_exception //This is the client that calls the proc,
 		neighbour = locate() in get_step(get_turf(C),C.d2)
 		if(!neighbour || neighbour.get_powernet() != C.get_powernet())
 			error_str += "<span class = 'warning'>Disconnected wire at [formatJumpTo(get_turf(C))]</span><br>"
-	
+	error_str += "<h1>Terminal connections on current Z Level [z]</h1>"
+	for(var/obj/machinery/power/terminal/T in power_machines)
+		var/turf/T2 = get_turf(T)
+		if(!T2.get_cable_node())
+			error_str += "<span class = 'warning'>Disconnected terminal at [formatJumpTo(T2)]</span><br>"
+
 	var/datum/browser/popup = new(usr, "Wire connections", usr.name, 300, 400)
 	popup.set_content(error_str)
 	popup.open()

--- a/code/modules/power/terminal.dm
+++ b/code/modules/power/terminal.dm
@@ -3,6 +3,8 @@
 // all conduit connects go to this object instead of the APC
 // using this solves the problem of having the APC in a wall yet also inside an area
 
+var/list/obj/machinery/power/terminal/terminals = list()
+
 /obj/machinery/power/terminal
 	name = "terminal"
 	icon_state = "term"
@@ -22,6 +24,7 @@
 
 /obj/machinery/power/terminal/New()
 	..()
+	terminals += src
 	var/turf/T = src.loc
 	if(level==1)
 		hide(T.intact)
@@ -50,6 +53,7 @@
 			plane = initial(plane)
 
 /obj/machinery/power/terminal/Destroy()
+	terminals -= src
 	if (master)
 		master:terminal = null
 		master = null


### PR DESCRIPTION
[general][administration]

## What this does
Makes wire connection check verb look for cableless terminals, below the cable checks themselves.

## Why it's good
Helps avoid the situation that got the cable smoothing PR killed by checking for this.

## How it was tested
Using the verb in-game, seeing the boxstation nukeop shuttle have a disconnected APC terminal. (currently the only one on that map like this)

## Changelog
:cl:
 * rscadd: The "check power connections" debug admin verb in the mapping tab now checks for power machinery terminals with no wire knot underneath.