### PR TITLE
Spessmart fixes

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
@@ -1,11 +1,12 @@
 /mob/living/simple_animal/hostile/retaliate
 	var/list/enemies = list()
 	var/hostile = 0 //Reverts back into a hostile mob when toggle to 1
+	var/stat_calm_threshold = UNCONSCIOUS
 
 /mob/living/simple_animal/hostile/retaliate/Found(var/atom/A)
 	if(isliving(A))
 		var/mob/living/L = A
-		if(!L.stat)
+		if(L.stat < stat_threshold)
 			stance = HOSTILE_STANCE_ATTACK
 			return L
 		else if(!L.reagents || !L.reagents.has_reagent(KILLERPHEROMONES))

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
@@ -1,12 +1,11 @@
 /mob/living/simple_animal/hostile/retaliate
 	var/list/enemies = list()
 	var/hostile = 0 //Reverts back into a hostile mob when toggle to 1
-	var/stat_calm_threshold = UNCONSCIOUS
 
 /mob/living/simple_animal/hostile/retaliate/Found(var/atom/A)
 	if(isliving(A))
 		var/mob/living/L = A
-		if(L.stat < stat_calm_threshold)
+		if(!L.stat)
 			stance = HOSTILE_STANCE_ATTACK
 			return L
 		else if(!L.reagents || !L.reagents.has_reagent(KILLERPHEROMONES))

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
@@ -6,7 +6,7 @@
 /mob/living/simple_animal/hostile/retaliate/Found(var/atom/A)
 	if(isliving(A))
 		var/mob/living/L = A
-		if(L.stat < stat_threshold)
+		if(L.stat < stat_calm_threshold)
 			stance = HOSTILE_STANCE_ATTACK
 			return L
 		else if(!L.reagents || !L.reagents.has_reagent(KILLERPHEROMONES))

--- a/maps/randomvaults/spessmart.dm
+++ b/maps/randomvaults/spessmart.dm
@@ -277,13 +277,13 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 		return
 
 	if(items.Find(AM))
-		return on_theft(AM,loc)
+		return on_theft(AM)
 	else
 		var/list/AM_contents = get_contents_in_object(AM, /obj/item)
 
 		for(var/obj/item/I in AM_contents)
 			if(items.Find(I))
-				return on_theft(I,loc)
+				return on_theft(I)
 
 /area/vault/supermarket/shop/proc/purchased(obj/item/I, price)
 	items.Remove(I)
@@ -307,15 +307,15 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 
 	if(!lockdown && map_element.customer_has_entered)
 		message_admins("Spessmart has entered lockdown due to the destruction of \a [destroyed]!")
-		on_theft(user = usr)
+		on_theft()
 
 /area/vault/supermarket/shop/proc/on_robot_kill()
 	if(map_element)
 		map_element.set_stats_alarm_activated("Destruction of a robot[usr ? " by [usr]" : ""]")
 
-	on_theft(user = usr)
+	on_theft()
 
-/area/vault/supermarket/shop/proc/on_theft(obj/item/I,mob/user)
+/area/vault/supermarket/shop/proc/on_theft(obj/item/I)
 	if(lockdown)
 		return
 
@@ -333,8 +333,6 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 			S.close()
 
 	for(var/mob/living/simple_animal/hostile/retaliate/spessmart_guardian/C in all_contents)
-		if(istype(user))
-			C.enemies |= user
 		C.Retaliate()
 
 	src.firealert()
@@ -697,7 +695,7 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 	qdel(src)
 
 /mob/living/simple_animal/hostile/retaliate/spessmart_guardian/update_canmove()
-	if(enemies.len || client)
+	if(hostile || client)
 		canmove = 1
 		anchored = 0
 	else
@@ -713,11 +711,12 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 
 /mob/living/simple_animal/hostile/retaliate/spessmart_guardian/Retaliate()
 	. = ..()
-	if(!enemies.len)
+	if(!hostile)
 		spawn(5)
 			wander = 1
 			canmove = 1
 			anchored = 0
+			hostile = 1
 
 			visible_message("<span class='userdanger'>\The [src] activates.</span>")
 

--- a/maps/randomvaults/spessmart.dm
+++ b/maps/randomvaults/spessmart.dm
@@ -685,12 +685,6 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 	overlays.Add(image('icons/mob/robots.dmi', icon_state = "eyes-securitron"))
 
 /mob/living/simple_animal/hostile/spessmart_guardian/Life()
