### PR TITLE
Stations with no living players will no longer lose power + maxed SMES at 5 players and less

### DIFF
--- a/code/controllers/subsystem/power.dm
+++ b/code/controllers/subsystem/power.dm
@@ -15,6 +15,7 @@ var/list/cable_list = list() //Index for all cables, so that powernets don't hav
 	var/list/currentrun_cables
 	var/list/currentrun_powerents
 	var/list/currentrun_power_machines
+	var/no_pop_mode // Will make powernets provide power when there's no players online.
 
 
 /datum/subsystem/power/New()
@@ -48,12 +49,19 @@ var/list/cable_list = list() //Index for all cables, so that powernets don't hav
 		if (PC.build_status && PC.rebuild_from() && MC_TICK_CHECK)
 			return
 
+	if(istype(ticker.mode, /datum/gamemode/dynamic))
+		var/datum/gamemode/dynamic/D = ticker.mode
+		if(!D.living_players.len)
+			no_pop_mode = TRUE
+		else
+			no_pop_mode = FALSE
 	while (currentrun_powerents.len)
 		var/datum/powernet/powerNetwork = currentrun_powerents[currentrun_powerents.len]
 		currentrun_powerents.len--
 		if (!powerNetwork || powerNetwork.gcDestroyed)
 			continue
 
+		powerNetwork.no_pop_mode = no_pop_mode
 		powerNetwork.reset()
 		if (MC_TICK_CHECK)
 			return

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -746,7 +746,8 @@ var/datum/controller/gameticker/ticker
 		var/datum/gamemode/dynamic/D = mode
 		if(D.living_players.len < 6) // Fill all the SMES to capacity if there's 5 or less players, to give players more time to set up the power.
 			for(var/obj/machinery/power/battery/smes/S in power_machines)
-				S.charge = S.capacity
+				if(S.charge) //Only do this if the SMES has any charge in the first place
+					S.charge = S.capacity
 
 // -- Tag mode!
 /datum/controller/gameticker/proc/tag_mode(var/mob/user)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -742,6 +742,11 @@ var/datum/controller/gameticker/ticker
 			play_vox_sound(sound,map.zMainStation,null)
 
 	create_random_orders(3) //Populate the order system so cargo has something to do
+	if(istype(mode, /datum/gamemode/dynamic))
+		var/datum/gamemode/dynamic/D = mode
+		if(D.living_players.len < 6) // Fill all the SMES to capacity if there's 5 or less players, to give players more time to set up the power.
+			for(var/obj/machinery/power/battery/smes/S in power_machines)
+				S.charge = S.capacity
 
 // -- Tag mode!
 /datum/controller/gameticker/proc/tag_mode(var/mob/user)

--- a/code/modules/power/powernet.dm
+++ b/code/modules/power/powernet.dm
@@ -15,6 +15,7 @@
 									//  An unsatisfied_priority of 0 means either there was either no power or more than enough to cover every load, so priorities get the
 									//  same satisfaction (0% for no power, 100% for excess)
 	var/haspulsedemon = 0
+	var/no_pop_mode = FALSE // If on, will always fulfill load demand. This is toggled on by having zero players.
 
 ////////////////////////////////////////////
 // POWERNET DATUM PROCS
@@ -120,11 +121,13 @@
 	// Apply loads, calculate satisfaction, and see how much excess we're left with (if any)
 	netexcess = max(avail, 0)
 	unsatisfied_priority = 0
-	if (!netexcess)
+	if (!netexcess && !no_pop_mode)
 		satisfaction = 0 // No power -> 0% satisfaction for all
 	else
 		satisfaction = 1 // Assume 100% satisfaction for all, for now
 		for (var/i in 1 to load.len)
+			if(no_pop_mode)
+				load[i] = 0
 			if (netexcess >= load[i]) // Go through all loads and substract them from excess
 				netexcess -= load[i]
 


### PR DESCRIPTION
This is heavy-handed but I believe it is a good thing.
It turns out that the gameplay of "hop on a powerless station, smash your way through arrivals, crowbar your way towards the spare ID and then set up the power" is not exactly a fun thing for most lowpop players to do, and can quickly get tiresome to do it over and over again so players generally hesitate to play lowpop further because they don't want to be on emergency power setup duty before they do anything else. This PR ensures that the station will generally remain powered by turning off power loads while there are no living players online, but will consume power normally as long as there is one living player online in the entire server. SMES units and such should not recharge from this unless power production was set up.

Also made SMES units be fully powered if there are at most 5 players, to give players a lot of breathing room for doing gimmicks, engineering projects, goofing around etc. if they don't want to set up the power right away. There's 3 Engineering SMES units on the average station (excluding the SMES dedicated to Engineering itself) and the neutral power consumption rate on Box for example is ~100kw, with a collective capacity of 300000kw the station can remain powered for nearly 2 hours (power drawing happens every 2 seconds, 300000/100 = 3000 * 2 = ~6000 seconds of power). This may vary for different stations such as Asteroid.

:cl:
 * tweak: The station will no longer consume power if there are no players online, to avoid most scenarios where players would hop on a powerless station.
 * tweak: The SMES units will be fully charged at roundstart if there are less than 6 players in the round.