### PR TITLE
Fix insectoid carapace colour selection runtime

### DIFF
--- a/code/modules/client/preferences/pref_datums_character.dm
+++ b/code/modules/client/preferences/pref_datums_character.dm
@@ -196,12 +196,12 @@
 				var/datum/preference_setting/numerical/g_facial = parent.get_pref_datum(/datum/preference_setting/numerical/g_facial)
 				var/datum/preference_setting/numerical/b_facial = parent.get_pref_datum(/datum/preference_setting/numerical/b_facial)
 
-				r_facial.setting = hex2num(copytext(carapace, 2, 4))
-				g_facial.setting = hex2num(copytext(carapace, 4, 6))
-				b_facial.setting = hex2num(copytext(carapace, 6, 8))
-				r_facial.setting = clamp(r_hair, 0, 80)
-				g_facial.setting = clamp(g_hair, 0, 50)
-				b_facial.setting = clamp(b_hair, 0, 35)
+				r_hair.setting = hex2num(copytext(carapace, 2, 4))
+				g_hair.setting = hex2num(copytext(carapace, 4, 6))
+				b_hair.setting = hex2num(copytext(carapace, 6, 8))
+				r_hair.setting = clamp(r_hair.setting, 0, 80)
+				g_hair.setting = clamp(g_hair.setting, 0, 50)
+				b_hair.setting = clamp(b_hair.setting, 0, 35)
 	parent.ShowChoices(user)
 
 /datum/preference_setting/string/h_style/choose_setting(var/mob/user)


### PR DESCRIPTION
## What this does

Fixes a runtime that looks like this:
```
[22:00:40] Runtime in code/modules/client/preferences/pref_datums_character.dm,202: type mismatch: cannot compare Red comp. RGB hair (/datum/preference_setting/numerical/r_hair) to 0
  proc name: input hair color (/datum/preference_setting/string/h_style/proc/input_hair_color)
  usr: Inorien (inorien) (/mob/new_player)
  usr.loc: The floor (8, 81, 2) (/turf/unsimulated/floor)
  src: Hair style (/datum/preference_setting/string/h_style)
  call stack:
  Hair style (/datum/preference_setting/string/h_style): input hair color(Inorien (/mob/new_player))
  Hair style (/datum/preference_setting/string/h_style): process link("input_hair_color", Inorien (/mob/new_player), /list (/list))
  /datum/preferences (/datum/preferences): process link(Inorien (/mob/new_player), /list (/list))
  Inorien (/client): Topic("_src_=prefs;preference=hair_st...", /list (/list), null)
```
that occurs when an insectoid player submits a hair colour in the hair colour picker in character setup.

Previously it attempted to clamp `r_hair` and such, which are datums - not numerical types. This resulted in the hair colour never being set, with the vars suggesting they should go to facial hair (that does nothing on insectoids). The insect remained black :(

The cause looks like something that slipped through the cracks when Shifty did his big prefs refactor a few months ago.

This change once again allows insectoids to select their carapace colour 🎉

## Why it's good
Insectoids can change their colour in prefs
Also fixes a runtime

## How it was tested
Attempted to change "hair" colour on insectoid in character setup pre and post fix, observed runtime and no colour change in pre-fix, saw no runtime and insectoid carapace changed colour as intended post-fix

## Changelog
:cl:
 * bugfix: Insectoids can once again change carapace colour in character prefs

