### PR TITLE
Grammar and formatting issue nuke

### DIFF
--- a/code/datums/striketeams/emergency_response_team.dm
+++ b/code/datums/striketeams/emergency_response_team.dm
@@ -124,7 +124,7 @@ var/list/response_team_members = list()
 	..()
 	if(Adjacent(user))
 		if(occupant)
-			to_chat(user, "A figure floats in the depths, they appear to be [occupant.real_name]")
+			to_chat(user, "A figure floats in the depths, they appear to be [occupant.real_name].")
 		else
 			to_chat(user, "<span class='info'>The chamber appears devoid of anything but its biotic fluids.</span>")
 	else

--- a/code/game/machinery/bees_apiary.dm
+++ b/code/game/machinery/bees_apiary.dm
@@ -123,7 +123,7 @@ var/list/apiaries_list = list()
 
 /obj/machinery/apiary/examine(mob/user)
 	..()
-	var/species_name = "bees"//people would expect an apiary to contain bees by default I guess.
+	var/species_name = BEESPECIES_NORMAL//people would expect an apiary to contain bees by default I guess.
 	if (species)
 		species_name = species.common_name
 	if(!worker_bees_inside && !queen_bees_inside)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -294,7 +294,7 @@ var/list/camera_messages = list()
 	else if ((istype(W, /obj/item/weapon/paper) || istype(W, /obj/item/device/pda)) && isliving(user))
 		user.delayNextAttack(5)
 		var/mob/living/U = user
-		to_chat(U, "You hold [W] up to the camera...")
+		to_chat(U, "You hold \the [W] up to the camera...")
 
 		var/info = ""
 		if(istype(W, /obj/item/weapon/paper))

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -314,7 +314,7 @@ var/list/camera_messages = list()
 		for(var/mob/living/silicon/ai/O in living_mob_list)
 			if(!O.client)
 				continue
-			to_chat(O, "<span class='name'><a href='byond://?src=\ref[O];track=[U.name]'>[U.name]</a></span> holds <a href='byond://?src=\ref[src];message_id=[key]'>[W]</a> up to one of your cameras...")
+			to_chat(O, "<span class='name'><a href='byond://?src=\ref[O];track=[U.name]'>[U.name]</a></span> holds <a href='byond://?src=\ref[src];message_id=[key]'>\the [W]</a> up to one of your cameras...")
 
 		for(var/obj/machinery/computer/security/tv in tv_monitors)
 			if(tv.active_camera != src)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -294,7 +294,7 @@ var/list/camera_messages = list()
 	else if ((istype(W, /obj/item/weapon/paper) || istype(W, /obj/item/device/pda)) && isliving(user))
 		user.delayNextAttack(5)
 		var/mob/living/U = user
-		to_chat(U, "You hold [W] up to the camera ...")
+		to_chat(U, "You hold [W] up to the camera...")
 
 		var/info = ""
 		if(istype(W, /obj/item/weapon/paper))
@@ -314,13 +314,13 @@ var/list/camera_messages = list()
 		for(var/mob/living/silicon/ai/O in living_mob_list)
 			if(!O.client)
 				continue
-			to_chat(O, "<span class='name'><a href='byond://?src=\ref[O];track=[U.name]'>[U.name]</a></span> holds <a href='byond://?src=\ref[src];message_id=[key]'>[W]</a> up to one of your cameras ...")
+			to_chat(O, "<span class='name'><a href='byond://?src=\ref[O];track=[U.name]'>[U.name]</a></span> holds <a href='byond://?src=\ref[src];message_id=[key]'>[W]</a> up to one of your cameras...")
 
 		for(var/obj/machinery/computer/security/tv in tv_monitors)
 			if(tv.active_camera != src)
 				continue
 			for(var/datum/tgui/ui in SStgui.open_uis_by_src[tv])
-				to_chat(ui.user, "[U] holds <a href='byond://?src=\ref[src];message_id=[key]'>[W]</a> up to one of the cameras ...")
+				to_chat(ui.user, "[U] holds <a href='byond://?src=\ref[src];message_id=[key]'>[W]</a> up to one of the cameras...")
 	else
 		..()
 		add_fingerprint(user)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -320,7 +320,7 @@ var/list/camera_messages = list()
 			if(tv.active_camera != src)
 				continue
 			for(var/datum/tgui/ui in SStgui.open_uis_by_src[tv])
