### PR TITLE
Cargo Cart Bugfixes

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -158,6 +158,9 @@
 	// Prevent AIs from being crammed into lockers. /vg/ Redmine #153 - N3X
 	if(istype(AM, /mob/living/silicon/ai) || istype(AM, /mob/living/simple_animal/scp_173))
 		return 0
+	//Prevent cargo carts from getting dragged into crates and closets
+	if(istype(AM, /obj/machinery/cart))
+		return 0
 
 	if(istype(AM, /mob/living))
 		var/mob/living/L = AM
@@ -168,7 +171,7 @@
 			L.client.eye = src
 	else if(!istype(AM, /obj/item) && !istype(AM, /obj/effect/dummy/chameleon))
 		return 0
-	else if(AM.density || AM.anchored || istype(AM,/obj/structure/closet))
+	else if(AM.density || AM.anchored || istype(AM,/obj/structure/closet) || locked_to == AM)
 		return 0
 	AM.forceMove(src)
 	return 1
@@ -504,6 +507,10 @@
 	if(user.incapacitated())
 		return 0
 	if((!( istype(O, /atom/movable) ) || O.anchored || !user.Adjacent(O) || !user.Adjacent(src)))
+		return 0
+	if(istype(O, /obj/machinery/cart)) //Prevent cargo carts from getting dragged into crates and closets
+		return 0
+	if(locked_to == O) //Don't let a closet contain that which it is attached to!
 		return 0
 	if(!istype(user.loc, /turf)) // are you in a container/closet/pod/etc? Will also check for null loc
 		return 0

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -447,7 +447,11 @@
 	else if(isobj(AM))
 		if(AM.density || AM.anchored || istype(AM,/obj/structure/closet))
 			return 0
-
+		else if(locked_to == AM)
+			return 0
+	//Prevent cargo carts from getting dragged into crates and closets
+	if(istype(AM, /obj/machinery/cart))
+		return 0
 	if(istype(AM, /obj/structure/bed)) //This is only necessary because of rollerbeds and swivel chairs.
 		var/obj/structure/bed/B = AM
 		if(B.is_locking(/datum/locking_category/buckle, subtypes=TRUE))

--- a/code/game/objects/structures/vehicles/carts/cargo.dm
+++ b/code/game/objects/structures/vehicles/carts/cargo.dm
@@ -20,7 +20,7 @@
 /obj/machinery/cart/cargo/get_cell()
 	return internal_battery
 
-/obj/machinery/cart/cargo/process()			
+/obj/machinery/cart/cargo/process()
 	if(internal_battery)
 		if(internal_battery.charge == 0 && loaded_machine)
 			loaded_machine.power_change()
@@ -78,7 +78,7 @@
 		return
 	if(is_locking(/datum/locking_category/cargocart) || istype(C, /obj/machinery/cart/))
 		return
-	
+
 	load(C)
 
 /obj/machinery/cart/cargo/MouseDropFrom(obj/over_object as obj, src_location, over_location)
@@ -113,10 +113,10 @@
 	if(istype(C,/obj/structure/closet/crate))
 		var/obj/structure/closet/crate/crate = C
 		crate.close()
-	
+
 	visible_message("The [C] is loaded onto the cart.")
 	lock_atom(C, /datum/locking_category/cargocart)
-	
+
 	if(istype(C, /obj/machinery))
 		loaded_machine = C
 		loaded_machine.anchored = 1
@@ -125,16 +125,12 @@
 		if(!is_blacklisted(C))
 			if(internal_battery)
 				loaded_machine.connected_cell = internal_battery
-			loaded_machine.state = 1		
+			loaded_machine.state = 1
 			loaded_machine.power_change()
 			visible_message("The [C]'s cables hook onto the carts power lines.")
-		
-
-
-	
 	return TRUE
 
-/obj/machinery/cart/cargo/proc/unload(var/dirn = 0)
+/obj/machinery/cart/cargo/proc/unload(var/dirn = 0, var/silent = FALSE)
 	if(!is_locking(/datum/locking_category/cargocart))
 		return
 
@@ -148,9 +144,10 @@
 		loaded_machine.connected_cell = null
 		loaded_machine.power_change()
 		loaded_machine.machine_flags |= WRENCHMOVE
-		visible_message("The [load] is unloaded from the cart.")
-		if(!is_blacklisted(load))		
-			visible_message("The [load]'s cables disconnect from the cart.'")			
+		if(!silent)
+			visible_message("The [load] is unloaded from the cart.")
+			if(!is_blacklisted(load))
+				visible_message("The [load]'s cables disconnect from the cart.")
 		loaded_machine = null
 
 
@@ -165,6 +162,11 @@
 	for(var/atom/movable/AM in src)
 		if(AM != internal_battery)
 			AM.forceMove(src.loc)
+
+//If destroyed, unload any cargo to avoid having permanently locked stuff sitting around
+/obj/machinery/cart/cargo/Destroy()
+	unload(silent = TRUE)
+	..()
 
 /obj/machinery/cart/cargo/lock_atom(var/atom/movable/AM, var/datum/locking_category/category)
 	. = ..()

--- a/code/game/objects/structures/vehicles/carts/cart.dm
+++ b/code/game/objects/structures/vehicles/carts/cart.dm
@@ -83,3 +83,18 @@
 	train_net = new
 	train_net.members += src
 	train_net.train_rebuild(src)
+
+//If destroyed, disconnect the cart from any trains!
+/obj/machinery/cart/Destroy()
+	if(next_cart)
+		var/obj/machinery/cart/C = next_cart
+		next_cart.previous_cart = null
+		next_cart = null
+		C.disconnected()
+	if(previous_cart)
+		var/obj/machinery/cart/C = previous_cart
+		previous_cart.next_cart = null
+		previous_cart = null
+		C.disconnected()
+	train_net = null
+	..()


### PR DESCRIPTION
## What this does
Removes the ability for cargo carts to be placed in closets or crates, which was causing a bunch of fun issues. Removes the ability for closets and crates to contain something that is locking them in place. Fixes several cargo cart related bugs.
* Fixes #35149. Sorry Cargobrains, the cart crate unlocker days are over...
* Fixes tractors permanently losing their ability to connect carts if their connected cart is destroyed.
* Fixes carts leaving behind permanently unmovable objects when they are destroyed.

## Why it's good
Less cart bugginess. Less unintended ways to open crates.

## How it was tested
I have spawned so many ``cart/car``, dragged locked crates/closets on them, qdel'd them, that I have lost my sanity.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscdel: Cargo carts can no longer be put in closets or crates.
 * bugfix: Cargo carts now have considerably less bugs related to being destroyed.
 * bugfix: Cargo carts can no longer open locked crates via a glitch.