### PR TITLE
Fixes Overloading Ammo Storage Objects

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -166,6 +166,8 @@
 			break
 		if (!do_after(usr, target, reload_delay, 5))
 			return fumbleLoad(bullets_from, target)
+		if (PW.loaded.len + PW.refuse.len >= PW.max_shells)
+			return fumbleLoad(bullets_from, target)
 
 		bullets_from.stored_ammo -= loading
 		PW.loaded += loading
@@ -199,6 +201,8 @@
 		if (!((AS.exact && (loading.type == text2path(AS.ammo_type))) || (!AS.exact && (bullets_from.caliber == caliber)))) // If not exact, check if same caliber
 			break
 		if (!do_after(usr, target, 5, 5))
+			return fumbleLoad(bullets_from, target)
+		if (AS.stored_ammo.len >= AS.max_ammo)
 			return fumbleLoad(bullets_from, target)
 
 		bullets_from.stored_ammo -= loading


### PR DESCRIPTION
## What this does
This PR makes it so that when loading ammo storages, if the ammo count goes to max or higher while you are mid-loading, you will fumble the bullet upon completion of your progress bar (after all, the target is now at max ammo, it will not fit). This prevents overloading magazines/making invisible sprites.

Note that this PR does not eliminate the ability to use two magazine boxes to refill a single magazine at once in order to load faster, or the ability for multiple people to load at once.

Fixes #38299. Fixes #35515. Fixes #38340.

## Why it's good
No longer will your magazine turn invisible because you just wanted to load things really fast. 

## How it was tested
<img width="182" height="181" alt="image" src="https://github.com/user-attachments/assets/fc959abc-1203-47a1-88f8-f39804ed7ff6" />

fastest loadin' in spess

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Attempting to overload magazines/other ammo storages will now fumble bullets once the magazine hits max ammo.
