### PR TITLE
Mining Pickaxe Speed Hotfix

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -556,9 +556,12 @@
 /proc/do_after_many(var/mob/user, var/list/targets, var/delay, var/numticks = 10, var/needhand = TRUE, var/use_user_turf = FALSE)
 	if(!user || numticks == 0 || !targets || !targets.len)
 		return 0
+	if(delay <= 0)
+		return TRUE //instant finish speed so no need for any of the below code
 
-	numticks = min(numticks,delay)
 	var/delay_fraction = round(delay / numticks)
+	if(delay_fraction == 0)
+		return TRUE //A sleep(0) below means instant finish speed, the progbar isn't even shown to the user since it finishes so fast.
 	if(istype(user.loc, /obj/mecha))
 		use_user_turf = TRUE
 	var/initial_user_location = use_user_turf ? get_turf(user) : user.loc
@@ -647,7 +650,7 @@
   * Arguments:
   * * mob/user - the user who will see the progress bar
   * * atom/target - the atom the progress bar will be attached to
-  * * delay - duration in deciseconds of the delay
+  * * delay - duration in deciseconds of the delay. If this is below numticks or is <=0, this will return TRUE instantly.
   * * numticks - how many times the failure conditions will be checked throughout the duration. default 10
   * * needhand - if TRUE, the item in the hands of the user needs to stay the same throughout the duration. default TRUE
   * * use_user_turf - if TRUE, the turf of the user is checked instead of its location. default FALSE
@@ -656,11 +659,14 @@
 /proc/do_after(var/mob/user as mob, var/atom/target, var/delay as num, var/numticks = 10, var/needhand = TRUE, var/use_user_turf = FALSE, callback/custom_checks)
 	if(!user || isnull(user))
 		return 0
+	if(delay <= 0)
+		return TRUE //instant finish speed so no need for any of the below code
 	if(numticks == 0)
 		return 0
 
-	numticks = min(numticks,delay)
 	var/delayfraction = round(delay/numticks)
+	if(delayfraction == 0)
+		return TRUE //A sleep(0) below means instant finish speed, the progbar isn't even shown to the user since it finishes so fast.
 	var/Location
 	if(istype(user.loc, /obj/mecha))
 		use_user_turf = TRUE

--- a/code/game/objects/items/stacks/stack_recipes.dm
+++ b/code/game/objects/items/stacks/stack_recipes.dm
@@ -14,6 +14,7 @@
 	var/start_unanchored = 0
 	var/z_up_required = 0
 	var/z_down_required = 0
+	//This allows the speed of a stack recipe to be boosted with cargo nanobots
 	var/cargonia_boost = 0
 	var/list/other_reqs = list()
 	var/list/extra_data = list()
@@ -67,7 +68,7 @@
 		var/actual_time = S.time_modifier(time)
 		if(cargonia_boost && user?.reagents.has_reagent(CARGONANOBOTS))
 			actual_time = round(actual_time/2)
-		if (!do_after(user, get_turf(S), actual_time))
+		if (!do_after(user, get_turf(S), actual_time, (actual_time < 10 ? actual_time : 10)))
 			S.stop_build(current_work == S.last_work)
 			return
 	if (S.amount < req_amount*multiplier)


### PR DESCRIPTION

## What this does
This PR fixes a bug introduced in #38388 by @SECBATON-GRIFFON where diamond drills and advanced plasma cutters no longer instantly mined turfs due to changes in do_after(). (IT WAS SUPPOSED TO SAVE CARGO, NOT DESTROY IT!!)

## Why it's good
Restores fast mining to miners who upgrade their picks.

## How it was tested
Built several crates with and without cargo nanobots, went to the mines, yearned for them.
<img width="317" height="282" alt="image" src="https://github.com/user-attachments/assets/76204c0f-88ac-4a9e-8827-a506496fb562" />
<img width="469" height="422" alt="image" src="https://github.com/user-attachments/assets/5bf3dcdb-a412-4910-858f-bd394f59d791" />

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Diamond Drills and Advanced Plasma Cutters once again instantly mine.
