### PR TITLE
Object rotation verb and alt click code cutdown

### DIFF
--- a/code/game/machinery/ATMOSPHERICS/components/binary_devices/MSGS.dm
+++ b/code/game/machinery/ATMOSPHERICS/components/binary_devices/MSGS.dm
@@ -11,6 +11,9 @@
 	machine_flags = WRENCHMOVE | FIXED2WORK
 	idle_power_usage = 1000					//This thing's serious
 
+	verb_rotates = TRUE
+	alt_click_rotates = TRUE
+
 	var/internal_volume = 10000
 	var/max_pressure = 10000
 
@@ -208,27 +211,6 @@
 
 		node1 = null
 		node2 = null
-
-/obj/machinery/atmospherics/binary/msgs/verb/rotate_clockwise()
-	set category = "Object"
-	set name = "Rotate MSGS (Clockwise)"
-	set src in view(1)
-
-	if(usr.isUnconscious() || usr.restrained() || anchored)
-		return
-
-	src.dir = turn(src.dir, -90)
-
-
-/obj/machinery/atmospherics/binary/msgs/verb/rotate_anticlockwise()
-	set category = "Object"
-	set name = "Rotate MSGS (Counter-clockwise)"
-	set src in view(1)
-
-	if(usr.isUnconscious() || usr.restrained() || anchored)
-		return
-
-	src.dir = turn(src.dir, 90)
 
 /obj/machinery/atmospherics/binary/msgs/toggle_status(var/mob/user)
 	return FALSE

--- a/code/game/machinery/ATMOSPHERICS/components/binary_devices/circulator.dm
+++ b/code/game/machinery/ATMOSPHERICS/components/binary_devices/circulator.dm
@@ -10,6 +10,9 @@
 
 	use_power = MACHINE_POWER_USE_NONE
 
+	verb_rotates = TRUE
+	alt_click_rotates = TRUE
+
 	var/obj/machinery/power/generator/linked_generator
 
 	var/kinetic_efficiency				= 0.04 //combined kinetic and kinetic-to-electric efficiency
@@ -146,26 +149,6 @@
 		node2 = null
 
 		linked_generator.reconnect()
-
-/obj/machinery/atmospherics/binary/circulator/verb/rotate_clockwise()
-	set category = "Object"
-	set name = "Rotate Circulator (Clockwise)"
-	set src in view(1)
-
-	if(usr.isUnconscious() || usr.restrained() || anchored)
-		return
-
-	src.dir = turn(src.dir, -90)
-
-/obj/machinery/atmospherics/binary/circulator/verb/rotate_anticlockwise()
-	set category = "Object"
-	set name = "Rotate Circulator (Counterclockwise)"
-	set src in view(1)
-
-	if(usr.isUnconscious() || usr.restrained() || anchored)
-		return
-
-	src.dir = turn(src.dir, 90)
 
 /obj/machinery/atmospherics/binary/circulator/toggle_status(var/mob/user)
 	return FALSE

--- a/code/game/machinery/ATMOSPHERICS/components/unary/tank.dm
+++ b/code/game/machinery/ATMOSPHERICS/components/unary/tank.dm
@@ -12,20 +12,16 @@
 	density = 1
 	anchored = 1
 	machine_flags = WRENCHMOVE
+	verb_rotates = TRUE
+	alt_click_rotates = TRUE
 
 	var/init_temp = T20C
 	var/init_gas
-	var/list/rotate_verbs = list(
-		/obj/machinery/atmospherics/unary/tank/verb/rotate,
-		/obj/machinery/atmospherics/unary/tank/verb/rotate_ccw,
-	)
 
 /obj/machinery/atmospherics/unary/tank/New()
 	..()
 	air_contents.temperature = init_temp
 	atmos_machines.Remove(src)
-	if(anchored)
-		verbs -= rotate_verbs
 	if(init_gas)
 		air_contents.adjust_gas(init_gas, (STARTING_PRESSURE)*(starting_volume)/(R_IDEAL_GAS_EQUATION*air_contents.temperature))
 
@@ -118,34 +114,11 @@
 	..()
 	update_icon()
 
-/obj/machinery/atmospherics/unary/tank/verb/rotate()
-	set name = "Rotate Clockwise"
-	set category = "Object"
-	set src in oview(1)
-
-	if(src.anchored || usr:stat)
-		to_chat(usr, "It is fastened to the floor!")
-		return 0
-	src.dir = turn(src.dir, -90)
-	return 1
-
-/obj/machinery/atmospherics/unary/tank/verb/rotate_ccw()
-	set name = "Rotate Counter Clockwise"
-	set category = "Object"
-	set src in oview(1)
-
-	if(src.anchored || usr:stat)
-		to_chat(usr, "It is fastened to the floor!")
-		return 0
-	src.dir = turn(src.dir, 90)
-	return 1
-
 /obj/machinery/atmospherics/unary/tank/wrenchAnchor(var/mob/user, var/obj/item/I)
 	. = ..()
 	if(!.)
 		return
 	if(anchored)
-		verbs -= rotate_verbs
 		initialize_directions = dir
 		initialize()
 		build_network()
@@ -153,7 +126,6 @@
 			node1.initialize()
 			node1.build_network()
 	else
-		verbs += rotate_verbs
 		if(node1)
 			node1.disconnect(src)
 			node1 = null

