### PR TITLE
Fix goonecode research

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -836,7 +836,7 @@
 	icon = 'icons/obj/module.dmi'
 	icon_state = "gooncode"
 	w_class = W_CLASS_TINY
-	origin_tech = Tc_MATERIALS + "=10;" + Tc_PLASMATECH + "=6;" + Tc_SYNDICATE + "=6;" + Tc_PROGRAMMING + "=-10;" + Tc_BLUESPACE + "=6;" + Tc_POWERSTORAGE + "=6;" + Tc_BIOTECH + "=6;" + Tc_NANOTRASEN + "1"
+	origin_tech = Tc_MATERIALS + "=10;" + Tc_PLASMATECH + "=6;" + Tc_SYNDICATE + "=6;" + Tc_PROGRAMMING + "=-10;" + Tc_BLUESPACE + "=6;" + Tc_POWERSTORAGE + "=6;" + Tc_BIOTECH + "=6"
 	mech_flags = MECH_SCAN_GOONECODE //It's closed source!
 
 /obj/item/toy/gooncode/suicide_act(var/mob/living/user)


### PR DESCRIPTION
## What this does

Fixes #38221 by adding a space before the ellipsis
Fixes #38222 kind of.

Goonecode research levels were added in #36082 but I'm pretty sure this PR was never tested by anybody. EDIT: apparently it lets you scan it if you kick the machine (while raising the runtime described in 2. below) but during this period the research computer is mustard gas

There were two bugs:

1. Formatting error (missing equals sign) in the tech string resulted in it attempting to look up `nanotrasen1` in known techs, which can't ever be there as the NT tech is just called `nanotrasen`. 
2. If the NT tech disk had not been previously scanned, `nanotrasen` would not be in `known_techs` so `GetKTechByID` would return null. Even if it had been scanned, due to 1. it would attempt to look up `nanotrasen1` and not find it and return null, runtiming when it tries to deref `null.level` in `rdconsole.dm:934`.

`nanotrasen` is a hidden_tech that is granted by disk ops using the NT research disk. It is probably possible to have the goonecode grant `nanotrasen` tech as an alternative to the research disk but that requires a larger code change. As it stands the goonecode research scan has *never* worked (unless you kick it, in which case you don't get NT tech anyway due to 1. and just a runtime + mustard gas instead) due to the above issues so I figure just removing `nanotrasen` research from it altogether doesn't impact anyone's optimised research strats and is enough

## Why it's good
Fixes runtimes and emulsion-ruining syntax errors in description

## How it was tested
Tried scanning goonecode before and after fix

## Changelog
:cl:
 * bugfix: Goonecode can actually be scanned in the DA now
