### PR TITLE
Adds spiders (back?) to salvage shuttles on box station and lowfat bagel

### DIFF
--- a/maps/lowfatbagel.dmm
+++ b/maps/lowfatbagel.dmm
@@ -57595,7 +57595,7 @@
 	},
 /area/centcom/ert)
 "jyl" = (
-/obj/effect/landmark/map_element/salvage_shuttle,
+/obj/effect/landmark/map_element/salvage_shuttle_spiders,
 /turf/space,
 /area)
 "jyA" = (

--- a/maps/tgstation.dmm
+++ b/maps/tgstation.dmm
@@ -95380,7 +95380,7 @@
 /turf/space,
 /area)
 "dNg" = (
-/obj/effect/landmark/map_element/salvage_shuttle,
+/obj/effect/landmark/map_element/salvage_shuttle_spiders,
 /turf/space,
 /area)
 "dNv" = (


### PR DESCRIPTION
[box][lowfat]

## What this does
Closes #38315.

## How it was tested
Playing the maps with fixed vaults enabled, jumping to the map element.

## Changelog
:cl:
 * tweak: The salvage shuttles on boxstation and lowfat bagel now have spiders... again?