### PR TITLE
Xenoarch Debug Small Find Spawn Tool

### DIFF
--- a/code/modules/admin/artifacts_panel.dm
+++ b/code/modules/admin/artifacts_panel.dm
@@ -70,6 +70,7 @@
 		</head>
 		<body>
 		<h2 style="text-align:center">Artifact Panel</h2>
+		<b><a href='?src=\ref[src];artifactpanel_spawnsmall=1'>Small Find Spawn Tool</a></b>
 		<table>
 		<tr>
 		<th style="width:1%">Artifact ID</th>

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -582,6 +582,11 @@
 
 		SendAdminGhostTo(T,null)
 
+	else if(href_list["artifactpanel_spawnsmall"])
+		if(!check_rights(R_ADMIN))
+			return
+		debug_spawn_find()
+
 	else if(href_list["bodyarchivepanel_focus"])
 		if(!check_rights(R_ADMIN))
 			return

--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -735,6 +735,11 @@
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/xenoarch.dmi', "right_hand" = 'icons/mob/in-hand/right/xenoarch.dmi')
 	desc = ""
 
+/obj/item/weapon/gun/projectile/xenoarch/examine(mob/user)
+	..()
+	for(var/x in caliber)
+		to_chat(user, "<span class='info'>Appears to fit [x] caliber rounds.</span>")
+
 /obj/item/weapon/gun/projectile/xenoarch/gun1
 	icon_state = "gun1"
 	item_state = "gun1"
@@ -1162,3 +1167,15 @@
 /obj/item/weapon/archaeological_find/New(loc)
 	..()
 	icon_state = "unknown[rand(1,4)]"
+
+/proc/debug_spawn_find()
+	if(!usr)
+		return
+	if(!usr.client || !usr.client.holder)
+		to_chat(usr, "<span class='warning'>You need to be an administrator to access this.</span>")
+		return
+	var/result = input(usr, "What type of find?", "spawn find debug", null) as null|anything in subtypesof(/datum/find)
+	if(!result)
+		return
+	var/datum/find/our_find = new result()
+	our_find.create_find(usr.loc)

--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -735,11 +735,6 @@
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/xenoarch.dmi', "right_hand" = 'icons/mob/in-hand/right/xenoarch.dmi')
 	desc = ""
 
-/obj/item/weapon/gun/projectile/xenoarch/examine(mob/user)
-	..()
-	for(var/x in caliber)
-		to_chat(user, "<span class='info'>Appears to fit [x] caliber rounds.</span>")
-
 /obj/item/weapon/gun/projectile/xenoarch/gun1
 	icon_state = "gun1"
 	item_state = "gun1"
@@ -1168,13 +1163,14 @@
 	..()
 	icon_state = "unknown[rand(1,4)]"
 
+//Debug proc to help test and debug xenoarch finds
 /proc/debug_spawn_find()
 	if(!usr)
 		return
 	if(!usr.client || !usr.client.holder)
 		to_chat(usr, "<span class='warning'>You need to be an administrator to access this.</span>")
 		return
-	var/result = input(usr, "What type of find?", "spawn find debug", null) as null|anything in subtypesof(/datum/find)
+	var/result = filter_typelist_input("What type of find?", "Small Find Spawn List", subtypesof(/datum/find))
 	if(!result)
 		return
 	var/datum/find/our_find = new result()


### PR DESCRIPTION
## What this does
This adds an admin debug tool to spawn small finds. This is an edit from the original PR, that added both this tool and let you see xenoarch gun calibers on examine. See below images for examples.

## Why it's good
Funny admin tool!!

## How it was tested
<img width="877" height="528" alt="image" src="https://github.com/user-attachments/assets/301bc9ea-0465-428f-99d8-257906b9f8ca" />
<img width="617" height="233" alt="image" src="https://github.com/user-attachments/assets/ab288e73-44fb-424c-9ad9-285cf7d50661" />
<img width="246" height="287" alt="image" src="https://github.com/user-attachments/assets/10fd77ed-52f0-47a4-86e6-64c33e6494b0" />


## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Admins can now spawn xenoarch small finds via the artifacts panel.
