### PR TITLE
Adds Dragging Crates onto Crate Weighers

### DIFF
--- a/code/datums/cargo_forwarding.dm
+++ b/code/datums/cargo_forwarding.dm
@@ -251,6 +251,21 @@
 	if(current_crate && current_crate.loc != src.loc)
 		remove_crate()
 
+/obj/machinery/crate_weigher/MouseDropTo(var/obj/structure/C, mob/user)
+	..()
+	if(!istype(C))
+		return
+	if(user.incapacitated() || user.lying)
+		return
+	if(!Adjacent(user) || !Adjacent(C) || !user.Adjacent(C))
+		return
+	if(C.anchored)
+		to_chat(user, "\The [C] is fastened to the floor!")
+		return
+	if(C.locked_to || C.is_locking())
+		return
+	C.Move(loc)
+
 /obj/machinery/crate_weigher/proc/remove_crate()
 	current_crate = null
 	icon_state = "up"

--- a/code/datums/cargo_forwarding.dm
+++ b/code/datums/cargo_forwarding.dm
@@ -255,6 +255,8 @@
 	..()
 	if(!istype(C))
 		return
+	if(!isturf(C.loc))
+		return
 	if(user.incapacitated() || user.lying)
 		return
 	if(!Adjacent(user) || !Adjacent(C) || !user.Adjacent(C))


### PR DESCRIPTION

<img width="386" height="416" alt="image" src="https://github.com/user-attachments/assets/7d943534-4d22-49ad-aa86-83ad212705a9" />


## What this does
This adds some QOL where you can drag a crate onto a crate weigher with your mouse. This makes it so that you can more efficiently run the crate forwarding gauntlet.

## Why it's good
Faster cargo busywork.

## How it was tested
[boxboy.webm](https://github.com/user-attachments/assets/82a05f5f-2874-493a-b089-25597499fe91)

Tested dragging crates onto weighers in many funny ways. I'm sure @Dacendeth will find more that I somehow missed.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: You can now mousedrag crates onto crate weighers.