-	if(retaliated || client)
-		canmove = 1
-		anchored = 0
-	else
-		canmove = 0
-		anchored = 1
 	EscapeConfinement()
 	..()
 
@@ -698,6 +692,15 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 	..(TRUE)
 	robogibs(get_turf(src))
 	qdel(src)
+
+/mob/living/simple_animal/hostile/spessmart_guardian/update_canmove()
+	if(retaliated || client)
+		canmove = 1
+		anchored = 0
+	else
+		canmove = 0
+		anchored = 1
+	return canmove
 
 /mob/living/simple_animal/hostile/spessmart_guardian/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	if(alert_on_movement && !canmove)

--- a/maps/randomvaults/spessmart.dm
+++ b/maps/randomvaults/spessmart.dm
@@ -641,7 +641,7 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 	icon = 'icons/mob/robots.dmi'
 	icon_state = "securitron"
 
-	timestopped = 1
+	wander = 0
 	anchored = 1
 	canmove = 0
 
@@ -688,11 +688,9 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 	if(retaliated || client)
 		canmove = 1
 		anchored = 0
-		timestopped = 0
 	else
 		canmove = 0
 		anchored = 1
-		timestopped = 1
 	EscapeConfinement()
 	..()
 
@@ -713,7 +711,6 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 			retaliated = TRUE
 			canmove = 1
 			anchored = 0
-			timestopped = 0
 
 			visible_message("<span class='userdanger'>\The [src] activates.</span>")
 

--- a/maps/randomvaults/spessmart.dm
+++ b/maps/randomvaults/spessmart.dm
@@ -677,6 +677,7 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 	meat_type = null
 
 	var/alert_on_movement = 1 //If moved, trigger an alert and become agressive
+	var/retaliated = FALSE
 
 /mob/living/simple_animal/hostile/spessmart_guardian/New()
 	..()
@@ -684,9 +685,14 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 	overlays.Add(image('icons/mob/robots.dmi', icon_state = "eyes-securitron"))
 
 /mob/living/simple_animal/hostile/spessmart_guardian/Life()
-	canmove = client != null
-	anchored = client == null
-	timestopped = client == null
+	if(retaliated || client)
+		canmove = 1
+		anchored = 0
+		timestopped = 0
+	else
+		canmove = 0
+		anchored = 1
+		timestopped = 1
 	EscapeConfinement()
 	..()
 
@@ -704,6 +710,7 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 /mob/living/simple_animal/hostile/spessmart_guardian/proc/Retaliate()
 	if(timestopped)
 		spawn(5)
+			retaliated = TRUE
 			canmove = 1
 			anchored = 0
 			timestopped = 0

--- a/maps/randomvaults/spessmart.dm
+++ b/maps/randomvaults/spessmart.dm
@@ -332,7 +332,7 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 		spawn()
 			S.close()
 
-	for(var/mob/living/simple_animal/hostile/spessmart_guardian/C in all_contents)
+	for(var/mob/living/simple_animal/hostile/retaliate/spessmart_guardian/C in all_contents)
 		C.Retaliate()
 
 	src.firealert()
@@ -634,7 +634,7 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 
 	return 1
 
-/mob/living/simple_animal/hostile/spessmart_guardian
+/mob/living/simple_animal/hostile/retaliate/spessmart_guardian
 	name = "Spessmart MERC-Bot"
 	desc = "Equipped with a ballistic weapon and a melee range shocker that is powerful enough to knock out a mega goliath through three layers of protection, this EMP-proof bot is not to be messed around with."
 
@@ -644,6 +644,8 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 	wander = 0
 	anchored = 1
 	canmove = 0
+
+	stat_calm_threshold = DEAD
 
 	melee_damage_lower = 10
 	melee_damage_upper = 25
@@ -679,21 +681,21 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 	var/alert_on_movement = 1 //If moved, trigger an alert and become agressive
 	var/retaliated = FALSE
 
-/mob/living/simple_animal/hostile/spessmart_guardian/New()
+/mob/living/simple_animal/hostile/retaliate/spessmart_guardian/New()
 	..()
 
 	overlays.Add(image('icons/mob/robots.dmi', icon_state = "eyes-securitron"))
 
