### PR TITLE
Fix add blood runtime (blood for the blood god)

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -793,7 +793,11 @@ its easier to just keep the beam vertical.
 	if(!istype(blood_DNA, /list))	//if our list of DNA doesn't exist yet (or isn't a list) initialise it.
 		blood_DNA = list()
 
-	blood_color = blood_DNA.len ? BlendRYB(blood_color, blood_data["blood_colour"], 0.5) : blood_data["blood_colour"] //mix new color into existing blood_color if applicable
+	if (blood_color && blood_DNA.len)
+		blood_color = BlendRYB(blood_color, blood_data["blood_colour"], 0.5) //mix new color into existing blood_color if applicable
+	else
+		blood_color = blood_data["blood_colour"]
+
 	return TRUE
 
 /atom/proc/add_vomit_floor(mob/living/carbon/M, toxvomit = 0, active = 0, steal_reagents_from_mob = 1)


### PR DESCRIPTION
## What this does
Fixes a runtime that looks like this:
```
[19:22:41] Runtime in code/modules/painting/palette.dm,332: bad color
  proc name: BlendRYB (/proc/BlendRYB)
  usr: Plaise W Atwork (killette2) (/mob/living/carbon/human)
  usr.loc: The floor (285, 274, 1) (/turf/simulated/floor)
  src: null
  call stack:
  BlendRYB("FF", "#2299FCFF", 0.5)
  Jack Whittier\'s head (/obj/item/organ/external/head): add blood from data(/list (/list))
  Jack Whittier\'s head (/obj/item/organ/external/head): add blood from data(/list (/list))
  Jack Whittier\'s head (/obj/item/organ/external/head): add fibers(Plaise W Atwork (/mob/living/carbon/human))
  Jack Whittier\'s head (/obj/item/organ/external/head): add fingerprint(Plaise W Atwork (/mob/living/carbon/human))
  Jack Whittier\'s head (/obj/item/organ/external/head): attack hand(Plaise W Atwork (/mob/living/carbon/human), "icon-x=17;icon-y=26;vis-x=15;v...", 1)
  Plaise W Atwork (/mob/living/carbon/human): UnarmedAttack(Jack Whittier\'s head (/obj/item/organ/external/head), 1, "icon-x=17;icon-y=26;vis-x=15;v...")
  Plaise W Atwork (/mob/living/carbon/human): ClickOn(Jack Whittier\'s head (/obj/item/organ/external/head), "icon-x=17;icon-y=26;vis-x=15;v...")
  Jack Whittier\'s head (/obj/item/organ/external/head): Click(the floor (286,274,1) (/turf/simulated/floor), "mapwindow.map", "icon-x=17;icon-y=26;vis-x=15;v...")
  ```
  
  `add_blood_from_data` attempts to call `BlendRYB` using `blood_color`, but in this circumstance `blood_color` is `null` while `blood_DNA` has `len` 1. As a result `BlendRYB` attempts to blend a null with an actual colour, inside `BlendRYB` this happens:

```
/proc/BlendRYB(rgb1, rgb2, amount)
	if (length(rgb1) < 8)
		rgb1 += "FF"
	if (length(rgb2) < 8)
		rgb2 += "FF"
	var/blend = colorRybBlend(rgb2num(rgb1), rgb2num(rgb2), amount)
	return rgb(blend[1], blend[2], blend[3], blend[4], "COLORSPACE_RGB")
```
- `rgb1` is `null`
- calls `rgb2num` with the cursed `rgb1`
- Byond raises the runtime

This change ensures that `blood_color` is not null before calling `BlendRYB` inside `add_blood_from_data`.

It should be noted that it looks like a similar runtime may exist inside `add_blood` just above `add_blood_from_data` inside `atoms.dm` but I didn't see (read: didn't look for) a runtime from that path so left it alone for this fix.

## Why it's good
Fewer runtimes
More things can get bloody because they don't runtime

## How it was tested
- Took blood from monkey
- Turned it into monkey man
- Chopped off its head
- Put blood in spray bottle
- Drop the monkey man's head and spray it with blood
- runtimes

after fix:
- as above but without the runtime
- monkey man's head got bloody

## Changelog
:cl:
 * bugfix: Fixed a runtime that prevented things getting bloody in certain circumstances