--- a/code/game/machinery/ATMOSPHERICS/pipe/construction.dm
+++ b/code/game/machinery/ATMOSPHERICS/pipe/construction.dm
@@ -331,6 +331,14 @@ var/list/straight_pipes = list(PIPE_SIMPLE_STRAIGHT, PIPE_HE_STRAIGHT, PIPE_INSU
 var/list/bent_pipes = list(PIPE_SIMPLE_BENT, PIPE_HE_BENT, PIPE_INSULATED_BENT)
 var/list/manifold_pipes = list(PIPE_MANIFOLD4W, PIPE_INSUL_MANIFOLD4W, PIPE_HE_MANIFOLD4W)
 
+/obj/item/pipe/change_dir(new_dir, changer)
+	. = ..()
+	if (pipe_type in straight_pipes)
+		dir=rotate_pipe_straight(dir)
+	else if (pipe_type in manifold_pipes)
+		dir = 2
+	//src.pipe_dir = get_pipe_dir()
+
 /obj/item/pipe/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	..()
 	if ((pipe_type in bent_pipes) \

--- a/code/game/machinery/ATMOSPHERICS/pipe/construction.dm
+++ b/code/game/machinery/ATMOSPHERICS/pipe/construction.dm
@@ -419,7 +419,7 @@ var/list/manifold_pipes = list(PIPE_MANIFOLD4W, PIPE_INSUL_MANIFOLD4W, PIPE_HE_M
 			return 0
 
 /obj/item/pipe/attack_self(mob/user as mob)
-	return rotate()
+	return rotate_ccw()
 
 /obj/item/pipe/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
 	..()

--- a/code/game/machinery/ATMOSPHERICS/pipe/construction.dm
+++ b/code/game/machinery/ATMOSPHERICS/pipe/construction.dm
@@ -75,6 +75,8 @@ var/global/list/heat_pipes = list(PIPE_HE_STRAIGHT, PIPE_HE_BENT, PIPE_JUNCTION,
 	flags = FPRINT
 	w_class = W_CLASS_MEDIUM
 	level = 2
+	verb_rotates = TRUE
+	alt_click_rotates = TRUE
 	var/frequency = 0
 	var/id_tag = null
 
@@ -328,28 +330,6 @@ var/global/list/nlist = list( \
 var/list/straight_pipes = list(PIPE_SIMPLE_STRAIGHT, PIPE_HE_STRAIGHT, PIPE_INSULATED_STRAIGHT, PIPE_MVALVE, PIPE_DVALVE)
 var/list/bent_pipes = list(PIPE_SIMPLE_BENT, PIPE_HE_BENT, PIPE_INSULATED_BENT)
 var/list/manifold_pipes = list(PIPE_MANIFOLD4W, PIPE_INSUL_MANIFOLD4W, PIPE_HE_MANIFOLD4W)
-/obj/item/pipe/verb/rotate()
-	set category = "Object"
-	set name = "Rotate Pipe"
-	set src in view(1)
-
-	if(usr.isUnconscious() || usr.restrained())
-		return
-
-	src.dir = turn(src.dir, -90)
-
-	if (pipe_type in straight_pipes)
-		dir=rotate_pipe_straight(dir)
-	else if (pipe_type in manifold_pipes)
-		dir = 2
-	//src.pipe_dir = get_pipe_dir()
-	return
-
-/obj/item/pipe/AltClick(var/mob/user)
-	if(user.incapacitated() || !Adjacent(user))
-		..()
-		return
-	rotate()
 
 /obj/item/pipe/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	..()
@@ -521,7 +501,7 @@ var/list/manifold_pipes = list(PIPE_MANIFOLD4W, PIPE_INSUL_MANIFOLD4W, PIPE_HE_M
 
 		if(PIPE_HE_CAP)
 			P=new /obj/machinery/atmospherics/unary/cap/heat(src.loc)
-			
+
 		if(PIPE_BSCAP)
 			P=new /obj/machinery/atmospherics/unary/cap/bluespace(src.loc)
 
@@ -606,7 +586,7 @@ var/list/manifold_pipes = list(PIPE_MANIFOLD4W, PIPE_INSUL_MANIFOLD4W, PIPE_HE_M
 	var/id_tag = null
 
 	var/layer_to_make = PIPING_LAYER_DEFAULT
-	
+
 /obj/item/pipe_meter/New(loc, freq, id)
 	..()
 	if(freq)
@@ -652,7 +632,7 @@ var/list/manifold_pipes = list(PIPE_MANIFOLD4W, PIPE_INSUL_MANIFOLD4W, PIPE_HE_M
 	w_class = W_CLASS_LARGE
 	var/frequency = 1439
 	var/id_tag = null
-	
+
 /obj/item/pipe_gsensor/New(loc, freq, id)
 	..()
 	if(freq)

--- a/code/game/machinery/Freezer.dm
+++ b/code/game/machinery/Freezer.dm
@@ -14,10 +14,8 @@
 
 	machine_flags = SCREWTOGGLE | CROWDESTROY | WRENCHMOVE | FIXED2WORK
 
-	var/list/rotate_verbs=list(
-		/obj/machinery/atmospherics/unary/cold_sink/freezer/verb/rotate,
-		/obj/machinery/atmospherics/unary/cold_sink/freezer/verb/rotate_ccw,
-	)
+	verb_rotates = TRUE
+	alt_click_rotates = TRUE
 
 /obj/machinery/atmospherics/unary/cold_sink/freezer/New()
 	. = ..()
@@ -31,9 +29,6 @@
 	)
 
 	RefreshParts()
-
-	if(anchored)
-		verbs -= rotate_verbs
 
 /obj/machinery/atmospherics/unary/cold_sink/freezer/RefreshParts()
 	var/lasercount = 0
@@ -74,7 +69,6 @@
 	if(!.)
 		return
 	if(anchored)
-		verbs -= rotate_verbs
 		initialize_directions = dir
 		initialize()
 		build_network()
@@ -82,7 +76,6 @@
 			node1.initialize()
 			node1.build_network()
 	else
-		verbs += rotate_verbs
 		if(node1)
 			node1.disconnect(src)
 			node1 = null
@@ -137,29 +130,6 @@
 	..()
 	src.updateUsrDialog()
 
-
-/obj/machinery/atmospherics/unary/cold_sink/freezer/verb/rotate()
-	set name = "Rotate Clockwise"
-	set category = "Object"
-	set src in oview(1)
-
-	if (src.anchored || usr:stat)
-		to_chat(usr, "It is fastened to the floor!")
-		return 0
-	src.dir = turn(src.dir, -90)
-	return 1
-
-/obj/machinery/atmospherics/unary/cold_sink/freezer/verb/rotate_ccw()
-	set name = "Rotate Counter Clockwise"
-	set category = "Object"
-	set src in oview(1)
-
-	if (src.anchored || usr:stat)
-		to_chat(usr, "It is fastened to the floor!")
-		return 0
-	src.dir = turn(src.dir, 90)
-	return 1
-
 /obj/machinery/atmospherics/unary/cold_sink/freezer/exposed()
 	return TRUE
 
@@ -185,11 +155,8 @@
 	var/temp_offset = 0
 
 	machine_flags = SCREWTOGGLE | CROWDESTROY | WRENCHMOVE | FIXED2WORK
-
-	var/list/rotate_verbs=list(
-		/obj/machinery/atmospherics/unary/heat_reservoir/heater/verb/rotate,
-		/obj/machinery/atmospherics/unary/heat_reservoir/heater/verb/rotate_ccw,
-	)
+	verb_rotates = TRUE
+	alt_click_rotates = TRUE
 
 /obj/machinery/atmospherics/unary/heat_reservoir/heater/New()
 	. = ..()
@@ -203,9 +170,6 @@
 	)
 
 	RefreshParts()
-
-	if(anchored)
-		verbs -= rotate_verbs
 
 /obj/machinery/atmospherics/unary/heat_reservoir/heater/RefreshParts()
 	var/lasercount = 0
@@ -247,7 +211,6 @@
 	if(!.)
 		return
 	if(anchored)
-		verbs -= rotate_verbs
 		initialize_directions = dir
 		initialize()
 		build_network()
@@ -255,7 +218,6 @@
 			node1.initialize()
 			node1.build_network()
 	else
-		verbs += rotate_verbs
 		if(node1)
 			node1.disconnect(src)
 			node1 = null
@@ -306,29 +268,6 @@
 /obj/machinery/atmospherics/unary/heat_reservoir/heater/process()
 	..()
 	src.updateUsrDialog()
-
-
-/obj/machinery/atmospherics/unary/heat_reservoir/heater/verb/rotate()
-	set name = "Rotate Clockwise"
-	set category = "Object"
-	set src in oview(1)
-
-	if (src.anchored || usr:stat)
-		to_chat(usr, "It is fastened to the floor!")
-		return 0
-	src.dir = turn(src.dir, -90)
-	return 1
-
-/obj/machinery/atmospherics/unary/heat_reservoir/heater/verb/rotate_ccw()
-	set name = "Rotate Counter Clockwise"
-	set category = "Object"
-	set src in oview(1)
-
-	if (src.anchored || usr:stat)
-		to_chat(usr, "It is fastened to the floor!")
-		return 0
-	src.dir = turn(src.dir, 90)
-	return 1
 
 /obj/machinery/atmospherics/unary/heat_reservoir/heater/exposed()
 	return TRUE

--- a/code/game/machinery/mass_driver.dm
+++ b/code/game/machinery/mass_driver.dm
@@ -126,6 +126,8 @@ var/list/mass_drivers = list()
 	icon_state = "mass_driver_b0"
 	density = 0
 	anchored = 0
+	verb_rotates = TRUE
+	alt_click_rotates = TRUE
 	var/datum/construction/reversible/construct
 
 /obj/machinery/mass_driver_frame/New()
@@ -135,17 +137,6 @@ var/list/mass_drivers = list()
 /obj/machinery/mass_driver_frame/attackby(var/obj/item/W, var/mob/user)
 	if(!construct || !construct.action(W, user))
 		..()
-
-/obj/machinery/mass_driver_frame/verb/rotate()
-	set category = "Object"
-	set name = "Rotate Frame"
-	set src in view(1)
-
-	if (usr.isUnconscious() || usr.restrained())
-		return
-
-	src.dir = turn(src.dir, -90)
-	return
 
 /datum/construction/reversible/mass_driver
 	result = /obj/machinery/mass_driver

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -290,7 +290,7 @@ var/global/list/reagents_to_always_log = list(AMUTATIONTOXIN, CYANIDE, CHEFSPECI
 
 /obj/AltClick(mob/user)
 	if(!user.incapacitated() && Adjacent(user) && alt_click_rotates)
-		rotate()
+		rotate_ccw()
 	return ..()
 
 /obj/proc/rotate_cw()

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -291,7 +291,7 @@ var/global/list/reagents_to_always_log = list(AMUTATIONTOXIN, CYANIDE, CHEFSPECI
 	return 0
 
 /obj/AltClick(mob/user)
-	if(!user.incapacitated() && Adjacent(user) && alt_click_rotates)
+	if(Adjacent(user) && alt_click_rotates)
 		rotate_ccw()
 	return ..()
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -318,7 +318,7 @@ var/global/list/reagents_to_always_log = list(AMUTATIONTOXIN, CYANIDE, CHEFSPECI
 			investigation_log(I_GHOST, "|| was rotated by [key_name(ghost)][ghost.locked_to ? ", who was haunting [ghost.locked_to]" : ""]")
 		ghost.last_obj_spin = world.time
 	else if (usr.incapacitated())
-		to_chat(usr, "You cannot rotate this while incapacitated!")
+		to_chat(usr, "<span class='warning'>You cannot rotate this while incapacitated!</span>")
 		return 0
 	if(!rotates_anchored && anchored)
 		var/turf/T = loc

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -71,6 +71,7 @@ var/global/list/reagents_to_always_log = list(AMUTATIONTOXIN, CYANIDE, CHEFSPECI
 	var/verb_rotates = FALSE
 	var/alt_click_rotates = FALSE
 	var/ghost_can_rotate = FALSE
+	var/rotates_anchored = FALSE
 	var/rotate_type = null
 
 /obj/New()
@@ -319,7 +320,7 @@ var/global/list/reagents_to_always_log = list(AMUTATIONTOXIN, CYANIDE, CHEFSPECI
 	else if (usr.incapacitated())
 		to_chat(usr, "You cannot rotate this while incapacitated!")
 		return 0
-	if(anchored)
+	if(!rotates_anchored && anchored)
 		var/turf/T = loc
 		if(T)
 			for(var/obj/O in T)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -68,6 +68,9 @@ var/global/list/reagents_to_always_log = list(AMUTATIONTOXIN, CYANIDE, CHEFSPECI
 	//Is the object covered in ash?
 	var/ash_covered = FALSE
 
+	var/verb_rotates = FALSE
+	var/alt_click_rotates = FALSE
+
 /obj/New()
 	..()
 	if(breakable_flags)
@@ -92,6 +95,9 @@ var/global/list/reagents_to_always_log = list(AMUTATIONTOXIN, CYANIDE, CHEFSPECI
 		var/turf/simulated/T = get_turf(src)
 		if(istype(T))
 			T.zone?.burnable_atoms |= src
+	if(verb_rotates)
+		verbs += /obj/proc/rotate
+		verbs += /obj/proc/rotate_ccw
 
 //More cooking stuff:
 /obj/proc/can_cook() //Returns true if object is currently in a state that would allow for food to be cooked on it (eg. the grill is currently powered on). Can (and generally should) be overriden to check for more specific conditions.
@@ -280,6 +286,39 @@ var/global/list/reagents_to_always_log = list(AMUTATIONTOXIN, CYANIDE, CHEFSPECI
 		QDEL_NULL(pAImove_delayer)
 		return P
 	return 0
+
+/obj/AltClick(mob/user)
+	if(!user.incapacitated() && Adjacent(user) && alt_click_rotates)
+		rotate()
+	return ..()
+
+/obj/proc/rotate()
+	set name = "Rotate Clockwise"
+	set category = "Object"
+	set src in oview(1)
+
+	if (src.anchored)
+		to_chat(usr, "It is fastened to the floor!")
+		return 0
+	if (usr.incapacitated())
+		to_chat(usr, "You cannot rotate this while incapacitated!")
+		return 0
+	src.dir = turn(src.dir, -90)
+	return 1
+
+/obj/proc/rotate_ccw()
+	set name = "Rotate Counter Clockwise"
+	set category = "Object"
+	set src in oview(1)
+
+	if (src.anchored)
+		to_chat(usr, "It is fastened to the floor!")
+		return 0
+	if (usr.incapacitated())
+		to_chat(usr, "You cannot rotate this while incapacitated!")
+		return 0
+	src.dir = turn(src.dir, 90)
+	return 1
 
 /obj/recycle(var/datum/materials/rec)
 	if(..())

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -735,6 +735,14 @@ a {
 		user.visible_message(	"<span class='notice'>[user] [anchored ? "wrench" : "unwrench"]es \the [src] [anchored ? "in place" : "from its fixture"]</span>",
 								"<span class='notice'>[bicon(src)] You [anchored ? "wrench" : "unwrench"] \the [src] [anchored ? "in place" : "from its fixture"].</span>",
 								"<span class='notice'>You hear a ratchet.</span>")
+
+		if(verb_rotates)
+			if(anchored)
+				verbs |= /obj/proc/rotate_cw
+				verbs |= /obj/proc/rotate_ccw
+			else
+				verbs -= /obj/proc/rotate_cw
+				verbs -= /obj/proc/rotate_ccw
 		return TRUE
 	return FALSE
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -321,7 +321,7 @@ var/global/list/reagents_to_always_log = list(AMUTATIONTOXIN, CYANIDE, CHEFSPECI
 		if(T)
 			for(var/obj/O in T)
 				var/rotated_type = rotate_type || src.type
-				if(istype(O,src.type) && !O.anchored && O.dir == src.dir)
+				if(istype(O,rotated_type) && !O.anchored && O.dir == src.dir)
 					O.rotate(angle)
 					return
 		to_chat(usr, "<span class='warning'>\The [src] is fastened to the floor, therefore you can't rotate it!</span>")

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -70,6 +70,7 @@ var/global/list/reagents_to_always_log = list(AMUTATIONTOXIN, CYANIDE, CHEFSPECI
 
 	var/verb_rotates = FALSE
 	var/alt_click_rotates = FALSE
+	var/ghost_can_rotate = FALSE
 	var/rotate_type = null
 
 /obj/New()
@@ -298,9 +299,6 @@ var/global/list/reagents_to_always_log = list(AMUTATIONTOXIN, CYANIDE, CHEFSPECI
 	set category = "Object"
 	set src in oview(1)
 
-	if (usr.incapacitated())
-		to_chat(usr, "You cannot rotate this while incapacitated!")
-		return 0
 	rotate(270)
 	return 1
 
@@ -309,13 +307,20 @@ var/global/list/reagents_to_always_log = list(AMUTATIONTOXIN, CYANIDE, CHEFSPECI
 	set category = "Object"
 	set src in oview(1)
 
-	if (usr.incapacitated())
-		to_chat(usr, "You cannot rotate this while incapacitated!")
-		return 0
 	rotate(90)
 	return 1
 
 /obj/proc/rotate(var/angle = 90)
+	if(isobserver(usr))
+		if(!ghost_can_rotate)
+			return
+		var/mob/dead/observer/ghost = usr
+		if(ghost.last_obj_spin <= world.time - 5) //do not spam this
+			investigation_log(I_GHOST, "|| was rotated by [key_name(ghost)][ghost.locked_to ? ", who was haunting [ghost.locked_to]" : ""]")
+		ghost.last_obj_spin = world.time
+	else if (usr.incapacitated())
+		to_chat(usr, "You cannot rotate this while incapacitated!")
+		return 0
 	if(anchored)
 		var/turf/T = loc
 		if(T)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -291,7 +291,7 @@ var/global/list/reagents_to_always_log = list(AMUTATIONTOXIN, CYANIDE, CHEFSPECI
 	return 0
 
 /obj/AltClick(mob/user)
-	if(Adjacent(user) && alt_click_rotates)
+	if(alt_click_rotates & Adjacent(user))
 		rotate_ccw()
 	return ..()
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -311,9 +311,7 @@ var/global/list/reagents_to_always_log = list(AMUTATIONTOXIN, CYANIDE, CHEFSPECI
 	return 1
 
 /obj/proc/rotate(var/angle = 90)
-	if(isobserver(usr))
-		if(!ghost_can_rotate)
-			return
+	if(ghost_can_rotate && isobserver(usr))
 		var/mob/dead/observer/ghost = usr
 		if(ghost.last_obj_spin <= world.time - 5) //do not spam this
 			investigation_log(I_GHOST, "|| was rotated by [key_name(ghost)][ghost.locked_to ? ", who was haunting [ghost.locked_to]" : ""]")

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -327,11 +327,12 @@ var/global/list/reagents_to_always_log = list(AMUTATIONTOXIN, CYANIDE, CHEFSPECI
 				var/rotated_type = rotate_type || src.type
 				if(istype(O,rotated_type) && !O.anchored && O.dir == src.dir)
 					O.rotate(angle)
-					return
+					return 0
 		to_chat(usr, "<span class='warning'>\The [src] is fastened to the floor, therefore you can't rotate it!</span>")
-		return
+		return 0
 
 	change_dir(turn(dir, angle))
+	return 1
 
 /obj/recycle(var/datum/materials/rec)
 	if(..())

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -70,6 +70,7 @@ var/global/list/reagents_to_always_log = list(AMUTATIONTOXIN, CYANIDE, CHEFSPECI
 
 	var/verb_rotates = FALSE
 	var/alt_click_rotates = FALSE
+	var/rotate_type = null
 
 /obj/New()
 	..()
@@ -96,7 +97,7 @@ var/global/list/reagents_to_always_log = list(AMUTATIONTOXIN, CYANIDE, CHEFSPECI
 		if(istype(T))
 			T.zone?.burnable_atoms |= src
 	if(verb_rotates)
-		verbs += /obj/proc/rotate
+		verbs += /obj/proc/rotate_cw
 		verbs += /obj/proc/rotate_ccw
 
 //More cooking stuff:
@@ -292,18 +293,15 @@ var/global/list/reagents_to_always_log = list(AMUTATIONTOXIN, CYANIDE, CHEFSPECI
 		rotate()
 	return ..()
 
-/obj/proc/rotate()
+/obj/proc/rotate_cw()
 	set name = "Rotate Clockwise"
 	set category = "Object"
 	set src in oview(1)
 
-	if (src.anchored)
-		to_chat(usr, "It is fastened to the floor!")
-		return 0
 	if (usr.incapacitated())
 		to_chat(usr, "You cannot rotate this while incapacitated!")
 		return 0
-	src.dir = turn(src.dir, -90)
+	rotate(270)
 	return 1
 
 /obj/proc/rotate_ccw()
@@ -311,14 +309,25 @@ var/global/list/reagents_to_always_log = list(AMUTATIONTOXIN, CYANIDE, CHEFSPECI
 	set category = "Object"
 	set src in oview(1)
 
-	if (src.anchored)
-		to_chat(usr, "It is fastened to the floor!")
-		return 0
 	if (usr.incapacitated())
 		to_chat(usr, "You cannot rotate this while incapacitated!")
 		return 0
-	src.dir = turn(src.dir, 90)
+	rotate(90)
 	return 1
+
+/obj/proc/rotate(var/angle = 90)
+	if(anchored)
+		var/turf/T = loc
+		if(T)
+			for(var/obj/O in T)
+				var/rotated_type = rotate_type || src.type
+				if(istype(O,src.type) && !O.anchored && O.dir == src.dir)
+					O.rotate(angle)
+					return
+		to_chat(usr, "<span class='warning'>\The [src] is fastened to the floor, therefore you can't rotate it!</span>")
+		return
+
+	change_dir(turn(dir, angle))
 
 /obj/recycle(var/datum/materials/rec)
 	if(..())

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -735,7 +735,6 @@ a {
 		user.visible_message(	"<span class='notice'>[user] [anchored ? "wrench" : "unwrench"]es \the [src] [anchored ? "in place" : "from its fixture"]</span>",
 								"<span class='notice'>[bicon(src)] You [anchored ? "wrench" : "unwrench"] \the [src] [anchored ? "in place" : "from its fixture"].</span>",
 								"<span class='notice'>You hear a ratchet.</span>")
-
 		if(verb_rotates)
 			if(anchored)
 				verbs |= /obj/proc/rotate_cw

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -133,6 +133,8 @@
 	sheetamount = 3
 	layer = ABOVE_DOOR_LAYER
 	is_fulltile = TRUE
+	verb_rotates = FALSE
+	alt_click_rotates = FALSE
 
 //Basically the barricade version of full windows, and inherits the former rather than the later
 /obj/structure/window/barricade/full/New(loc)

--- a/code/game/objects/structures/electricchair.dm
+++ b/code/game/objects/structures/electricchair.dm
@@ -37,8 +37,8 @@
 	icon_state = "echair[on]"
 	to_chat(usr, "<span class='notice'>You switch [on ? "on" : "off"] [src].</span>")
 
-/obj/structure/bed/chair/e_chair/rotate(var/angle = 90)
-	..()
+/obj/structure/bed/chair/e_chair/change_dir(new_dir, changer)
+	. = ..()
 	overlays.len = 0
 	var/image/electric_chair_overlay = image('icons/obj/objects.dmi', src, "echair_over")
 	electric_chair_overlay.plane = ABOVE_HUMAN_PLANE

--- a/code/game/objects/structures/electricchair.dm
+++ b/code/game/objects/structures/electricchair.dm
@@ -37,7 +37,7 @@
 	icon_state = "echair[on]"
 	to_chat(usr, "<span class='notice'>You switch [on ? "on" : "off"] [src].</span>")
 
-/obj/structure/bed/chair/e_chair/rotate()
+/obj/structure/bed/chair/e_chair/rotate(var/angle = 90)
 	..()
 	overlays.len = 0
 	var/image/electric_chair_overlay = image('icons/obj/objects.dmi', src, "echair_over")

--- a/code/game/objects/structures/fullwindow.dm
+++ b/code/game/objects/structures/fullwindow.dm
@@ -13,6 +13,8 @@
 	penetration_dampening = 1
 	cracked_base = "fcrack"
 	is_fulltile = TRUE
+	verb_rotates = FALSE
+	alt_click_rotates = FALSE
 	disperse_coeff = 0.95
 	pass_flags_self = PASSGLASS
 	bordersmooth_override = 1

--- a/code/game/objects/structures/mannequin.dm
+++ b/code/game/objects/structures/mannequin.dm
@@ -19,6 +19,8 @@
 	plane = ABOVE_HUMAN_PLANE
 	layer = VEHICLE_LAYER
 	flags = FPRINT | PROXMOVE
+	verb_rotates = TRUE
+	alt_click_rotates = TRUE
 	var/trueForm = /mob/living/simple_animal/hostile/mannequin
 	var/pedestal = /obj/item/trash/mannequin
 	var/datum/species/species
@@ -970,27 +972,10 @@
 	update_icon()
 
 
-/obj/structure/mannequin/proc/spin()
+/obj/structure/mannequin/change_dir(new_dir, changer)
 	INVOKE_EVENT(src, /event/before_move)
-	change_dir(turn(dir, 90))
+	. = ..()
 	INVOKE_EVENT(src, /event/after_move)
-
-/obj/structure/mannequin/verb/rotate_mannequin()
-	set name = "Rotate Mannequin"
-	set category = "Object"
-	set src in oview(1)
-
-	if(!usr || !isturf(usr.loc))
-		return
-
-	if(anchored)
-		return
-
-	if(usr.isUnconscious() || usr.restrained())
-		return
-
-	spin()
-
 
 /obj/structure/mannequin/woman
 	name = "human woman marble mannequin"

--- a/code/game/objects/structures/mannequin.dm
+++ b/code/game/objects/structures/mannequin.dm
@@ -22,7 +22,6 @@
 	verb_rotates = TRUE
 	alt_click_rotates = TRUE
 	rotates_anchored = FALSE
-	rotate_type = /obj/structure/mannequin
 	var/trueForm = /mob/living/simple_animal/hostile/mannequin
 	var/pedestal = /obj/item/trash/mannequin
 	var/datum/species/species

--- a/code/game/objects/structures/mannequin.dm
+++ b/code/game/objects/structures/mannequin.dm
@@ -21,6 +21,8 @@
 	flags = FPRINT | PROXMOVE
 	verb_rotates = TRUE
 	alt_click_rotates = TRUE
+	rotates_anchored = FALSE
+	rotate_type = /obj/structure/mannequin
 	var/trueForm = /mob/living/simple_animal/hostile/mannequin
 	var/pedestal = /obj/item/trash/mannequin
 	var/datum/species/species

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -13,6 +13,9 @@
 	layer = RAILING_BACK_LAYER
 	flow_flags = ON_BORDER
 	pass_flags_self = PASSRAILING|PASSGLASS
+	verb_rotates = TRUE
+	alt_click_rotates = TRUE
+	rotate_type = /obj/structure/railing
 	var/railingtype = "metal"
 	var/wrenchtime = 10
 	var/weldtime = 25
@@ -182,38 +185,6 @@
 			layer = RAILING_FRONT_LAYER
 		if(4, 8)
 			layer = RAILING_MID_LAYER
-
-/obj/structure/railing/AltClick(mob/user)
-	if(user.incapacitated() || !Adjacent(user))
-		return
-	ccwrotate()
-
-/obj/structure/railing/verb/cwrotate()
-	set name = "Rotate Railing Clockwise"
-	set category = "Object"
-	set src in oview(1)
-
-	rotate(270)
-
-/obj/structure/railing/verb/ccwrotate()
-	set name = "Rotate Railing Counter-Clockwise"
-	set category = "Object"
-	set src in oview(1)
-
-	rotate(90)
-
-/obj/structure/railing/proc/rotate(var/angle = 90)
-	if(anchored)
-		var/turf/T = loc
-		if(T)
-			for(var/obj/structure/railing/R in T)
-				if(!R.anchored && R.dir == src.dir)
-					R.rotate(angle)
-					return
-		to_chat(usr, "<span class='warning'>\The [src] is fastened to the floor, therefore you can't rotate it!</span>")
-		return
-
-	change_dir(turn(dir, angle))
 
 /obj/structure/railing/attackby(var/obj/item/C, var/mob/user)
 	if(..())

--- a/code/game/objects/structures/shuttle_engines.dm
+++ b/code/game/objects/structures/shuttle_engines.dm
@@ -41,7 +41,7 @@
 	icon_state = "propulsion"
 	opacity = 1
 	var/exhaust_type = /obj/item/projectile/fire_breath/shuttle_exhaust
-	var/destroyed = 0 
+	var/destroyed = 0
 
 /obj/structure/shuttle/engine/propulsion/ex_act(severity)
 	switch(severity)
@@ -111,6 +111,8 @@
 	name = "shuttle engine"
 	var/obj/structure/shuttle/engine/heater/DIY/heater = null
 	anchored = FALSE
+	verb_rotates = TRUE
+	alt_click_rotates = TRUE
 
 /obj/structure/shuttle/engine/propulsion/DIY/proc/disconnect()
 	if(heater)
@@ -167,36 +169,6 @@
 		if(O.flow_flags & ON_BORDER && dir == O.dir)
 			to_chat(user, "<span class = 'warning''>\The [O] is blocking engine flow to space.</span>")
 			return FALSE
-	return ..()
-
-/obj/structure/shuttle/engine/propulsion/DIY/verb/rotate_cw()
-	set src in view(1)
-	set name = "Rotate suspension gen (Clockwise)"
-	set category = "Object"
-
-	if(anchored)
-		to_chat(usr, "<span class='warning'>You cannot rotate [src], it has been firmly fixed to the floor.</span>")
-	else
-		dir = turn(dir, -90)
-
-/obj/structure/shuttle/engine/propulsion/DIY/verb/rotate_ccw()
-	set src in view(1)
-	set name = "Rotate suspension gen (Counter-Clockwise)"
-	set category = "Object"
-
-	if(anchored)
-		to_chat(usr, "<span class='warning'>You cannot rotate [src], it has been firmly fixed to the floor.</span>")
-	else
-		dir = turn(dir, 90)
-
-/obj/structure/shuttle/engine/propulsion/DIY/AltClick(mob/user)
-	if(Adjacent(user))
-		return rotate_cw()
-	return ..()
-
-/obj/structure/shuttle/engine/propulsion/DIY/ShiftClick(mob/user)
-	if(Adjacent(user))
-		return rotate_ccw()
 	return ..()
 
 /obj/structure/shuttle/engine/propulsion/proc/shoot_exhaust(forward=9, backward=9, var/turf/source_turf)

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -12,7 +12,6 @@
 	icon_state = "chair"
 	sheet_amt = 1
 	verb_rotates = TRUE
-	rotate_type = /obj/structure/bed/chair
 	ghost_can_rotate = TRUE
 	var/image/buckle_overlay = null // image for overlays when a mob is buckled to the chair
 	var/image/secondary_buckle_overlay = null // for those really complicated chairs

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -16,7 +16,6 @@
 	var/image/buckle_overlay = null // image for overlays when a mob is buckled to the chair
 	var/image/secondary_buckle_overlay = null // for those really complicated chairs
 	var/can_rotate = TRUE
-	var/ghost_can_rotate = TRUE
 	mob_lock_type = /datum/locking_category/buckle/chair
 
 /obj/structure/bed/chair/New()
@@ -137,20 +136,6 @@
 		plane = ABOVE_HUMAN_PLANE
 	else
 		plane = OBJ_PLANE
-
-/obj/structure/bed/chair/rotate(var/angle = 90)
-	if(!can_rotate || !usr || !isturf(usr.loc))
-		return
-
-	if(isobserver(usr))
-		if(!ghost_can_rotate)
-			return
-		var/mob/dead/observer/ghost = usr
-		if(ghost.lastchairspin <= world.time - 5) //do not spam this
-			investigation_log(I_GHOST, "|| was rotated by [key_name(ghost)][ghost.locked_to ? ", who was haunting [ghost.locked_to]" : ""]")
-		ghost.lastchairspin = world.time
-
-	change_dir(turn(dir, angle))
 
 /obj/structure/bed/chair/relayface(var/mob/living/user, direction) //ALSO for vehicles!
 	if(!can_rotate || user.incapacitated())

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -11,6 +11,8 @@
 	desc = "You sit in this. Either by will or force."
 	icon_state = "chair"
 	sheet_amt = 1
+	verb_rotates = TRUE
+	rotate_type = /obj/structure/bed/chair
 	var/image/buckle_overlay = null // image for overlays when a mob is buckled to the chair
 	var/image/secondary_buckle_overlay = null // for those really complicated chairs
 	var/can_rotate = TRUE
@@ -136,7 +138,7 @@
 	else
 		plane = OBJ_PLANE
 
-/obj/structure/bed/chair/proc/spin(mob/user)
+/obj/structure/bed/chair/rotate(var/angle = 90)
 	if(!can_rotate || !user || !isturf(user.loc))
 		return
 
@@ -148,14 +150,7 @@
 			investigation_log(I_GHOST, "|| was rotated by [key_name(ghost)][ghost.locked_to ? ", who was haunting [ghost.locked_to]" : ""]")
 		ghost.lastchairspin = world.time
 
-	change_dir(turn(dir, 90))
-
-/obj/structure/bed/chair/verb/rotate()
-	set name = "Rotate Chair"
-	set category = "Object"
-	set src in oview(1)
-
-	spin(usr)
+	change_dir(turn(dir, angle))
 
 /obj/structure/bed/chair/relayface(var/mob/living/user, direction) //ALSO for vehicles!
 	if(!can_rotate || user.incapacitated())

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -16,7 +16,7 @@
 	ghost_can_rotate = TRUE
 	var/image/buckle_overlay = null // image for overlays when a mob is buckled to the chair
 	var/image/secondary_buckle_overlay = null // for those really complicated chairs
-	var/can_rotate = TRUE
+	rotates_anchored = TRUE
 	mob_lock_type = /datum/locking_category/buckle/chair
 
 /obj/structure/bed/chair/New()
@@ -139,7 +139,7 @@
 		plane = OBJ_PLANE
 
 /obj/structure/bed/chair/relayface(var/mob/living/user, direction) //ALSO for vehicles!
-	if(!can_rotate || user.incapacitated())
+	if(!rotates_anchored || user.incapacitated())
 		return
 	change_dir(direction)
 	return 1
@@ -205,7 +205,7 @@
 	desc = "Uncomfortable."
 	sheet_amt = 2
 	anchored = 1
-	can_rotate = FALSE
+	rotates_anchored = FALSE
 
 /obj/structure/bed/chair/wood/pew/left
 	icon_state = "bench_left"
@@ -436,7 +436,6 @@
 	desc = "Looks really comfy."
 	sheet_amt = 2
 	anchored = 1
-	can_rotate = TRUE
 	color = null
 
 // layer stuff
@@ -627,8 +626,6 @@
 	desc = "A reinforced chair that's firmly secured to the ground."
 	icon_state = "shuttleseat_neutral"
 	anchored = 1
-	can_rotate = TRUE
-	ghost_can_rotate = TRUE
 
 /obj/structure/bed/chair/shuttle/attackby(var/obj/item/W, var/mob/user)
 	var/mob/living/M = locate() in loc //so attacking people isn't made harder by the seats' bulkiness
@@ -698,11 +695,6 @@
 /obj/structure/bed/chair/shuttle/gamer
 	desc = "Ain't got nothing to compensate."
 	icon_state = "shuttleseat_GAMER"
-	can_rotate = TRUE
-	ghost_can_rotate = TRUE
-
-/obj/structure/bed/chair/shuttle/gamer/rotate(angle)
-	change_dir(turn(dir, angle))
 
 //Plastic chairs
 /obj/structure/bed/chair/plastic

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -139,13 +139,13 @@
 		plane = OBJ_PLANE
 
 /obj/structure/bed/chair/rotate(var/angle = 90)
-	if(!can_rotate || !user || !isturf(user.loc))
+	if(!can_rotate || !usr || !isturf(usr.loc))
 		return
 
-	if(isobserver(user))
+	if(isobserver(usr))
 		if(!ghost_can_rotate)
 			return
-		var/mob/dead/observer/ghost = user
+		var/mob/dead/observer/ghost = usr
 		if(ghost.lastchairspin <= world.time - 5) //do not spam this
 			investigation_log(I_GHOST, "|| was rotated by [key_name(ghost)][ghost.locked_to ? ", who was haunting [ghost.locked_to]" : ""]")
 		ghost.lastchairspin = world.time

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -715,8 +715,8 @@
 	can_rotate = TRUE
 	ghost_can_rotate = TRUE
 
-/obj/structure/bed/chair/shuttle/gamer/spin(var/mob/M)
-	change_dir(turn(dir, 90))
+/obj/structure/bed/chair/shuttle/gamer/rotate(angle)
+	change_dir(turn(dir, angle))
 
 //Plastic chairs
 /obj/structure/bed/chair/plastic

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -13,6 +13,7 @@
 	sheet_amt = 1
 	verb_rotates = TRUE
 	rotate_type = /obj/structure/bed/chair
+	ghost_can_rotate = TRUE
 	var/image/buckle_overlay = null // image for overlays when a mob is buckled to the chair
 	var/image/secondary_buckle_overlay = null // for those really complicated chairs
 	var/can_rotate = TRUE

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -234,8 +234,8 @@
 	//Update to reflect changes(if applicable)
 	update_icon()
 
-/obj/structure/windoor_assembly/rotate(var/angle = 90)
-	..()
+/obj/structure/windoor_assembly/change_dir(new_dir, changer)
+	. = ..()
 	update_nearby_tiles()
 	update_icon()
 

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -16,6 +16,8 @@
 	density = FALSE
 	dir = NORTH
 	pass_flags_self = PASSDOOR|PASSGLASS
+	verb_rotates = TRUE
+	alt_click_rotates = TRUE
 	var/obj/item/weapon/circuitboard/airlock/electronics = null
 	var/windoor_type = /obj/machinery/door/window
 	var/secure_type = /obj/machinery/door/window/brigdoor
@@ -233,15 +235,13 @@
 	update_icon()
 
 //Rotates the windoor assembly clockwise
-/obj/structure/windoor_assembly/verb/revrotate()
-	set name = "Rotate window door assembly"
-	set category = "Object"
-	set src in oview(1)
+/obj/structure/windoor_assembly/rotate()
+	..()
+	update_nearby_tiles()
+	update_icon()
 
-	if(anchored)
-		to_chat(usr, "It is fastened to the floor; therefore, you can't rotate it!")
-		return FALSE
-	change_dir(turn(dir, 270))
+/obj/structure/windoor_assembly/rotate_ccw()
+	..()
 	update_nearby_tiles()
 	update_icon()
 

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -234,13 +234,7 @@
 	//Update to reflect changes(if applicable)
 	update_icon()
 
-//Rotates the windoor assembly clockwise
-/obj/structure/windoor_assembly/rotate()
-	..()
-	update_nearby_tiles()
-	update_icon()
-
-/obj/structure/windoor_assembly/rotate_ccw()
+/obj/structure/windoor_assembly/rotate(var/angle = 90)
 	..()
 	update_nearby_tiles()
 	update_icon()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -28,6 +28,9 @@ var/list/one_way_windows
 	var/reinforced = 0 //Used for deconstruction steps
 	penetration_dampening = 1
 	pass_flags_self = PASSGLASS
+	verb_rotates = TRUE
+	alt_click_rotates = TRUE
+	rotate_type = /obj/structure/window
 	var/mutable_appearance/damage_overlay
 	var/image/oneway_overlay
 	var/cracked_base = "crack"
@@ -63,7 +66,7 @@ var/list/one_way_windows
 /obj/structure/window/isSmoothableNeighbor(atom/A)
 	if(A?.density && ismovable(A))
 		var/atom/movable/O = A
-		return O.anchored && ..() 
+		return O.anchored && ..()
 
 /obj/structure/window/relativewall()
 	icon_state = anchored && density ? "[base_state][..()]" : initial(icon_state)
@@ -88,14 +91,6 @@ var/list/one_way_windows
 /obj/structure/window/examine(mob/user)
 	..()
 	examine_health(user)
-
-/obj/structure/window/AltClick(mob/user)
-	if(is_fulltile)
-		. = ..()
-	else
-		if(user.incapacitated() || !Adjacent(user))
-			return
-		ccwrotate()
 
 /obj/structure/window/proc/examine_health(mob/user)
 	if(!anchored)
@@ -612,33 +607,9 @@ var/list/one_way_windows
 					return 0
 	return 1
 
-/obj/structure/window/verb/ccwrotate()
-	set name = "Rotate Window Counter-Clockwise"
-	set category = "Object"
-	set src in oview(1)
-
-	rotate(90)
-
-/obj/structure/window/verb/cwrotate()
-	set name = "Rotate Window Clockwise"
-	set category = "Object"
-	set src in oview(1)
-
-	rotate(270)
-
-/obj/structure/window/proc/rotate(var/angle = 90)
-	if(anchored)
-		var/turf/T = loc
-		if(T)
-			for(var/obj/structure/window/W in T)
-				if(!W.anchored && W.dir == src.dir)
-					W.rotate(angle)
-					return
-		to_chat(usr, "<span class='warning'>\The [src] is fastened to the floor, therefore you can't rotate it!</span>")
-		return
-
+/obj/structure/window/change_dir(new_dir, changer)
 	update_nearby_tiles() //Compel updates before
-	change_dir(turn(dir, angle))
+	. = ..()
 	update_nearby_tiles()
 
 /obj/structure/window/Destroy()

--- a/code/modules/mecha/mech_bay.dm
+++ b/code/modules/mecha/mech_bay.dm
@@ -128,6 +128,8 @@
 	anchored = 1
 	icon = 'icons/mecha/mech_bay.dmi'
 	icon_state = "recharge_port"
+	verb_rotates = TRUE
+	alt_click_rotates = TRUE
 	var/obj/machinery/mech_bay_recharge_floor/recharge_floor
 	var/obj/machinery/computer/mech_bay_power_console/recharge_console
 	var/datum/global_iterator/mech_bay_recharger/pr_recharger
@@ -243,36 +245,6 @@
 		recharge_console.recharge_floor = recharge_floor
 		return 1
 	return 0
-
-/obj/machinery/mech_bay_recharge_port/verb/rotate_cw()
-	set name = "Rotate (Clockwise)"
-	set category = "Object"
-	set src in oview(1)
-
-	if(!istype(usr,/mob/living))
-		return
-
-	var/mob/living/U = usr
-	if(src.anchored || U.stat)
-		to_chat(usr, "<span class='warning'>It is fastened to the floor!</span>")
-		return 0
-	src.dir = turn(src.dir, -90)
-	return 1
-
-/obj/machinery/mech_bay_recharge_port/verb/rotate_ccw()
-	set name = "Rotate (Counter-Clockwise)"
-	set category = "Object"
-	set src in oview(1)
-
-	if(!istype(usr,/mob/living))
-		return
-
-	var/mob/living/U = usr
-	if(src.anchored || U.stat)
-		to_chat(usr, "<span class='warning'>It is fastened to the floor!</span>")
-		return 0
-	src.dir = turn(src.dir, 90)
-	return 1
 
 /datum/global_iterator/mech_bay_recharger
 	delay = 20

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -44,7 +44,7 @@ var/creating_arena = FALSE
 	var/conversionHUD = 0
 	incorporeal_move = INCORPOREAL_GHOST
 	var/movespeed = 0.75
-	var/lastchairspin
+	var/last_obj_spin
 	var/pathogenHUD = FALSE
 	var/manual_poltergeist_cooldown //var-edit this to manually modify a ghost's poltergeist cooldown, set it to null to reset to global
 

--- a/code/modules/optics/mirrors/mirror.dm
+++ b/code/modules/optics/mirrors/mirror.dm
@@ -17,6 +17,8 @@ var/global/list/obj/machinery/mirror/mirror_list = list()
 	var/list/emitted_beams[4] // directions
 
 	machine_flags = WRENCHMOVE | SCREWTOGGLE | CROWDESTROY
+	verb_rotates = TRUE
+	alt_click_rotates = TRUE
 
 /obj/machinery/mirror/New()
 	..()
@@ -61,28 +63,8 @@ var/global/list/obj/machinery/mirror/mirror_list = list()
 	var/obj/structure/mirror_frame/MF = new (src.loc)
 	MF.anchored=anchored
 
-/obj/machinery/mirror/verb/rotate_cw()
-	set name = "Rotate (Clockwise)"
-	set category = "Object"
-	set src in oview(1)
-
-	if (src.anchored)
-		to_chat(usr, "It is fastened to the floor!")
-		return 0
-	src.dir = turn(src.dir, -90)
-	kill_all_beams()
-	update_beams()
-	return 1
-
-/obj/machinery/mirror/verb/rotate_ccw()
-	set name = "Rotate (Counter-Clockwise)"
-	set category = "Object"
-	set src in oview(1)
-
-	if (src.anchored)
-		to_chat(usr, "It is fastened to the floor!")
-		return 0
-	src.dir = turn(src.dir, 90)
+/obj/machinery/mirror/rotate(var/angle = 90)
+	..()
 	kill_all_beams()
 	update_beams()
 	return 1

--- a/code/modules/optics/mirrors/mirror.dm
+++ b/code/modules/optics/mirrors/mirror.dm
@@ -63,11 +63,10 @@ var/global/list/obj/machinery/mirror/mirror_list = list()
 	var/obj/structure/mirror_frame/MF = new (src.loc)
 	MF.anchored=anchored
 
-/obj/machinery/mirror/rotate(var/angle = 90)
-	..()
+/obj/machinery/mirror/change_dir(new_dir, changer)
+	. = ..()
 	kill_all_beams()
 	update_beams()
-	return 1
 
 /obj/machinery/mirror/wrenchAnchor(var/mob/user, var/obj/item/I)
 	. = ..()

--- a/code/modules/optics/prism.dm
+++ b/code/modules/optics/prism.dm
@@ -9,6 +9,8 @@ var/list/obj/machinery/prism/prism_list = list()
 	use_power = MACHINE_POWER_USE_NONE
 	anchored = 0
 	density = 1
+	verb_rotates = TRUE
+	alt_click_rotates = TRUE
 
 	var/obj/effect/beam/emitter/beam
 
@@ -33,40 +35,6 @@ var/list/obj/machinery/prism/prism_list = list()
 		to_chat(world, "[src] \ref[src] found [get_dir(src, B)] its dir is [dir]")
 		if(get_dir(src, B) != dir)
 			return 1
-
-/obj/machinery/prism/verb/rotate_cw()
-	set name = "Rotate (Clockwise)"
-	set category = "Object"
-	set src in oview(1)
-
-	if (src.anchored)
-		to_chat(usr, "It is fastened to the floor!")
-		return 0
-	src.dir = turn(src.dir, -90)
-	qdel(beam)
-	beam=null
-	update_beams()
-	return 1
-
-/obj/machinery/prism/verb/rotate_ccw()
-	set name = "Rotate (Counter-Clockwise)"
-	set category = "Object"
-	set src in oview(1)
-
-	if (src.anchored)
-		to_chat(usr, "It is fastened to the floor!")
-		return 0
-	src.dir = turn(src.dir, 90)
-	qdel(beam)
-	beam=null
-	update_beams()
-	return 1
-
-
-/obj/machinery/prism/AltClick(mob/user)
-	if(user.incapacitated() || !Adjacent(user))
-		return
-	rotate_cw()
 
 /obj/machinery/prism/wrenchAnchor(var/mob/user, var/obj/item/I)
 	. = ..()

--- a/code/modules/optics/prism.dm
+++ b/code/modules/optics/prism.dm
@@ -36,6 +36,12 @@ var/list/obj/machinery/prism/prism_list = list()
 		if(get_dir(src, B) != dir)
 			return 1
 
+/obj/machinery/prism/change_dir(new_dir, changer)
+	. = ..()
+	qdel(beam)
+	beam=null
+	update_beams()
+
 /obj/machinery/prism/wrenchAnchor(var/mob/user, var/obj/item/I)
 	. = ..()
 	if(!.)

--- a/code/modules/optics/prism.dm
+++ b/code/modules/optics/prism.dm
@@ -25,8 +25,7 @@ var/list/obj/machinery/prism/prism_list = list()
 	prism_list += src
 
 /obj/machinery/prism/Destroy()
-	qdel(beam)
-	beam=null
+	QDEL_NULL(beam)
 	prism_list -= src
 	..()
 
@@ -38,8 +37,7 @@ var/list/obj/machinery/prism/prism_list = list()
 
 /obj/machinery/prism/change_dir(new_dir, changer)
 	. = ..()
-	qdel(beam)
-	beam=null
+	QDEL_NULL(beam)
 	update_beams()
 
 /obj/machinery/prism/wrenchAnchor(var/mob/user, var/obj/item/I)

--- a/code/modules/power/ShieldGen/shield_capacitor.dm
+++ b/code/modules/power/ShieldGen/shield_capacitor.dm
@@ -15,6 +15,8 @@
 	idle_power_usage = 10
 	active_power_usage = 100
 	machine_flags = EMAGGABLE | SCREWTOGGLE | CROWDESTROY | WRENCHMOVE | FIXED2WORK
+	verb_rotates = TRUE
+	alt_click_rotates = TRUE
 	var/active = TRUE
 	var/stored_charge = 0
 	var/time_since_fail = 100
@@ -141,28 +143,3 @@
 		return
 	if(prob(50))
 		active = !active
-
-/obj/machinery/shield_capacitor/proc/rotate(var/mob/user, var/degrees)
-	if(anchored)
-		to_chat(user, "\The [src] is fastened to the floor!")
-		return
-	dir = turn(dir, degrees)
-
-/obj/machinery/shield_capacitor/verb/rotate_cw()
-	set name = "Rotate capacitor clockwise"
-	set category = "Object"
-	set src in oview(1)
-
-	rotate(usr, -90)
-
-/obj/machinery/shield_capacitor/verb/rotate_ccw()
-	set name = "Rotate capacitor counter-clockwise"
-	set category = "Object"
-	set src in oview(1)
-
-	rotate(usr, 90)
-
-/obj/machinery/shield_capacitor/AltClick(mob/user)
-	if(user.incapacitated() || !Adjacent(user))
-		return
-	rotate(usr,-90)

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -8,6 +8,9 @@
 	use_power = MACHINE_POWER_USE_NONE
 	idle_power_usage = 100 //Watts, I hope.  Just enough to do the computer and display things.
 
+	verb_rotates = TRUE
+	alt_click_rotates = TRUE
+
 	var/thermal_efficiency = 0.65
 
 	var/tmp/obj/machinery/atmospherics/binary/circulator/circ1
@@ -206,23 +209,3 @@
 /obj/machinery/power/generator/power_change()
 	..()
 	update_icon()
-
-/obj/machinery/power/generator/verb/rotate_clock()
-	set category = "Object"
-	set name = "Rotate Generator (Clockwise)"
-	set src in view(1)
-
-	if (usr.isUnconscious() || usr.restrained()  || anchored)
-		return
-
-	src.dir = turn(src.dir, -90)
-
-/obj/machinery/power/generator/verb/rotate_anticlock()
-	set category = "Object"
-	set name = "Rotate Generator (Counterclockwise)"
-	set src in view(1)
-
-	if (usr.isUnconscious() || usr.restrained()  || anchored)
-		return
-
-	src.dir = turn(src.dir, 90)

--- a/code/modules/power/rust/fuel_injector.dm
+++ b/code/modules/power/rust/fuel_injector.dm
@@ -20,6 +20,8 @@
 	power_priority = POWER_PRIORITY_POWER_EQUIPMENT
 	idle_power_usage = 10
 	active_power_usage = 500
+	verb_rotates = TRUE
+	alt_click_rotates = TRUE
 	var/remote_access_enabled = TRUE
 	var/emergency_insert_ready = FALSE
 	var/last_power_request = 0
@@ -324,29 +326,3 @@
 		updateDialog()
 	else
 		visible_message("<span class='warning'>[bicon(src)] A red light flashes on \the [src].</span>")
-
-/obj/machinery/power/rust_fuel_injector/verb/rotate_clock()
-	set category = "Object"
-	set name = "Rotate injector (Clockwise)"
-	set src in view(1)
-
-	if (anchored || usr.incapacitated())
-		return
-
-	src.dir = turn(src.dir, -90)
-
-/obj/machinery/power/rust_fuel_injector/verb/rotate_anticlock()
-	set category = "Object"
-	set name = "Rotate injector (Counter-clockwise)"
-	set src in view(1)
-
-	if (anchored || usr.incapacitated())
-		return
-
-	src.dir = turn(src.dir, 90)
-
-
-/obj/machinery/power/rust_fuel_injector/AltClick(mob/user)
-	if(user.incapacitated() || !Adjacent(user))
-		return
-	rotate_clock()

--- a/code/modules/power/rust/gyrotron.dm
+++ b/code/modules/power/rust/gyrotron.dm
@@ -24,6 +24,8 @@
 	power_priority = POWER_PRIORITY_POWER_EQUIPMENT
 	idle_power_usage = 10
 	active_power_usage = GYRO_MEGA_COST * MIN_MEGA_ENERGY
+	verb_rotates = TRUE
+	alt_click_rotates = TRUE
 
 /obj/machinery/power/gyrotron/initialize()
 	if(!id_tag)
@@ -139,36 +141,3 @@
 				connect_to_network()
 		return 1
 	return -1
-
-/obj/machinery/power/gyrotron/verb/rotate_cw()
-	set name = "Rotate (Clockwise)"
-	set src in oview(1)
-	set category = "Object"
-
-	if(usr.incapacitated() || !Adjacent(usr))
-		return
-
-	if(anchored)
-		to_chat(usr, "<span class='notify'>\The [src] is anchored to the floor!</span>")
-		return
-
-	dir = turn(dir, -90)
-
-/obj/machinery/power/gyrotron/verb/rotate_ccw()
-	set name = "Rotate (Counter-Clockwise)"
-	set src in oview(1)
-	set category = "Object"
-
-	if(usr.incapacitated() || !Adjacent(usr))
-		return
-
-	if(anchored)
-		to_chat(usr, "<span class='notify'>\The [src] is anchored to the floor!</span>")
-		return
-
-	dir = turn(dir, 90)
-
-/obj/machinery/power/gyrotron/AltClick(mob/user)
-	if(user.incapacitated() || !Adjacent(user))
-		return
-	rotate_cw()

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -27,6 +27,8 @@
 	var/last_satisfaction = 0
 
 	machine_flags = EMAGGABLE | WRENCHMOVE | FIXED2WORK | WELD_FIXED | MULTITOOL_MENU
+	verb_rotates = TRUE
+	alt_click_rotates = TRUE
 
 	var/frequency = 0
 	var/datum/radio_frequency/radio_connection
@@ -44,33 +46,6 @@
 	frequency = new_frequency
 	if(frequency)
 		radio_connection = radio_controller.add_object(src, frequency, RADIO_ATMOSIA)
-
-/obj/machinery/power/emitter/verb/rotate_cw()
-	set name = "Rotate (Clockwise)"
-	set category = "Object"
-	set src in oview(1)
-
-	if(src.anchored || usr:stat)
-		to_chat(usr, "<span class='warning'>It is fastened to the floor!</span>")
-		return 0
-	src.dir = turn(src.dir, -90)
-	return 1
-
-/obj/machinery/power/emitter/verb/rotate_ccw()
-	set name = "Rotate (Counter-Clockwise)"
-	set category = "Object"
-	set src in oview(1)
-
-	if(src.anchored || usr:stat)
-		to_chat(usr, "<span class='warning'>It is fastened to the floor!</span>")
-		return 0
-	src.dir = turn(src.dir, 90)
-	return 1
-
-/obj/machinery/power/emitter/AltClick(mob/user)
-	if(user.incapacitated() || !Adjacent(user))
-		return
-	rotate_cw()
 
 /obj/machinery/power/emitter/initialize()
 	..()

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -64,6 +64,8 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	icon_state = "none"
 	anchored = 0
 	density = 1
+	verb_rotates = TRUE
+	alt_click_rotates = TRUE
 	var/obj/machinery/particle_accelerator/control_box/master = null
 	var/construction_state = 0
 	var/reference = null
@@ -82,33 +84,6 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	desc_holder = "This is where Alpha particles are generated from \[REDACTED\]"
 	icon_state = "end_cap"
 	reference = "end_cap"
-
-/obj/structure/particle_accelerator/verb/rotate()
-	set name = "Rotate Clockwise"
-	set category = "Object"
-	set src in oview(1)
-
-	if (src.anchored || usr:stat)
-		to_chat(usr, "It is fastened to the floor!")
-		return 0
-	src.dir = turn(src.dir, -90)
-	return 1
-
-/obj/structure/particle_accelerator/verb/rotateccw()
-	set name = "Rotate Counter Clockwise"
-	set category = "Object"
-	set src in oview(1)
-
-	if (src.anchored || usr:stat)
-		to_chat(usr, "It is fastened to the floor!")
-		return 0
-	src.dir = turn(src.dir, 90)
-	return 1
-
-/obj/structure/particle_accelerator/AltClick(mob/user)
-	if(user.incapacitated() || !Adjacent(user))
-		return
-	rotate()
 
 /obj/structure/particle_accelerator/examine(mob/user)
 	switch(src.construction_state)

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -66,7 +66,6 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	density = 1
 	verb_rotates = TRUE
 	alt_click_rotates = TRUE
-	rotate_type = /obj/structure/particle_accelerator
 	var/obj/machinery/particle_accelerator/control_box/master = null
 	var/construction_state = 0
 	var/reference = null
@@ -246,7 +245,6 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	active_power_usage = 0
 	verb_rotates = TRUE
 	alt_click_rotates = TRUE
-	rotate_type = /obj/structure/railing
 	var/construction_state = 0
 	var/active = 0
 	var/reference = null

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -66,6 +66,7 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	density = 1
 	verb_rotates = TRUE
 	alt_click_rotates = TRUE
+	rotate_type = /obj/structure/particle_accelerator
 	var/obj/machinery/particle_accelerator/control_box/master = null
 	var/construction_state = 0
 	var/reference = null
@@ -243,40 +244,15 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	use_power = MACHINE_POWER_USE_NONE
 	idle_power_usage = 0
 	active_power_usage = 0
+	verb_rotates = TRUE
+	alt_click_rotates = TRUE
+	rotate_type = /obj/structure/railing
 	var/construction_state = 0
 	var/active = 0
 	var/reference = null
 	var/powered = null
 	var/strength = 0
 	var/desc_holder = null
-
-
-/obj/machinery/particle_accelerator/verb/rotate()
-	set name = "Rotate Clockwise"
-	set category = "Object"
-	set src in oview(1)
-
-	if (src.anchored || usr:stat)
-		to_chat(usr, "It is fastened to the floor!")
-		return 0
-	src.dir = turn(src.dir, -90)
-	return 1
-
-/obj/machinery/particle_accelerator/verb/rotateccw()
-	set name = "Rotate Counter-Clockwise"
-	set category = "Object"
-	set src in oview(1)
-
-	if (src.anchored || usr:stat)
-		to_chat(usr, "It is fastened to the floor!")
-		return 0
-	src.dir = turn(src.dir, 90)
-	return 1
-
-/obj/machinery/particle_accelerator/AltClick(mob/user)
-	if(user.incapacitated() || !Adjacent(user))
-		return
-	rotate()
 
 /obj/machinery/particle_accelerator/update_icon()
 	return

--- a/code/modules/power/treadmill.dm
+++ b/code/modules/power/treadmill.dm
@@ -17,6 +17,8 @@
 	use_power = MACHINE_POWER_USE_NONE
 	idle_power_usage = 0
 	pass_flags_self = PASSGLASS
+	verb_rotates = TRUE
+	alt_click_rotates = TRUE
 	var/count_power = 0 //How much power have we produced SO FAR this count?
 	var/tick_power = 0 //How much power did we produce last count?
 	var/power_efficiency = 1 //Based on parts
@@ -122,24 +124,3 @@
 	emagged = 1
 	name = "\improper DREADMILL"
 	desc = "FEEL THE BURN!"
-
-/obj/machinery/power/treadmill/verb/rotate_clock()
-	set category = "Object"
-	set name = "Rotate Treadmill (Clockwise)"
-	set src in view(1)
-
-	if (usr.isUnconscious() || usr.restrained()  || anchored)
-		return
-
-	change_dir(turn(src.dir, -90))
-
-/obj/machinery/power/treadmill/verb/rotate_anticlock()
-	set category = "Object"
-	set name = "Rotate Treadmill (Counterclockwise)"
-	set src in view(1)
-
-	if (usr.isUnconscious() || usr.restrained()  || anchored)
-		to_chat(usr, "It is fastened to the floor!")
-		return
-
-	change_dir(turn(src.dir, 90))

--- a/code/modules/projectiles/guns/projectile/constructable/cannon.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/cannon.dm
@@ -69,22 +69,6 @@
 		to_chat(usr, "You clean the fuel out of \the [src].")
 	update_verbs()
 
-/obj/structure/bed/chair/vehicle/wheelchair/wheelchair_assembly/cannon/verb/rotate_cw()
-	set name = "Rotate (Clockwise)"
-	set category = "Object"
-	set src in oview(1)
-
-	src.dir = turn(src.dir, -90)
-	return 1
-
-/obj/structure/bed/chair/vehicle/wheelchair/wheelchair_assembly/cannon/verb/rotate_ccw()
-	set name = "Rotate (Counter-Clockwise)"
-	set category = "Object"
-	set src in oview(1)
-
-	src.dir = turn(src.dir, 90)
-	return 1
-
 /obj/structure/bed/chair/vehicle/wheelchair/wheelchair_assembly/cannon/attackby(obj/item/W as obj, mob/user as mob)
 	var/item_prohibited = 0
 	for(var/i=1, i<=prohibited_items.len, i++)

--- a/code/modules/projectiles/guns/projectile/constructable/siegecannon.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/siegecannon.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/siege_cannon.dmi'
 	icon_state = "siege_cannon"
 	density = TRUE
+	verb_rotates = TRUE
 	var/obj/item/loadedItem = null
 	var/mob/living/loadedMob = null
 	var/wFuel = 0
@@ -180,22 +181,6 @@
 		beenClowned = TRUE
 		icon_state = "clownnon"
 		name = "circus cannon"
-
-/obj/structure/siege_cannon/verb/rotate_cw()
-	set name = "Rotate (Clockwise)"
-	set category = "Object"
-	set src in oview(1)
-
-	src.dir = turn(src.dir, -90)
-	return 1
-
-/obj/structure/siege_cannon/verb/rotate_ccw()
-	set name = "Rotate (Counter-Clockwise)"
-	set category = "Object"
-	set src in oview(1)
-
-	src.dir = turn(src.dir, 90)
-	return 1
 
 
 //CANNONBALLS/////

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -13,6 +13,8 @@
 	starting_materials = list(MAT_IRON = 1850)
 	w_type = RECYK_METAL
 	level = 2
+	verb_rotates = TRUE
+	alt_click_rotates = TRUE
 	var/ptype = 0
 	// 0=straight, 1=bent, 2=junction-j1, 3=junction-j2, 4=junction-y, 5=trunk, 6=disposal bin, 7=outlet, 8=inlet, 9=up, 10=down
 
@@ -102,23 +104,6 @@
 	// change visibility status and force update of icon
 /obj/structure/disposalconstruct/hide(var/intact)
 	invisibility = (intact && level==1) ? 101: 0	// hide if floor is intact
-	update()
-
-
-	// flip and rotate verbs
-/obj/structure/disposalconstruct/verb/rotate()
-	set name = "Rotate Pipe"
-	set category = "Object"
-	set src in view(1)
-
-	if(usr.isUnconscious())
-		return
-
-	if(anchored)
-		to_chat(usr, "You must unfasten the pipe before rotating it.")
-		return
-
-	dir = turn(dir, -90)
 	update()
 
 /obj/structure/disposalconstruct/verb/flip()

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -28,6 +28,10 @@
 	else
 		to_chat(user, "<span class='info'>It's currently detached from the floor plating.</span>")
 
+/obj/structure/disposalconstruct/change_dir(new_dir, changer)
+	. = ..()
+	update()
+
 // update iconstate and dpdir due to dir and type
 /obj/structure/disposalconstruct/proc/update()
 	var/flip = turn(dir, 180)

--- a/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
+++ b/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
@@ -9,6 +9,7 @@
 	density = 1
 	req_access = list(access_science)
 	machine_flags = EMAGGABLE
+	verb_rotates = TRUE
 	var/obj/item/weapon/cell/cell
 	var/obj/item/weapon/card/id/auth_card
 	var/locked = 1
@@ -345,26 +346,6 @@
 	//safety checks: clear the field and drop anything it's holding
 	deactivate()
 	..()
-
-/obj/machinery/suspension_gen/verb/rotate_cw()
-	set src in view(1)
-	set name = "Rotate suspension gen (Clockwise)"
-	set category = "Object"
-
-	if(anchored)
-		to_chat(usr, "<span class='warning'>You cannot rotate \the [src], it has been firmly fixed to the floor.</span>")
-	else
-		dir = turn(dir, -90)
-
-/obj/machinery/suspension_gen/verb/rotate_ccw()
-	set src in view(1)
-	set name = "Rotate suspension gen (Counter-Clockwise)"
-	set category = "Object"
-
-	if(anchored)
-		to_chat(usr, "<span class='warning'>You cannot rotate \the [src], it has been firmly fixed to the floor.</span>")
-	else
-		dir = turn(dir, 90)
 
 /obj/effect/suspension_field
 	name = "energy field"

--- a/code/modules/spacepods/parts.dm
+++ b/code/modules/spacepods/parts.dm
@@ -16,6 +16,8 @@
 	siemens_coefficient = 1
 	density = 0
 	anchored = 0
+	verb_rotates = TRUE
+	alt_click_rotates = TRUE
 	var/link_to = null
 	var/link_angle = 0
 
@@ -83,16 +85,6 @@
 		anchored = !anchored
 		setDensity(anchored)
 		O.playtoolsound(src, 50)
-
-/obj/item/pod_parts/pod_frame/verb/rotate()
-	set name = "Rotate Frame"
-	set category = "Object"
-	set src in oview(1)
-	if(anchored)
-		to_chat(usr, "\The [src] is securely bolted!")
-		return 0
-	src.dir = turn(src.dir, -90)
-	return 1
 
 /obj/item/pod_parts/pod_frame/attack_hand()
 	src.rotate()

--- a/code/modules/spacepods/parts.dm
+++ b/code/modules/spacepods/parts.dm
@@ -87,7 +87,7 @@
 		O.playtoolsound(src, 50)
 
 /obj/item/pod_parts/pod_frame/attack_hand()
-	src.rotate()
+	rotate_ccw()
 
 /obj/item/pod_parts/pod_frame/fore_port
 	name = "fore port pod frame"


### PR DESCRIPTION
[cleanup][consistency]

## What this does
Reduces these duplicated verbs down to the object level, making them usable on alt click or right click if set as a variable.
Ports the functionality from railings and windows that allows alt click rotating items underneath if unrotatable to anything else, with suitable type checks.
Ports functionality from chairs to let ghost rotate objects, off on everything else by default but admins can enable it.
Suggestions for objects that could use them are welcome, by the way.
Puts a lot of stuff updated from these rotate verbs into change_dir() so they work elsewhere too.
Closes #16569. (but I could probably leave that in if people want it, one line change as mentoned above)

## Why it's good
Allows coding this for more items to be much easier.

## How it was tested
Putting windows down, fastening some, then alt click rotating some underneath, alt clicking emitters anchored and unanchored, creating pipes and disposal pipes with an RPD and rotating them, using the hobo shack, connecting an emitter to a beam and prism and then alt click rotating them by varediting rotates_anchored to be true.

## Changelog

:cl:
 * tweak: The rotate clockwise and counterclockwise verb on machinery no longer appears if the machine is anchored, more consistently.
 * rscadd: The MSGS, pressure tanks, freezers, heaters, mass driver frames, mannequins, windoor assemblies, mech bay recharge ports, beam mirrors and prisms, TEG parts, treadmills, wheelchair cannon assemblies, siege cannons, disposal pipe pieces and pod frame parts can be rotated on alt click, if unanchored where applicable to their verb.
 * bugfix: Ghosts or unconscious people can no longer rotate beam mirrors or prisms.
 * spellcheck: All formatting for object rotation failure via verb or alt click now formats as a warning.