### PR TITLE
Some vault mapping fixes

### DIFF
--- a/maps/fixedvaults/medship.dmm
+++ b/maps/fixedvaults/medship.dmm
@@ -1,34 +1,34 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/simulated/wall/shuttle,
-/area)
+/area/derelict/ship)
 "b" = (
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area)
+/area/derelict/ship)
 "c" = (
 /obj/machinery/computer/crew,
 /turf/simulated/floor/engine,
-/area)
+/area/derelict/ship)
 "g" = (
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid/toxin,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area)
+/area/derelict/ship)
 "j" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/space,
-/area)
+/area/derelict/ship)
 "k" = (
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid/adv,
 /turf/simulated/floor/engine,
-/area)
+/area/derelict/ship)
 "l" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -40,7 +40,7 @@
 	dir = 8
 	},
 /turf/space,
-/area)
+/area/derelict/ship)
 "m" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -49,7 +49,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area)
+/area/derelict/ship)
 "n" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -57,7 +57,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area)
+/area/derelict/ship)
 "o" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -70,23 +70,23 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area)
+/area/derelict/ship)
 "p" = (
 /obj/structure/grille/window_spawner/reinforced/full,
 /turf/simulated/floor/engine,
-/area)
+/area/derelict/ship)
 "s" = (
 /obj/structure/shuttle/diag_wall/smooth{
 	dir = 1
 	},
 /turf/space,
-/area)
+/area/derelict/ship)
 "t" = (
 /obj/structure/shuttle/diag_wall/smooth{
 	dir = 8
 	},
 /turf/space,
-/area)
+/area/derelict/ship)
 "u" = (
 /turf/space,
 /area)
@@ -100,11 +100,11 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area)
+/area/derelict/ship)
 "w" = (
 /obj/structure/shuttle/diag_wall/smooth,
 /turf/space,
-/area)
+/area/derelict/ship)
 "y" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -113,7 +113,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area)
+/area/derelict/ship)
 "z" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -122,20 +122,20 @@
 	dir = 1
 	},
 /turf/space,
-/area)
+/area/derelict/ship)
 "A" = (
 /obj/structure/table,
 /turf/simulated/floor/engine,
-/area)
+/area/derelict/ship)
 "C" = (
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area)
+/area/derelict/ship)
 "D" = (
 /turf/simulated/floor/engine,
-/area)
+/area/derelict/ship)
 "E" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -144,7 +144,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area)
+/area/derelict/ship)
 "F" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4
@@ -152,7 +152,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area)
+/area/derelict/ship)
 "H" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -162,7 +162,7 @@
 	dir = 8
 	},
 /turf/space,
-/area)
+/area/derelict/ship)
 "I" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -173,7 +173,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area)
+/area/derelict/ship)
 "J" = (
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid/regular{
@@ -183,14 +183,14 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area)
+/area/derelict/ship)
 "K" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/structure/window/reinforced,
 /turf/space,
-/area)
+/area/derelict/ship)
 "L" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -200,7 +200,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area)
+/area/derelict/ship)
 "M" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -208,7 +208,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area)
+/area/derelict/ship)
 "O" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -218,13 +218,13 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area)
+/area/derelict/ship)
 "P" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/space,
-/area)
+/area/derelict/ship)
 "Q" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -234,37 +234,31 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area)
+/area/derelict/ship)
 "T" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	id_tag = "salvage_external"
 	},
 /turf/simulated/floor/engine,
-/area)
+/area/derelict/ship)
 "U" = (
 /obj/machinery/door/airlock/hatch,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area)
+/area/derelict/ship)
 "V" = (
 /obj/structure/shuttle/diag_wall/smooth{
 	dir = 4
 	},
 /turf/space,
-/area)
+/area/derelict/ship)
 "W" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area)
-"X" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	id_tag = "salvage_external"
-	},
-/turf/space,
-/area)
+/area/derelict/ship)
 "Y" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -275,13 +269,13 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area)
+/area/derelict/ship)
 "Z" = (
 /obj/machinery/optable,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area)
+/area/derelict/ship)
 
 (1,1,1) = {"
 u
@@ -434,7 +428,7 @@ a
 w
 "}
 (11,1,1) = {"
-X
+T
 D
 T
 b
@@ -446,10 +440,10 @@ b
 b
 T
 D
-X
+T
 "}
 (12,1,1) = {"
-u
+D
 D
 D
 b
@@ -461,7 +455,7 @@ b
 b
 D
 D
-u
+D
 "}
 (13,1,1) = {"
 s

--- a/maps/randomvaults/black_site_prism.dmm
+++ b/maps/randomvaults/black_site_prism.dmm
@@ -372,7 +372,6 @@
 "bd" = (
 /obj/item/clothing/under/syndicate/executive,
 /obj/item/clothing/suit/storage/syndicateexec,
-/obj/item/clothing/head/helmet/space/rig/syndicate_elite,
 /obj/item/clothing/suit/space/rig/syndicate_elite,
 /obj/item/clothing/shoes/swat,
 /obj/item/clothing/mask/gas/swat,

--- a/maps/randomvaults/mini_station.dmm
+++ b/maps/randomvaults/mini_station.dmm
@@ -1542,9 +1542,8 @@
 	pixel_x = 24
 	},
 /obj/structure/cable{
-	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
 /turf/simulated/floor{
 	dir = 6;


### PR DESCRIPTION
[vault]

## What this does
Closes #38466.
Closes #38407.
Closes #38280.

## Changelog
:cl:
 * tweak: The deep space medical white ship now has lighting and floors under its outer doors.
 * tweak: The NT microstation vault now has a properly wired cable in its medbay.
 * tweak; The black site prism vault no longer has a duplicate rigsuit helmet in its vault.