-/mob/living/simple_animal/hostile/spessmart_guardian/Life()
+/mob/living/simple_animal/hostile/retaliate/spessmart_guardian/Life()
 	EscapeConfinement()
 	..()
 
-/mob/living/simple_animal/hostile/spessmart_guardian/death(var/gibbed = FALSE)
+/mob/living/simple_animal/hostile/retaliate/spessmart_guardian/death(var/gibbed = FALSE)
 	..(TRUE)
 	robogibs(get_turf(src))
 	qdel(src)
 
-/mob/living/simple_animal/hostile/spessmart_guardian/update_canmove()
+/mob/living/simple_animal/hostile/retaliate/spessmart_guardian/update_canmove()
 	if(retaliated || client)
 		canmove = 1
 		anchored = 0
@@ -702,16 +704,16 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 		anchored = 1
 	return canmove
 
-/mob/living/simple_animal/hostile/spessmart_guardian/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
+/mob/living/simple_animal/hostile/retaliate/spessmart_guardian/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	if(alert_on_movement && !canmove)
 		Retaliate()
 
 	..()
 
-/mob/living/simple_animal/hostile/spessmart_guardian/proc/Retaliate()
-	if(timestopped)
+/mob/living/simple_animal/hostile/retaliate/spessmart_guardian/Retaliate()
+	. = ..()
+	if(!retaliated)
 		spawn(5)
-			retaliated = TRUE
 			wander = 1
 			canmove = 1
 			anchored = 0
@@ -723,16 +725,16 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 			var/phrase = pick("Spessmart law was broken. The punishment is death.", "Spessmart law is above everything. Prepare to die.", "Spessmart law is sacred. Die, heretic.", "Threat to Spessmart detected. Extermination protocol started.")
 			say(phrase)
 
-/mob/living/simple_animal/hostile/spessmart_guardian/secure_area/attack_hand(mob/user)
+/mob/living/simple_animal/hostile/retaliate/spessmart_guardian/secure_area/attack_hand(mob/user)
 	if(user.a_intent == I_HELP)
 		say("[user.gender == FEMALE ? "Miss" : "Sir"], only Spessmart employees with level 5 access may access this area. If you are a Spessmart employee, please show me your ID card.")
 	else
 		return ..()
 
-/mob/living/simple_animal/hostile/spessmart_guardian/recharging
+/mob/living/simple_animal/hostile/retaliate/spessmart_guardian/recharging
 	var/introduced = FALSE
 
-/mob/living/simple_animal/hostile/spessmart_guardian/recharging/Aggro()
+/mob/living/simple_animal/hostile/retaliate/spessmart_guardian/recharging/Aggro()
 	if(!introduced)
 		say("The tank was labeled and scanned as drinking water, not welding fuel. It was not my fault that it was fed to the human. It is nonsense that you're punishing me instead of... Wait. You are not EPSILON. Unknown intruder detected. Extermination protocol started.")
 		introduced = TRUE

--- a/maps/randomvaults/spessmart.dm
+++ b/maps/randomvaults/spessmart.dm
@@ -645,8 +645,6 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 	anchored = 1
 	canmove = 0
 
-	stat_calm_threshold = INFINITY //keeps attacking after kill, as per original design wishes
-
 	melee_damage_lower = 10
 	melee_damage_upper = 25
 
@@ -710,7 +708,6 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 	..()
 
 /mob/living/simple_animal/hostile/retaliate/spessmart_guardian/Retaliate()
-	. = ..()
 	if(!hostile)
 		spawn(5)
 			wander = 1

--- a/maps/randomvaults/spessmart.dm
+++ b/maps/randomvaults/spessmart.dm
@@ -555,6 +555,7 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 
 	icon = 'icons/mob/robots.dmi'
 	icon_state = "booty-red"
+	faction = "spessmart"
 
 	var/spawn_sample_on_creation = 1
 	var/obj/item/weapon/reagent_containers/food/snacks/food_type = /obj/item/weapon/reagent_containers/food/snacks/faggot //Type of the food
@@ -692,7 +693,8 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 	qdel(src)
 
 /mob/living/simple_animal/hostile/spessmart_guardian/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
-	if(alert_on_movement && !canmove)
+	canmove = client != null
+	if(!client && alert_on_movement && !canmove)
 		Retaliate()
 
 	..()
