### PR TITLE
Misc Borg Bugfixes

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -36,7 +36,7 @@
 
 	if(required_modules.len)
 		if(!(R.modtype in required_modules))
-			to_chat(user, "<span class='warning'>\The [src] will not fit into \the [R.module.name]!</span>")
+			to_chat(user, "<span class='warning'>\The [src] is not compatible with \the [R.module.name]!</span>")
 			return FAILED_TO_ADD
 
 	if(required_upgrades.len)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -251,19 +251,23 @@
 	if(module)
 		return
 	var/list/modules = getModules()
+	var/selected_module
 	if(forced_module)
-		modtype = forced_module
+		selected_module = forced_module
 	else
-		modtype = input("Please, select a module!", "Robot", null, null) as null|anything in modules
+		selected_module = input("Please, select a module!", "Robot", null, null) as null|anything in modules
 	// END forced modules.
 
+	if(!selected_module)
+		return
 	if(module)
 		return
-	if(!(modtype in all_robot_modules))
+	if(!(selected_module in all_robot_modules))
 		return
 
-	var/module_type = all_robot_modules[modtype]
+	var/module_type = all_robot_modules[selected_module]
 	module = new module_type(src)
+	modtype = selected_module
 
 	feedback_inc("cyborg_[lowertext(modtype)]",1)
 	updatename()

--- a/code/modules/tgui/states.dm
+++ b/code/modules/tgui/states.dm
@@ -80,7 +80,7 @@
 /mob/living/silicon/robot/shared_ui_interaction(src_object)
 	// Disable UIs if the object isn't installed in the borg AND the borg is either locked, has a dead cell, or no cell.
 	var/atom/device = src_object
-	if((istype(device) && device.loc != src) && (get_cell_charge() <= 0 || lockdown))
+	if((istype(device) && device.loc != src) && (get_cell_charge(src) <= 0 || lockdown))
 		return UI_DISABLED
 	return UI_INTERACTIVE
 


### PR DESCRIPTION

## What this does
This PR solves an issue caused by opening multiple input windows at the same time. If you spammed the select module button as a borg, while you would receive the tools/sprite/etc of the first choice you make, the last choice in the flood of input windows is what you would count-as for purposes of borg module upgrades. This PR fixes this bug.

This PR also changes the wording of an incompatible upgrade, now clearly stating that the upgrade is incompatible, not just "it will not fit".

Finally, as a bonus because I don't want to make another PR, this fixes Borgs/MoMMis from being able to open TGUI-based computer consoles. This was broken by #37919 for two months and nobody reported it on github.

## Why it's good
Fixes #38394.

## How it was tested
<img width="645" height="652" alt="image" src="https://github.com/user-attachments/assets/be806ee6-e75d-4be8-b157-80fa88654a37" />
<img width="348" height="94" alt="image" src="https://github.com/user-attachments/assets/6e59f6de-1386-473d-96bd-ecf8bf171666" />

<img width="1158" height="611" alt="image" src="https://github.com/user-attachments/assets/4afdc56e-b6d9-49ad-8692-40598f2293d3" />


## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Borgs can no longer change their internal borg type multiple times by spamming the set module button.
 * bugfix: Borgs and MoMMi can remotely view tgui-based windows again.