-				to_chat(ui.user, "[U] holds <a href='byond://?src=\ref[src];message_id=[key]'>[W]</a> up to one of the cameras...")
+				to_chat(ui.user, "[U] holds <a href='byond://?src=\ref[src];message_id=[key]'>\the [W]</a> up to one of the cameras...")
 	else
 		..()
 		add_fingerprint(user)

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -203,7 +203,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 	..()
 	if(Adjacent(user))
 		if(contents.len)
-			to_chat(user, "You can just about make out some properties of the cryo's murky depths:")
+			to_chat(user, "You can just about make out some properties of \the [src]'s murky depths:")
 			var/count = 0
 			var/list/stuff = list()
 			for(var/atom/movable/floater in ((contents - beaker) - occupant))
@@ -213,14 +213,14 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 					stuff += floater
 
 			if(occupant)
-				to_chat(user, "A figure floats in the depths, they appear to be [occupant]")
+				to_chat(user, "A figure floats in the depths, they appear to be [occupant].")
 
 			if (count)
 				// Let's just assume you can only have observers if there's a mob too.
-				to_chat(user, "<i>...[count] shape\s float behind them...</i>")
+				to_chat(user, "<i>...[count] shape\s float[count == 1 ? "s" : ""] behind them...</i>")
 
 			if(stuff.len)
-				to_chat(user, "Miscellaneous contents float in the depths, it appears to be [counted_english_list(stuff)]")
+				to_chat(user, "Miscellaneous contents float in the depths, it appears to be [counted_english_list(stuff)].")
 
 			if(beaker)
 				to_chat(user, "A beaker, releasing the following chemicals into the fluids:")

--- a/code/game/objects/items/stacks/misc.dm
+++ b/code/game/objects/items/stacks/misc.dm
@@ -66,7 +66,7 @@
 					return
 
 			if(T.canBuildLattice(src))
-				to_chat(user, "<span class='notice'>Constructing support lattice ...</span>")
+				to_chat(user, "<span class='notice'>Constructing support lattice...</span>")
 				playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
 				new /obj/structure/lattice(T)
 				use(1)

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -104,7 +104,7 @@
 			var/turf/T = get_turf(Target)
 			if(T.canBuildLattice(src))
 				if(src.use(1))
-					to_chat(user, "<span class='notice'>Constructing some foundations ...</span>")
+					to_chat(user, "<span class='notice'>Constructing some foundations...</span>")
 					playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
 					new /obj/structure/lattice/wood(T)
 

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -454,7 +454,7 @@ var/list/global/id_cards = list()
 /obj/item/weapon/card/id/syndicate/AltClick()
 	if (can_use(usr)) // Checks that the this is in our inventory. This will be checked by the proc anyways, but we don't want to generate an error message if not.
 		copy_appearance = !copy_appearance
-		to_chat(usr, "<span class='notice'>[src] is now set to copy [copy_appearance ? "the appearance along with" : "just"] the access.</span>")
+		to_chat(usr, "<span class='notice'>\The [src] is now set to copy [copy_appearance ? "the appearance along with" : "just"] the access.</span>")
 		return
 	return ..()
 

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -454,7 +454,7 @@ var/list/global/id_cards = list()
 /obj/item/weapon/card/id/syndicate/AltClick()
 	if (can_use(usr)) // Checks that the this is in our inventory. This will be checked by the proc anyways, but we don't want to generate an error message if not.
 		copy_appearance = !copy_appearance
-		to_chat(usr, "<span class='notice'>zThe [src] is now set to copy [copy_appearance ? "the appearance along with" : "just"] the access.</span>")
+		to_chat(usr, "<span class='notice'>[src] is now set to copy [copy_appearance ? "the appearance along with" : "just"] the access.</span>")
 		return
 	return ..()
 

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -754,7 +754,7 @@
 
 /obj/item/weapon/pocket_mirror/arcane
 	name = "strange pocket mirror"
-	desc = "is that your reflection? or someone elses."
+	desc = "Is that your reflection? Or someone else's..."
 	arcanetampered = 1
 
 

--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -301,7 +301,7 @@
 
 /obj/structure/strange_present
 	name = "strange present"
-	desc = "It's a ... present?"
+	desc = "It's a... present?"
 	icon = 'icons/obj/items.dmi'
 	icon_state = "strangepresent"
 	density = 1

--- a/code/game/objects/items/weapons/shard.dm
+++ b/code/game/objects/items/weapons/shard.dm
@@ -8,7 +8,7 @@
 	icon_state = "large"
 	sharpness = 0.8
 	sharpness_flags = SHARP_TIP | SHARP_BLADE
-	desc = "Could probably be used as ... a throwing weapon?"
+	desc = "Could probably be used as... a throwing weapon?"
 	w_class = W_CLASS_TINY
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	force = 5.0

