### PR TITLE
More table fixes

### DIFF
--- a/code/game/machinery/doors/table.dm
+++ b/code/game/machinery/doors/table.dm
@@ -8,6 +8,7 @@
 	pass_flags_self = PASSTABLE
 	layer = TABLE_LAYER
 	open_layer = TABLE_LAYER
+	closed_layer = TABLE_LAYER
 	throwpass = 1	//You can throw objects over this, despite its density.
 	use_power = MACHINE_POWER_USE_NONE
 	machine_flags = SCREWTOGGLE

--- a/code/game/objects/items/stacks/stack_recipes.dm
+++ b/code/game/objects/items/stacks/stack_recipes.dm
@@ -230,7 +230,7 @@
 	if(!dirs_found)
 		to_chat(user, "<span class='warning'>\The [title] must be constructed next to a table or wall!</span>")
 		return 0
-	return 1
+	return ..()
 
 /datum/stack_recipe/table_door/finish_building(mob/user, var/obj/item/stack/S, var/obj/R)
 	if(!(dirs_found & clockwise_perpendicular_dirs(R.dir)))


### PR DESCRIPTION
[bugfix]

## What this does
Closes #38419.
Closes #38421.

## How it was tested
putting an item right south of a table door, opening it and closing it while checking the sprite, spam clicking the table door construction recipe next to a table.

## Changelog
:cl:
 * bugfix: Table doors no longer display above their proper layer when closed.
 * bugfix: Table doors can no longer be spam built on one turf.