### PR TITLE
Fix solar panels issues

### DIFF
--- a/code/modules/power/solars/panel.dm
+++ b/code/modules/power/solars/panel.dm
@@ -356,10 +356,10 @@
 		return 1
 
 	if(stat & BROKEN)
-		to_chat(user, "<span class='warning'>\The [S] is too damaged.</span>")
+		to_chat(user, "<span class='warning'>\The [src] is too damaged.</span>")
 		return 1
 
-	var/diff = initial(health) - health
+	var/diff = maxHealth - health
 	if(!diff) // Not damaged.
 		to_chat(user, "<span class='notice'>\The [src] is already in perfect condition!</span>")
 		return 1


### PR DESCRIPTION
## What this does
Fixes #38214 

This is actually two bugs, when using silicate on the panel it checks the panel's current `health` against `initial(health)` - which for any solar panel is always `15`. For something like reinforced plasma glass, `maxHealth` is correctly set from the sheet properties to `30`, as is `health`. When attacking the panel `health` may be reduced to something like `24`. When using the silicate sprayer on it it checks `initial(health) - health` --> `15 - 24` for a negative `diff`... which then causes #38219 , as well as further bad behaviour as the health then gets reduced to `15` (using silicate sprayer on damaged plasma glass solars actually damages them further if they were above 15 health!) but then this is equal to the compile-time value on solar panels so it then thinks its in "perfect condition".
Checking how much health is missing by comparing `health` against `maxHealth` makes much more sense than against the compile-time value.

Fixes #38219 

Also fixes an unreported bug where attempting to use a silicate sprayer on a completely broken solar panel would say `The Silicate Sprayer is too damaged.` rather than solar panel

## Why it's good
bugge fixe

## How it was tested
Comparing `health` and `maxHealth` with expected values while adding glass to, damaging and repairing solar panels pre and post fix

## Changelog

 * bugfix: Fixed solar panels damage overlays not getting removed
 * bugfix: Fixed solar panels actually being damaged by silicate sprayers if used above 15 health
 * bugfix: Fixed wording issue when attempting to use silicate sprayer on fully broken solar panels