--- a/code/modules/RCD/schematics/pipe.dm
+++ b/code/modules/RCD/schematics/pipe.dm
@@ -479,7 +479,7 @@
 		set_dir(dirs[index])
 
 /datum/rcd_schematic/pipe/attack(var/atom/A, var/mob/user, frequency, id)
-	to_chat(user, "Building Pipes ...")
+	to_chat(user, "Building Pipes...")
 	playsound(user, 'sound/machines/click.ogg', 50, 1)
 	var/thislayer = layer
 	var/thisdir = selected_dir
@@ -545,7 +545,7 @@
 	return "<a href='?src=\ref[master.interface];set_dir=[dir]'[selected] title='[title]'><img src='RPD_D_[pipe_id]_[dir].png'/></a>"
 
 /datum/rcd_schematic/pipe/disposal/attack(var/atom/A, var/mob/user)
-	to_chat(user, "Building Pipes ...")
+	to_chat(user, "Building Pipes...")
 	playsound(user, 'sound/machines/click.ogg', 50, 1)
 	var/thisdir = selected_dir
 	if(!master.delay(user, A, 2 SECONDS))

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -228,7 +228,7 @@ var/list/hydro_trays = list()
 	lastcycle = world.time
 	weedlevel = 0
 	update_icon()
-	visible_message("<span class='info'>The [initial(name)] has been overtaken by [seed.display_name]</span>.")
+	visible_message("<span class='info'>\The [initial(name)] has been overtaken by [seed.display_name]</span>.")
 
 	return
 

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -228,7 +228,7 @@ var/list/hydro_trays = list()
 	lastcycle = world.time
 	weedlevel = 0
 	update_icon()
-	visible_message("<span class='info'>[initial(name)] has been overtaken by [seed.display_name]</span>.")
+	visible_message("<span class='info'>The [initial(name)] has been overtaken by [seed.display_name]</span>.")
 
 	return
 

--- a/code/modules/mob/living/carbon/human/combat.dm
+++ b/code/modules/mob/living/carbon/human/combat.dm
@@ -272,12 +272,14 @@
 			to_chat(src, "<span class='notice'><B>They don't have a mouth!</B></span>")
 			return 0
 	if(src.check_body_part_coverage(MOUTH))
-		to_chat(src, "<span class='notice'><B>Remove your [src.get_body_part_coverage(MOUTH)]!</B></span>")
+		var/obj/item/I = src.get_body_part_coverage(MOUTH)
+		to_chat(src, "<span class='notice'><B>Remove your [I.name]!</B></span>")
 		return 0
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		if(H.check_body_part_coverage(MOUTH))
-			to_chat(src, "<span class='notice'><B>Remove their [H.get_body_part_coverage(MOUTH)]!</B></span>")
+			var/obj/item/I = H.get_body_part_coverage(MOUTH)
+			to_chat(src, "<span class='notice'><B>Remove their [I.name]!</B></span>")
 			return 0
 
 	if(!target.cpr_time)

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -24,8 +24,19 @@ var/list/solars_list = list()
 
 // this is here because it is fucking here. If you found this, you're lucky !
 /obj/item/weapon/paper/solar