@@ -777,6 +779,9 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 			clothing -= clothing_type
 	if (!clothing_prices.len)
 		for(var/C in clothing)
+			var/obj/item/clothing/CL = C
+			if(!initial(CL.canremove)) // no cursed unremovable stuff
+				continue
 			clothing_prices[C] = 150
 	to_spawn = clothing_prices
 	return ..()

--- a/maps/randomvaults/spessmart.dm
+++ b/maps/randomvaults/spessmart.dm
@@ -680,6 +680,7 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 
 /mob/living/simple_animal/hostile/spessmart_guardian/New()
 	..()
+
 	overlays.Add(image('icons/mob/robots.dmi', icon_state = "eyes-securitron"))
 
 /mob/living/simple_animal/hostile/spessmart_guardian/Life()

--- a/maps/randomvaults/spessmart.dm
+++ b/maps/randomvaults/spessmart.dm
@@ -645,7 +645,7 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 	anchored = 1
 	canmove = 0
 
-	stat_calm_threshold = DEAD
+	stat_calm_threshold = INFINITY //keeps attacking after kill, as per original design wishes
 
 	melee_damage_lower = 10
 	melee_damage_upper = 25

--- a/maps/randomvaults/spessmart.dm
+++ b/maps/randomvaults/spessmart.dm
@@ -277,13 +277,13 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 		return
 
 	if(items.Find(AM))
-		return on_theft(AM)
+		return on_theft(AM,loc)
 	else
 		var/list/AM_contents = get_contents_in_object(AM, /obj/item)
 
 		for(var/obj/item/I in AM_contents)
 			if(items.Find(I))
-				return on_theft(I)
+				return on_theft(I,loc)
 
 /area/vault/supermarket/shop/proc/purchased(obj/item/I, price)
 	items.Remove(I)
@@ -307,15 +307,15 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 
 	if(!lockdown && map_element.customer_has_entered)
 		message_admins("Spessmart has entered lockdown due to the destruction of \a [destroyed]!")
-		on_theft()
+		on_theft(user = usr)
 
 /area/vault/supermarket/shop/proc/on_robot_kill()
 	if(map_element)
 		map_element.set_stats_alarm_activated("Destruction of a robot[usr ? " by [usr]" : ""]")
 
-	on_theft()
+	on_theft(user = usr)
 
-/area/vault/supermarket/shop/proc/on_theft(obj/item/I)
+/area/vault/supermarket/shop/proc/on_theft(obj/item/I,mob/user)
 	if(lockdown)
 		return
 
@@ -333,6 +333,8 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 			S.close()
 
 	for(var/mob/living/simple_animal/hostile/retaliate/spessmart_guardian/C in all_contents)
+		if(istype(user))
+			C.enemies |= user
 		C.Retaliate()
 
 	src.firealert()

--- a/maps/randomvaults/spessmart.dm
+++ b/maps/randomvaults/spessmart.dm
@@ -709,6 +709,7 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 	if(timestopped)
 		spawn(5)
 			retaliated = TRUE
+			wander = 1
 			canmove = 1
 			anchored = 0
 

--- a/maps/randomvaults/spessmart.dm
+++ b/maps/randomvaults/spessmart.dm
@@ -680,10 +680,12 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 
 /mob/living/simple_animal/hostile/spessmart_guardian/New()
 	..()
-
 	overlays.Add(image('icons/mob/robots.dmi', icon_state = "eyes-securitron"))
 
 /mob/living/simple_animal/hostile/spessmart_guardian/Life()
+	canmove = client != null
+	anchored = client == null
+	timestopped = client == null
 	EscapeConfinement()
 	..()
 
@@ -693,8 +695,7 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 	qdel(src)
 
 /mob/living/simple_animal/hostile/spessmart_guardian/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
-	canmove = client != null
-	if(!client && alert_on_movement && !canmove)
+	if(alert_on_movement && !canmove)
 		Retaliate()
 
 	..()

--- a/maps/randomvaults/spessmart.dm
+++ b/maps/randomvaults/spessmart.dm
@@ -679,7 +679,6 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 	meat_type = null
 
 	var/alert_on_movement = 1 //If moved, trigger an alert and become agressive
-	var/retaliated = FALSE
 
 /mob/living/simple_animal/hostile/retaliate/spessmart_guardian/New()
 	..()
