### PR TITLE
Crate Jiggling Update

### DIFF
--- a/code/controllers/subsystem/supply_shuttle.dm
+++ b/code/controllers/subsystem/supply_shuttle.dm
@@ -348,6 +348,10 @@ var/datum/subsystem/supply_shuttle/SSsupply_shuttle
 
 		var/obj/item/weapon/paper/manifest/slip = new /obj/item/weapon/paper/manifest(A)
 
+		if(istype(A, /obj/structure/closet/crate))
+			var/obj/structure/closet/crate/my_box = A
+			my_box.jiggle_all(W_CLASS_MEDIUM)
+
 		slip.name = "Shipping Manifest for [SO.orderedby]'s Order"
 		slip.info = {"<h3>[command_name()] Shipping Manifest for [SO.orderedby]'s Order</h3><hr><br>
 			Order #[SO.ordernum]<br>

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -394,16 +394,18 @@
 		return 0
 	return (!density)
 
-/obj/structure/closet/crate/proc/jiggle(var/obj/item/I)
-	var/jx = I.w_class == W_CLASS_TINY ? 7 : 3
-	var/jy = I.w_class == W_CLASS_TINY ? 3 : 1
+//Jiggles an item in a crate, raw power scales how much things are jostled
+/obj/structure/closet/crate/proc/jiggle(var/obj/item/I, var/raw_power = W_CLASS_SMALL)
+	var/jx = I.w_class < raw_power ? 7 : 3
+	var/jy = I.w_class < raw_power ? 3 : 1
 	I.pixel_x = rand(-jx,jx)
 	I.pixel_y = rand(-jy,jy)
 
+//Randomly moves around objects inside the crate based off of item size, representing items getting jostled around
 /obj/structure/closet/crate/proc/jiggle_all(var/max_size_jiggle = W_CLASS_SMALL)
 	for(var/obj/item/I in contents)
 		if(I.w_class <= max_size_jiggle)
-			jiggle(I)
+			jiggle(I, max_size_jiggle)
 
 /obj/structure/closet/crate/open()
 	if(src.opened)
@@ -475,13 +477,49 @@
 		open()
 	return
 
+//Jiggles when tackled
 /obj/structure/closet/crate/tackled(var/mob/living/user)
 	..()
-	jiggle_all(W_CLASS_SMALL)
+	if(M_HULK in user.mutations)
+		jiggle_all(W_CLASS_MEDIUM)
+	else
+		jiggle_all(W_CLASS_SMALL)
 
+//Jiggles when kicked
 /obj/structure/closet/crate/kick_act(var/mob/living/carbon/human/user)
 	..()
-	jiggle_all(W_CLASS_SMALL)
+	if(M_HULK in user.mutations)
+		jiggle_all(W_CLASS_MEDIUM)
+	else
+		jiggle_all(W_CLASS_SMALL)
+
+//Jiggles when run into with heavy objects
+/obj/structure/closet/crate/Bumped(atom/movable/AM)
+	..()
+	var/bump_amt = 0
+	if(istype(AM,/obj))
+		if(istype(AM,/obj/item/projectile))
+			bump_amt = W_CLASS_TINY
+		else if(istype(AM,/obj/structure/bed/chair/vehicle))
+			bump_amt = W_CLASS_MEDIUM
+		else
+			var/obj/O = AM
+			switch(O.w_class)
+				if(W_CLASS_LARGE)
+					bump_amt = W_CLASS_TINY
+				if(W_CLASS_HUGE)
+					bump_amt = W_CLASS_SMALL
+				if(W_CLASS_GIANT)
+					bump_amt = W_CLASS_MEDIUM
+	else if(istype(AM,/mob/living))
+		var/mob/living/M = AM
+		if(M.reagents)
+			if(M.reagents.get_sportiness() > 1)
+				bump_amt = W_CLASS_SMALL
+		if(M_HULK in M.mutations)
+			bump_amt = W_CLASS_MEDIUM
+	if(bump_amt)
+		jiggle_all(bump_amt)
 
 /obj/structure/closet/crate/secure/attack_hand(mob/user as mob)
 	if(!Adjacent(user))

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -12,12 +12,6 @@
 	var/sound_effect_open = 'sound/machines/click.ogg'
 	var/sound_effect_close = 'sound/machines/click.ogg'
 
-/obj/structure/closet/crate/proc/jiggle(var/obj/item/I)
-	var/jx = I.w_class == W_CLASS_TINY ? 7 : 3
-	var/jy = I.w_class == W_CLASS_TINY ? 3 : 1
-	I.pixel_x = rand(-jx,jx)
-	I.pixel_y = rand(-jy,jy)
-
 /obj/structure/closet/crate/basic
 	has_lock_type = /obj/structure/closet/crate/secure/basic
 
@@ -400,16 +394,23 @@
 		return 0
 	return (!density)
 
+/obj/structure/closet/crate/proc/jiggle(var/obj/item/I)
+	var/jx = I.w_class == W_CLASS_TINY ? 7 : 3
+	var/jy = I.w_class == W_CLASS_TINY ? 3 : 1
+	I.pixel_x = rand(-jx,jx)
+	I.pixel_y = rand(-jy,jy)
+
+/obj/structure/closet/crate/proc/jiggle_all(var/max_size_jiggle = W_CLASS_SMALL)
+	for(var/obj/item/I in contents)
+		if(I.w_class <= max_size_jiggle)
+			jiggle(I)
+
 /obj/structure/closet/crate/open()
 	if(src.opened)
 		return 0
 	if(!src.can_open())
 		return 0
 	playsound(src, sound_effect_open, 15, 1, -3)
-
-	for(var/obj/item/I in contents)
-		if(I.w_class <= W_CLASS_SMALL)
-			jiggle(I)
 
 	dump_contents()
 
@@ -473,6 +474,14 @@
 					return
 		open()
 	return
+
+/obj/structure/closet/crate/tackled(var/mob/living/user)
+	..()
+	jiggle_all(W_CLASS_SMALL)
+
+/obj/structure/closet/crate/kick_act(var/mob/living/carbon/human/user)
+	..()
+	jiggle_all(W_CLASS_SMALL)
 
 /obj/structure/closet/crate/secure/attack_hand(mob/user as mob)
 	if(!Adjacent(user))
@@ -670,6 +679,8 @@
 					dump_electronics()
 				dump_contents()
 				qdel(src)
+			else
+				jiggle_all(W_CLASS_MEDIUM)
 
 /obj/structure/closet/crate/secure/weapon/experimental
 	name = "Experimental Weapons Crate"

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -652,6 +652,8 @@
 		AM.forceMove(src)
 		if(istype(AM, /obj/item/delivery/large) && !hasmob)
 			var/obj/item/delivery/large/T = AM
+			for(var/obj/structure/closet/crate/my_box in T.contents)
+				my_box.jiggle_all(W_CLASS_SMALL) //Properly packaged, less shaking!
 			src.destinationTag = T.sortTag
 		if(istype(AM, /obj/item/delivery) && !hasmob)
 			var/obj/item/delivery/T = AM
@@ -659,6 +661,9 @@
 		if(istype(AM, /obj/item/weapon/paper/envelope) && !hasmob)
 			var/obj/item/weapon/paper/envelope/E = AM
 			src.destinationTag = E.sortTag
+		if(istype(AM, /obj/structure/closet/crate))
+			var/obj/structure/closet/crate/my_box = AM
+			my_box.jiggle_all(W_CLASS_MEDIUM)
 
 // start the movement process
 // argument is the disposal unit the holder started in


### PR DESCRIPTION
<img width="268" height="179" alt="image" src="https://github.com/user-attachments/assets/5d2bd112-f09d-43b9-933e-4c0a55fd220b" />

## What this does
This PR is the long awaited followup to #35822 which introduced jiggling the contents of crates. This PR changes crate jiggling such that it jiggles the contents of crates in most bumpy situations instead of when you open the crate. The amount of jiggling also somewhat scales on the force used.
It will jiggle the crate to some degree when:
* Bumped by a sporty or hulky person
* Arriving in the supply shuttle
* Sent through disposals
* Kicked
* Tackled
* Shot at
* Exploded
* Run into with a car

## Why it's good
Commence the jigglin'.

## How it was tested
<img width="359" height="377" alt="image" src="https://github.com/user-attachments/assets/a72bb140-771f-47eb-a87d-43b5cd653e6c" />
<img width="289" height="229" alt="image" src="https://github.com/user-attachments/assets/f3c67410-ac64-4221-8506-8c300f8e5085" />
<img width="342" height="333" alt="image" src="https://github.com/user-attachments/assets/19719b97-dc54-40b8-89bb-dbb7b5823571" />

See above list of things that shake the crate. I did those things!!

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Crate contents now jiggle around when the crate is subject to sufficient force, such as from kicks, being shot through disposals, or exploding.