-	name = "paper - 'Going green with Greencorps! Instrunctions on setting up your own solar array.'"
-	info = "<h1>Welcome</h1><p>We at Greencorps we love the environment, and space. With this package you will help mother nature and produce energy without using fossil fuel or plasma! The Singularity Engine is dangerous while solar energy is safe, which is why it's better. Now here is how you setup your own solar array.</p><p>You can make a solar panel by wrenching the solar assembly onto a cable node. Add a glass panel, reinforced or regular glass will do, which will finish the construction of your solar panel. It's that easy!.</p><p>Now after setting up 19 more of these solar panels you will want to create a solar tracker to keep track of mother nature's gift, the sun. These are the same steps as before except you insert the tracker equipment circuit into the assembly before performing the final step of adding the glass. You now have a tracker! Now the last step is to add a computer to calculate the sun's movements and to send commands to the solar panels to change direction with the sun. Setting up the solar computer is the same as setting up any computer, so you should have no trouble in doing that. You do need to put a wire node under the computer, and the wire needs to be connected to the tracker.</p><p>Congratulations, you should have a working solar array. If you are having trouble, here are some tips. Make sure all solar equipment are on a cable node, even the computer. You can always deconstruct your creations if you make a mistake.</p><p>That's all to it, be safe, be green!</p>"
+	name = "paper - 'Going green with Greencorps! Instructions on setting up your own solar array.'"
+	info = {"<h1>Welcome</h1>
+	<p>We at Greencorps love the environment, and space. With this package you can help mother nature and produce energy without using fossil fuel or plasma! Solar energy is one of the safest kinds you can use, without any of the nasty accidents associated with ones such as the supermatter or singularity. This paper details instructions on how you setup your own solar array.</p>
+	<p>To make a solar panel, you must:</p>
+	<ul><li>Wrench the solar assembly onto a cable node.</li>
+	<li>Add a glass panel, reinforced or regular glass will do.</li></ul>
+	<p>It's that easy!.</p>
+	<p>Now after setting up 19 more of these solar panels, you would want to create a solar tracker to keep track of mother nature's gift, the sun. These are the same steps as before except you insert the tracker equipment circuit into the assembly before performing the final step of adding the glass. You now have a tracker!</p>
+	<p>Now the last step is to add a computer to calculate the sun's movements and to send commands to the solar panels to change direction with the sun. Setting up the solar computer is the same as setting up any computer, so you should have no trouble in doing that. You do need to put a wire node under the computer, and the wire needs to be connected to the tracker.</p>
+	<p>Congratulations, you should have a working solar array. If you are having any trouble, here are some tips:</p>
+	<ul><li>Make sure all solar equipment is on a cable node, even the computer.</li>
+	<li>You can always deconstruct your creations if you make a mistake.</li></ul>
+	<p>That's all there is to it. Be safe, be green!</p>"}
 
 //Solar Assembly - For construction of solar arrays
 /obj/machinery/power/solar_assembly

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -225,7 +225,7 @@
 
 	else if (tool.clumsy_check(user) && prob(20))
 		user.visible_message("<span class='notice'>[user] takes something out of incision on [target]'s [affected.display_name] with \the [tool].</span>", \
-		"<span class='notice'>You take something out of the incision on [target]'s [affected.display_name] with \the [tool].</span>" )
+		"<span class='notice'>You take something out of the incision on \the [target]'s [affected.display_name] with \the [tool].</span>" )
 		var/obj/clowndigobj = pick(/obj/item/weapon/bikehorn/rubberducky, /obj/item/weapon/reagent_containers/food/snacks/pie, /obj/item/toy/singlecard, /obj/item/clothing/accessory/waterflower)
 		clowndigobj = new clowndigobj(target.loc)
 		if (istype(clowndigobj, /obj/item/toy/singlecard))

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -196,7 +196,7 @@
 	if (affected.implants.len)
 		var/obj/item/obj = affected.implants[affected.implants.len]
 		user.visible_message("<span class='notice'>[user] takes something out of incision on [target]'s [affected.display_name] with \the [tool].</span>", \
-		"<span class='notice'>You take [obj] out of incision on [target]'s [affected.display_name]s with \the [tool].</span>" )
+		"<span class='notice'>You take [obj] out of the incision on [target]'s [affected.display_name] with \the [tool].</span>" )
 		affected.implants -= obj
 
 		//Handle possessive brain borers.
@@ -214,7 +214,7 @@
 			obj.forceMove(get_turf(target))
 	else if (affected.hidden)
 		user.visible_message("<span class='notice'>[user] takes something out of incision on [target]'s [affected.display_name] with \the [tool].</span>", \
-		"<span class='notice'>You take something out of incision on [target]'s [affected.display_name]s with \the [tool].</span>" )
+		"<span class='notice'>You take something out of the incision on [target]'s [affected.display_name] with \the [tool].</span>" )
 		affected.hidden.forceMove(get_turf(target))
 		user.put_in_hands(affected.hidden)
 		if(!affected.hidden.blood_DNA)