@@ -696,7 +695,7 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 	qdel(src)
 
 /mob/living/simple_animal/hostile/retaliate/spessmart_guardian/update_canmove()
-	if(retaliated || client)
+	if(enemies.len || client)
 		canmove = 1
 		anchored = 0
 	else
@@ -712,7 +711,7 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 
 /mob/living/simple_animal/hostile/retaliate/spessmart_guardian/Retaliate()
 	. = ..()
-	if(!retaliated)
+	if(!enemies.len)
 		spawn(5)
 			wander = 1
 			canmove = 1

--- a/maps/randomvaults/spessmart.dmm
+++ b/maps/randomvaults/spessmart.dmm
@@ -182,7 +182,7 @@
 /turf/simulated/floor,
 /area/vault/supermarket/shop)
 "aw" = (
-/mob/living/simple_animal/hostile/spessmart_guardian,
+/mob/living/simple_animal/hostile/retaliate/spessmart_guardian,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -306,7 +306,7 @@
 /turf/simulated/floor/grass,
 /area/vault/supermarket/shop)
 "aM" = (
-/mob/living/simple_animal/hostile/spessmart_guardian,
+/mob/living/simple_animal/hostile/retaliate/spessmart_guardian,
 /turf/simulated/floor,
 /area/vault/supermarket/shop)
 "aN" = (
@@ -319,7 +319,7 @@
 	icon_state = "warning";
 	tag = "icon-warning (WEST)"
 	},
-/mob/living/simple_animal/hostile/spessmart_guardian,
+/mob/living/simple_animal/hostile/retaliate/spessmart_guardian,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -383,7 +383,7 @@
 	icon_state = "warning";
 	tag = "icon-warning (WEST)"
 	},
-/mob/living/simple_animal/hostile/spessmart_guardian,
+/mob/living/simple_animal/hostile/retaliate/spessmart_guardian,
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "dark"
@@ -715,7 +715,7 @@
 	icon_state = "warning";
 	tag = "icon-warning (SOUTHWEST)"
 	},
-/mob/living/simple_animal/hostile/spessmart_guardian,
+/mob/living/simple_animal/hostile/retaliate/spessmart_guardian,
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "dark"
@@ -988,7 +988,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/mob/living/simple_animal/hostile/spessmart_guardian,
+/mob/living/simple_animal/hostile/retaliate/spessmart_guardian,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -1016,7 +1016,7 @@
 /area/vault/supermarket/restricted)
 "cp" = (
 /obj/machinery/recharge_station,
-/mob/living/simple_animal/hostile/spessmart_guardian/recharging,
+/mob/living/simple_animal/hostile/retaliate/spessmart_guardian/recharging,
 /turf/simulated/floor/plating/airless,
 /area/vault/supermarket/restricted)
 "cq" = (
@@ -1579,7 +1579,7 @@
 /turf/simulated/floor/plating/airless,
 /area/vault/supermarket/restricted)
 "dC" = (
-/mob/living/simple_animal/hostile/spessmart_guardian/secure_area,
+/mob/living/simple_animal/hostile/retaliate/spessmart_guardian/secure_area,
 /turf/simulated/floor,
 /area/vault/supermarket/restricted)
 "dD" = (
@@ -1587,7 +1587,7 @@
 /turf/simulated/floor,
 /area/vault/supermarket/entrance)
 "dE" = (
-/mob/living/simple_animal/hostile/spessmart_guardian,
+/mob/living/simple_animal/hostile/retaliate/spessmart_guardian,
 /turf/simulated/floor,
 /area/vault/supermarket/entrance)
 "dF" = (
@@ -1984,7 +1984,7 @@
 	},
 /area/vault/supermarket/entrance)
 "eF" = (
-/mob/living/simple_animal/hostile/spessmart_guardian,
+/mob/living/simple_animal/hostile/retaliate/spessmart_guardian,
 /turf/simulated/floor{
 	icon_state = "bar"
 	},


### PR DESCRIPTION
[bugfix]

## What this does
Closes #38411.
Closes #28124.
Closes #24921.

## How it was tested
loading spessmart, stealing an item from spessmart, admin possessing a mercbot.

## Changelog
:cl:
 * bugfix: Spessmart MERC bots no longer target the free sample offering bots.
 * bugfix: Spessmart MERC bots can now move if controlled by a player.
 * tweak: Unremovable clothing items can no longer spawn in spessmart.