### PR TITLE
Admin UI Right Click Inspect Bugfix

### DIFF
--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -133,6 +133,8 @@
 	update_colour()
 	if (client.byond_version >= 516)
 		winset(client, null, list("browser-options"="find,refresh,byondstorage"))
+		if(client.holder?.rights & R_DEBUG)
+			winset(client, null, list("browser-options"="+devtools"))
 
 	if(client)
 		client.CAN_MOVE_DIAGONALLY = 0


### PR DESCRIPTION

## What this does
Due to /mob/Login() resetting flags, you had to deadmin and readmin to have +devtools reapplied if you wanted to use the internet browser right click inspect as an admin if you left the lobby. This PR fixes it so that you can right click inspect at any time without needing to readmin.

## Why it's good
@west3436 can test his UIs with less button presses now.

## How it was tested
<img width="537" height="207" alt="image" src="https://github.com/user-attachments/assets/60171a13-b902-4204-963f-895a826f4ab8" />

Actually joined the round and became a ghost, possessed various mobs, basically triggering Login() multiple ways.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Admins with +DEBUG can actually right click inspect UIs again without needing to deadmin then readmin.