@@ -225,7 +225,7 @@
 
 	else if (tool.clumsy_check(user) && prob(20))
 		user.visible_message("<span class='notice'>[user] takes something out of incision on [target]'s [affected.display_name] with \the [tool].</span>", \
-		"<span class='notice'>You take something out of incision on [target]'s [affected.display_name]s with \the [tool].</span>" )
+		"<span class='notice'>You take something out of the incision on [target]'s [affected.display_name] with \the [tool].</span>" )
 		var/obj/clowndigobj = pick(/obj/item/weapon/bikehorn/rubberducky, /obj/item/weapon/reagent_containers/food/snacks/pie, /obj/item/toy/singlecard, /obj/item/clothing/accessory/waterflower)
 		clowndigobj = new clowndigobj(target.loc)
 		if (istype(clowndigobj, /obj/item/toy/singlecard))

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -214,7 +214,7 @@
 			obj.forceMove(get_turf(target))
 	else if (affected.hidden)
 		user.visible_message("<span class='notice'>[user] takes something out of incision on [target]'s [affected.display_name] with \the [tool].</span>", \
-		"<span class='notice'>You take something out of the incision on [target]'s [affected.display_name] with \the [tool].</span>" )
+		"<span class='notice'>You take something out of the incision on \the [target]'s [affected.display_name] with \the [tool].</span>" )
 		affected.hidden.forceMove(get_turf(target))
 		user.put_in_hands(affected.hidden)
 		if(!affected.hidden.blood_DNA)

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -196,7 +196,7 @@
 	if (affected.implants.len)
 		var/obj/item/obj = affected.implants[affected.implants.len]
 		user.visible_message("<span class='notice'>[user] takes something out of incision on [target]'s [affected.display_name] with \the [tool].</span>", \
-		"<span class='notice'>You take [obj] out of the incision on [target]'s [affected.display_name] with \the [tool].</span>" )
+		"<span class='notice'>You take \the [obj] out of the incision on \the [target]'s [affected.display_name] with \the [tool].</span>" )
 		affected.implants -= obj
 
 		//Handle possessive brain borers.

--- a/code/modules/trader/trade_gear.dm
+++ b/code/modules/trader/trade_gear.dm
@@ -57,7 +57,7 @@
 	if(!master)
 		master = user
 	if(master != user)
-		to_chat(user,"<span class='danger'>This nanodictionary is already partially used up. Useless. You need the fundamentals.</span>.")
+		to_chat(user,"<span class='danger'>This nanodictionary is already partially used up. Useless. You need the fundamentals.</span>")
 		return
 	busy = TRUE
 	if(do_after(user, src,progress_time, 10, custom_checks = new /callback(src, /obj/item/dictionary/proc/on_do_after)))

--- a/code/modules/virus2/dishincubator.dm
+++ b/code/modules/virus2/dishincubator.dm
@@ -188,7 +188,7 @@
 		if(!stage_to_focus)
 			to_chat(usr, "<span class='notice'>The effect focusing is now turned off.</span>")
 		else
-			to_chat(usr, "span class='notice'>\The [src] will now focus on stage [stage_to_focus].</span>")
+			to_chat(usr, "<span class='notice'>\The [src] will now focus on stage [stage_to_focus].</span>")
 		effect_focus = stage_to_focus
 		return TRUE
 

--- a/maps/waystation.dmm
+++ b/maps/waystation.dmm
@@ -43616,7 +43616,7 @@
 "kBh" = (
 /obj/machinery/atmospherics/trinary/mixer/mirrored{
 	dir = 1;
-	name = "Air to MIx"
+	name = "Air to Mix"
 	},
 /turf/simulated/floor,
 /area/engineering/atmos)


### PR DESCRIPTION
[grammar]

## What this does
Closes #37105.
Closes #37167.
Closes #37170.
Closes #38113.
Closes #38171. (properly)
Closes #38211. (doubt this is intentional since the paper was added before /vg/station was even a thing)
Closes #38255.
Closes #38296.
Closes #38310.
Closes #38329. (and also gets rid of as many erroneous ellipsis spaces as possible)
Closes #38337.
Closes #38338.

## Why it's good
Easier to read the solar panel instructions.

## How it was tested
reading the solar panel instructions paper, putting someone in a cryo tube and examining them, alt clicking an agent ID card, doing CPR on someone with breathmasks.

## Changelog
:cl:
 * spellcheck: Virtually all spaces between letters and ellipses should be eliminated now.
 * spellcheck: Nanodictionaries no longer have an extra full stop printed when language learning cannot be done.
 * spellcheck: Langstroth hives no longer show an extra s after "bees" in examination.
 * spellcheck: Agent ID card copying no longer shows a mistaken letter Z at the start.
 * spellcheck: The air to mix on waystation no longer has the I mistakenly capitalized.
 * spellcheck: Removing masks for CPR no longer shows any mistaken "the".
 * spellcheck: Cryo cells now show a proper "s" after the verb float if 1 figure is behind the occupant, while the occupant gets a full stop for their description as it should.
 * spellcheck: The incubator stage focus message is now formatted right.
 * spellcheck: Botany trays being overtaken by weeds now has a "The" at the start as needed.
 * spellcheck: Removing shrapnel from people now has a proper "the" before incision and no plural after the area removed from.
 * spellcheck: Solar panel installation instructions have gotten a passthrough for formatting and grammar, making them more readable.
