### PR TITLE
Stops Roid Debris Spam

### DIFF
--- a/code/modules/research/xenoarchaeology/finds/finds_container.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds_container.dm
@@ -187,11 +187,11 @@
             else
                 artifact_debris(1)
 
-        else if(!excavation_level > 0 && prob(15))
+        else if(excavation_level > 0 && prob(15))
             B = new /obj/structure/boulder(T)
             B.geological_data = geologic_data
 
-        
+
 /datum/finds/proc/large_artifact_fail()
     var/turf/unsimulated/T = holder.get()
     if(!istype(T))


### PR DESCRIPTION
## What this does
In #37226, the backend boulder spawning code was rearranged to add the ability to depress digsites. Unfortunately, a random ! was thrown in the code for some reason, completely changing the behavior of the function. As a result, mining now results in a lot of rocky debris being strewn about. This PR removes the !.

## Why it's good
Less double drilling and rocky debris flooding all over the place.

## How it was tested
BRRR GO DRILL

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: There's no longer a 15% of spawning rocky debris on every tile on the roid.
