### PR TITLE
Revert atmos presets

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -201,7 +201,7 @@
 							GAS_SLEEPING = new /datum/airalarm_threshold(-1, -1, 0.5, 1),
 							GAS_CRYOTHEUM = new /datum/airalarm_threshold(-1, -1, 0.5, 1) )
 	other_gas_threshold = new /datum/airalarm_threshold(-1, -1, 0.5, 1)
-	pressure_threshold = new /datum/airalarm_threshold(ONE_ATMOSPHERE*0.80, ONE_ATMOSPHERE*0.90, ONE_ATMOSPHERE*2.00, ONE_ATMOSPHERE*3.20)
+	pressure_threshold = new /datum/airalarm_threshold(ONE_ATMOSPHERE*0.80, ONE_ATMOSPHERE*0.90, ONE_ATMOSPHERE*1.10, ONE_ATMOSPHERE*1.20)
 	temperature_threshold = new /datum/airalarm_threshold(T0C-30, T0C, T0C+40, T0C+70)
 	target_temperature = T0C+20
 	scrubbed_gases = list( GAS_CARBON, GAS_PLASMA )
@@ -218,7 +218,7 @@
 							GAS_SLEEPING = new /datum/airalarm_threshold(-1, -1, 0.5, 1),
 							GAS_CRYOTHEUM = new /datum/airalarm_threshold(-1, -1, 0.5, 1) )
 	other_gas_threshold = new /datum/airalarm_threshold(-1, -1, 0.5, 1)
-	pressure_threshold = new /datum/airalarm_threshold(ONE_ATMOSPHERE*0.80, ONE_ATMOSPHERE*0.90, ONE_ATMOSPHERE*2.00, ONE_ATMOSPHERE*3.20)
+	pressure_threshold = new /datum/airalarm_threshold(ONE_ATMOSPHERE*0.80, ONE_ATMOSPHERE*0.90, ONE_ATMOSPHERE*1.10, ONE_ATMOSPHERE*1.20)
 	temperature_threshold = new /datum/airalarm_threshold(T0C-30, T0C, T0C+40, T0C+70)
 	target_temperature = T0C+20
 	scrubbed_gases = list( GAS_OXYGEN, GAS_CARBON, GAS_PLASMA )
@@ -235,7 +235,7 @@
 							GAS_SLEEPING = new /datum/airalarm_threshold(-1, -1, 0.5, 1),
 							GAS_CRYOTHEUM = new /datum/airalarm_threshold(-1, -1, 0.5, 1) )
 	other_gas_threshold = new /datum/airalarm_threshold(-1, -1, 0.5, 1)
-	pressure_threshold = new /datum/airalarm_threshold(-1, ONE_ATMOSPHERE*0.10, ONE_ATMOSPHERE*3.20, ONE_ATMOSPHERE*5.4)
+	pressure_threshold = new /datum/airalarm_threshold(-1, ONE_ATMOSPHERE*0.10, ONE_ATMOSPHERE*1.90, ONE_ATMOSPHERE*2.3)
 	temperature_threshold = new /datum/airalarm_threshold(20, 40, 140, 160)
 	target_temperature = 90
 	scrubbed_gases = list( GAS_OXYGEN, GAS_CARBON, GAS_PLASMA )
@@ -252,7 +252,7 @@
 							GAS_SLEEPING = new /datum/airalarm_threshold(-1, -1, 0.5, 1),
 							GAS_CRYOTHEUM = new /datum/airalarm_threshold(-1, -1, 0.5, 1) )
 	other_gas_threshold = new /datum/airalarm_threshold(-1, -1, 0.5, 1)
-	pressure_threshold = new /datum/airalarm_threshold(ONE_ATMOSPHERE*0.80, ONE_ATMOSPHERE*0.90, ONE_ATMOSPHERE*2.00, ONE_ATMOSPHERE*3.20)
+	pressure_threshold = new /datum/airalarm_threshold(ONE_ATMOSPHERE*0.80, ONE_ATMOSPHERE*0.90, ONE_ATMOSPHERE*1.10, ONE_ATMOSPHERE*1.20)
 	temperature_threshold = new /datum/airalarm_threshold(T0C-30, T0C, T0C+40, T0C+70)
 	target_temperature = T0C+20
 	scrubbed_gases = list( GAS_OXYGEN, GAS_NITROGEN, GAS_CARBON )


### PR DESCRIPTION
## What this does

Fixes #38429 
Reverts changes to atmos presets made as part of Junglestation. I believe the original intent behind these changes was to make Junglestation atmos not have under/overpressurisation issues, however the way that batch presets are applied via the CAC (target pressure is average of min1 and max1) results in target pressures for human presets (and others) getting set to an incorrect value. This leads to vents pushing more air into rooms than they should have and scrubbers quickly removing the un-needed excess.

## How it was tested
Before change:
<img width="866" height="785" alt="image" src="https://github.com/user-attachments/assets/9832cef1-440b-47f5-a28f-2279bf27d0ee" />
Batch Apply:
<img width="660" height="1306" alt="image" src="https://github.com/user-attachments/assets/45301ed6-5eec-4ab0-b303-bfd2e29c56d8" />


After change:
<img width="860" height="777" alt="image" src="https://github.com/user-attachments/assets/ae833bcd-5d8b-4254-907b-bc5b691a8a5d" />
Batch Apply:
<img width="665" height="1141" alt="image" src="https://github.com/user-attachments/assets/8fe7f6db-8646-4c10-9554-25205c0f00ad" />


## Changelog
:cl:

 * bugfix: Batch atmos presets no longer fuck up station air
