### PR TITLE
Maybe fixes sound channel leak

### DIFF
--- a/code/modules/sound/sound_listener_context/sound_listener_context.dm
+++ b/code/modules/sound/sound_listener_context/sound_listener_context.dm
@@ -103,10 +103,7 @@
 	if (!chan)
 		return //no channel to release, no sound to stop (hopefully)
 	// flush it
-	var/sound/nullsound = sound(file = null)
-	nullsound.channel = chan
-	nullsound.status = SOUND_UPDATE | SOUND_MUTE
-	client << nullsound
+	client << sound(file = null, channel = chan)
 
 	current_channels_by_emitter -= E
 	free_channels += chan


### PR DESCRIPTION
## What this does
Riekland reported an issue whereby looping sounds could get stuck playing even when moving away from the source. This was noticed with bubbling cryo tubes where the bubbling would still be audible when far out of the range they should only be audible in. The issue occurs incredibly rarely and seems to be the result of the stars aligning just right.

This proved extremely difficult to reproduce locally, however while investigating I noted that when the `sound_stopped` event is raised and the client's `sound_listener_context` *supposedly* frees the channel, the Byond client doesn't actually immediately free it and it continues to "play" muted in the background on that channel for at least a couple of seconds. This is not supposed to happen, but it was happening due to erroneous use of the `SOUND_UPDATE | SOUND_MUTE` status on the flushing nullsound. These flags effectively mute the sound but don't immediately purge the channel, which is not intended behaviour. Removing these flags and just leaving `status` blank immediately flushes the channel.

## Why it's good
Back-end system now behaves the way it was intended to. Might fix Riekland's reported issue. If it doesn't then I need to keep digging

## How it was tested
Set a proc to run `SoundQuery` and dump the channels in use to `world.log` every 0.5 sec. Walked around medbay with the tubes active and noted that sound channels were not being freed in a timely manner.
Repeated test after the code change and confirmed that sound channels are now freed in a timely manner.

## Changelog
:cl:
 * bugfix: Maybe fixed looping sounds getting stuck

