### PR TITLE
Makes more admin tools use filtered type lists with text matches

### DIFF
--- a/code/datums/gamemode/objectives/target/syndicate/steal.dm
+++ b/code/datums/gamemode/objectives/target/syndicate/steal.dm
@@ -45,7 +45,8 @@ var/list/potential_theft_objectives=list(
 		return FALSE
 	if (new_target == "custom")
 		var/datum/theft_objective/O=new
-		O.typepath = filter_typelist_input("Select type:", "Type", subtypesof(/obj/item))
+		var/match = input("Filter to type:","Type") as text
+		O.typepath = filter_typelist_input("Select type:", "Type", get_matching_types(match,/obj/item))
 		if (!O.typepath)
 			return FALSE
 		var/tmp_obj = new O.typepath

--- a/code/datums/gamemode/objectives/target/syndicate/steal.dm
+++ b/code/datums/gamemode/objectives/target/syndicate/steal.dm
@@ -45,7 +45,7 @@ var/list/potential_theft_objectives=list(
 		return FALSE
 	if (new_target == "custom")
 		var/datum/theft_objective/O=new
-		O.typepath = input("Select type:","Type") as null|anything in typesof(/obj/item)
+		O.typepath = filter_typelist_input("Select type:", "Type", subtypesof(/obj/item))
 		if (!O.typepath)
 			return FALSE
 		var/tmp_obj = new O.typepath

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1154,7 +1154,7 @@ fieldset {width:140px;}
 	var/mission_to_load = alert(usr, "How do you want to select the map element?", "Map element loading", "Choose a /datum/map_element object", "Load external .dmm file", "Cancel")
 	switch(mission_to_load)
 		if("Choose a /datum/map_element object")
-			var/new_map_element = input(usr, "Please select the map element object.", "Map element loading") as null|anything in typesof(/datum/map_element) - /datum/map_element
+			var/new_map_element = filter_typelist_input("Please select the map element object.", "Map element loading", subtypesof(/datum/map_element))
 			if(!new_map_element)
 				return
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1154,7 +1154,8 @@ fieldset {width:140px;}
 	var/mission_to_load = alert(usr, "How do you want to select the map element?", "Map element loading", "Choose a /datum/map_element object", "Load external .dmm file", "Cancel")
 	switch(mission_to_load)
 		if("Choose a /datum/map_element object")
-			var/new_map_element = filter_typelist_input("Please select the map element object.", "Map element loading", subtypesof(/datum/map_element))
+			var/element_type = input("Specify a map element type. Periods exclude subtypes.", "Map element type") as text
+			var/new_map_element = filter_typelist_input("Please select the map element object.", "Map element loading", get_matching_types(element_type,/datum/map_element))
 			if(!new_map_element)
 				return
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -3929,7 +3929,7 @@ access_sec_doors,access_salvage_captain,access_cent_ert,access_syndicate,access_
 				var/choice = input("Are you sure you want to fill the station with a bunch of unnecessary mobs?") in list("Of course!", "No, I hate timespace anomalies involving fun")
 				if(choice == "Of course!")
 					var/amt = input("How many would you like to spawn?", 10) as num
-					var/mobtype = input("What mob would you like?", "Mob Swarm") as null|anything in typesof(/mob/living)
+					var/mobtype = filter_typelist_input("What mob would you like?", "Mob Swarm", subtypesof(/mob/living))
 					message_admins("[key_name_admin(usr)] triggered a mob swarm.")
 					new /datum/event/mob_swarm(mobtype, amt)
 			if("pick_event")

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -3929,7 +3929,8 @@ access_sec_doors,access_salvage_captain,access_cent_ert,access_syndicate,access_
 				var/choice = input("Are you sure you want to fill the station with a bunch of unnecessary mobs?") in list("Of course!", "No, I hate timespace anomalies involving fun")
 				if(choice == "Of course!")
 					var/amt = input("How many would you like to spawn?", 10) as num
-					var/mobtype = filter_typelist_input("What mob would you like?", "Mob Swarm", subtypesof(/mob/living))
+					var/typefilter = input("Mob type to filter to?","Mob Swarm") as text
+					var/mobtype = filter_typelist_input("What mob would you like?", "Mob Swarm", get_matching_types(typefilter,/mob/living))
 					message_admins("[key_name_admin(usr)] triggered a mob swarm.")
 					new /datum/event/mob_swarm(mobtype, amt)
 			if("pick_event")

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -410,7 +410,7 @@ Pressure: [env.pressure]"}
 
 	// to prevent REALLY stupid deletions
 	var/blocked = list(/obj, /mob, /mob/living, /mob/living/carbon, /mob/living/carbon/human, /mob/dead, /mob/dead/observer, /mob/living/silicon, /mob/living/silicon/robot, /mob/living/silicon/ai)
-	var/hsbitem = input(usr, "Choose an object to delete.", "Delete:") as null|anything in typesof(/obj) + typesof(/mob) - blocked
+	var/hsbitem = filter_typelist_input("Choose an object to delete.", "Delete:", subtypesof(/obj) + subtypesof(/mob) - blocked)
 	if(hsbitem)
 		for(var/atom/O in world)
 			if(istype(O, hsbitem))

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -404,13 +404,16 @@ Pressure: [env.pressure]"}
 */
 
 //TODO: merge the vievars version into this or something maybe mayhaps
-/client/proc/cmd_debug_del_all()
+/client/proc/cmd_debug_del_all(target as text)
 	set category = "Debug"
 	set name = "Del-All"
+	set desc = "Delete all atoms of a type. Finish path with a period to hide subtypes."
 
+	if(!istext(target))
+		return
 	// to prevent REALLY stupid deletions
-	var/blocked = list(/obj, /mob, /mob/living, /mob/living/carbon, /mob/living/carbon/human, /mob/dead, /mob/dead/observer, /mob/living/silicon, /mob/living/silicon/robot, /mob/living/silicon/ai)
-	var/hsbitem = filter_typelist_input("Choose an object to delete.", "Delete:", subtypesof(/obj) + subtypesof(/mob) - blocked)
+	var/blocked = list(/atom/movable/lighting_overlay, /atom/movable/border_dummy, /obj, /mob, /mob/living, /mob/living/carbon, /mob/living/carbon/human, /mob/dead, /mob/dead/observer, /mob/living/silicon, /mob/living/silicon/robot, /mob/living/silicon/ai)
+	var/hsbitem = filter_typelist_input("Choose an object to delete.", "Delete:", get_matching_types(target,/atom/movable) - blocked)
 	if(hsbitem)
 		for(var/atom/O in world)
 			if(istype(O, hsbitem))

--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -364,7 +364,7 @@ var/global/list/accessable_z_levels = list()
 		var/choice = input("Which Z-level do you wish to set the base turf for?") as null|num
 		if(!choice)
 			return
-		var/new_base_path = input("Please select a turf path (cancel to reset to /turf/space).") as null|anything in typesof(/turf)
+		var/new_base_path = filter_typelist_input("Please select a turf path (cancel to reset to /turf/space).","Turf Path",subtypesof(/turf))
 		if(!new_base_path)
 			new_base_path = /turf/space //Only hardcode in the whole thing, feel free to change this if somewhere in the distant future spess is deprecated
 		var/update_old_base = alert(src, "Do you wish to update the old base? This will LAG.", "Update old turfs?", "Yes", "No")

--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -364,7 +364,8 @@ var/global/list/accessable_z_levels = list()
 		var/choice = input("Which Z-level do you wish to set the base turf for?") as null|num
 		if(!choice)
 			return
-		var/new_base_path = filter_typelist_input("Please select a turf path (cancel to reset to /turf/space).","Turf Path",subtypesof(/turf))
+		var/new_base_text = input("Filter to a turf type.","Turf Type") as text
+		var/new_base_path = filter_typelist_input("Please select a turf path (cancel to reset to /turf/space).","Turf Path",get_matching_types(new_base_text,/turf))
 		if(!new_base_path)
 			new_base_path = /turf/space //Only hardcode in the whole thing, feel free to change this if somewhere in the distant future spess is deprecated
 		var/update_old_base = alert(src, "Do you wish to update the old base? This will LAG.", "Update old turfs?", "Yes", "No")


### PR DESCRIPTION
[qol][administration]

## What this does
Makes the type text take up less space on the selection window and use text beforehand to filter them like in the spawn verb.

## Why it's good
Easier visibility, reading and selecting.

## How it was tested
Loading in the fast food joint map element, mass deleting grilles with del-all, creating greymlin mob swarms from the gremlin type search, setting the base turf to grass.

## Changelog
:cl:
 * tweak: The admin type selection menus for loading map elements, deleting all atoms, creating mob swarms, setting a steal item objective and setting a z-level base turf now have their type list text filtered down to common type starts for easier reading, and allow typing text to filter types down beforehand.