### PR TITLE
Fix gas canister hiss volume

### DIFF
--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -248,7 +248,6 @@
 		//Can not have a pressure delta that would cause environment pressure > tank pressure
 		var/soundvol = 0
 		if (env_pressure > 0.01)
-			// pd/env usually in range 0~10
 			soundvol = calc_sound_vol(pressure_delta, env_pressure)
 		sound_emitter.update_active_sound_param(volume = soundvol)
 

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -50,6 +50,13 @@
 		hiss.volume = 100
 		sound_emitter.add(hiss, "gas_hiss")
 
+/obj/machinery/portable_atmospherics/canister/proc/calc_sound_vol(var/p_delta, var/p_env)
+	var/soundvol = 0
+	if (p_env > 0.01)
+		// p_delta/p_env is usually 0~10
+		soundvol = clamp(10 * p_delta / p_env, 0.001, 100)
+	return soundvol
+
 /obj/machinery/portable_atmospherics/canister/proc/set_initial_sound_volume() // i copied some of this from process(). sorry
 	if(valve_open)
 		var/datum/gas_mixture/environment
@@ -62,7 +69,7 @@
 		var/soundvol = 0
 		if (env_pressure > 0.01)
 			var/pressure_delta = min(release_pressure - env_pressure, (air_contents.return_pressure() - env_pressure)/2)
-			soundvol = clamp(pressure_delta / env_pressure, 0.001, 100)
+			soundvol = calc_sound_vol(pressure_delta, env_pressure)
 		sound_emitter.update_active_sound_param(volume = soundvol)
 
 /obj/machinery/portable_atmospherics/canister/sleeping_agent
@@ -242,7 +249,7 @@
 		var/soundvol = 0
 		if (env_pressure > 0.01)
 			// pd/env usually in range 0~10
-			soundvol = clamp(10 * pressure_delta / env_pressure, 0.001, 100)
+			soundvol = calc_sound_vol(pressure_delta, env_pressure)
 		sound_emitter.update_active_sound_param(volume = soundvol)
 
 		var/transfer_moles = 0


### PR DESCRIPTION
## What this does
I was a dumb and copypasted a calculation then only modified it one place, as a result there was a missing factor of 10 for initial valve open vs. continuous valve open that led to the can starting too quiet before shifting to the correct formula and abruptly getting louder then quieter/silent again as the pressure differential reduces.

#37957 was already fixed but this corrects other bad behaviour with the cans.
Putting this here so Github closes it anyway:

Fixes #37957 

Note: due to the way the machinery subsystem processes canisters there doesn't seem to be a clean way of lerping or creating a smoother volume curve without higher frequency calls

## Why it's good
gas canisters dont sound retarded anymore

## How it was tested
Opened a gas can with and without tank at various pressure levels pre and post fix

## Changelog
:cl:
 * bugfix: Gas can hissing volume works properly now
