### PR TITLE
Pluckening Patch : Vox and Vox Chickens

### DIFF
--- a/code/datums/helper_datums/butchering.dm
+++ b/code/datums/helper_datums/butchering.dm
@@ -287,9 +287,10 @@
 		if(color_data)
 			F.color = color_data["hex"]
 			F.name = "[color_data["name"]] feather"
-	if(amount == 0)
+	if(amount >= 5) // Stores original tone when the first feather is plucked.
 		if(!V.original_vox_tone)
 			V.original_vox_tone = V.my_appearance.s_tone
+	if(amount == 0)
 		V.my_appearance.s_tone = VOXPLUCKED
 		to_chat(V, "<span class='notice'>Your plumage is looking a bit bare...</span>")
 		V.species.updatespeciescolor(V)

--- a/code/modules/dna/genes/monkey.dm
+++ b/code/modules/dna/genes/monkey.dm
@@ -51,7 +51,11 @@
 		if (borer.controlling)
 			Mo.do_release_control(0)
 
-	var/mob/living/carbon/human/O = new(src)
+	var/mob/living/carbon/human/O
+	if(Mo.greaterform == "Vox")
+		O = new /mob/living/carbon/human/vox(src) //Special case for vox, needed for vox chickens else they never get feathers.
+	else
+		O = new(src)
 	if(Mo.greaterform)
 		O.set_species(Mo.greaterform) //Damage transfer is handled later in the code
 	Mo.transferImplantsTo(O)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
Fixes vox defaulting to green when they regenerate feathers and fixes vox chickens not having feathers when they get genetically altered. This is a new branch because the old one was being weird.
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## Why it's good
I love it when stuff works properly.
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->

## How it was tested
Tested to make sure vox chickens have the proper butchering tables when de-monkeyed. Made sure other monkeys were untouched. Made sure vox kept their original colors when they regenerate.
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed vox chickens not having feathers to pluck as well as fixing vox turning green after regenerating.
