### PR TITLE
Material scrap fixes

### DIFF
--- a/code/game/objects/items/material-scraps.dm
+++ b/code/game/objects/items/material-scraps.dm
@@ -11,7 +11,7 @@
 	if(material_type)
 		sheet_material = material_type
 	starting_materials = list("[sheet_material]" = material_amount)
-	. = ..(loc)
+	. = ..()
 	var/datum/material/mat = materials.getMaterial(sheet_material)
 	sheet_type = mat.sheettype
 	var/material_name = lowertext(mat.name)

--- a/code/game/objects/items/material-scraps.dm
+++ b/code/game/objects/items/material-scraps.dm
@@ -7,11 +7,11 @@
 	flammable = FALSE
 	var/sheet_material = MAT_IRON
 
-/obj/item/trash/scrap/New(location,material_amount = CC_PER_SHEET_DEFAULT,material_type)
+/obj/item/trash/scrap/New(loc, age, icon_state, color, dir, pixel_x, pixel_y, obj/item/source, material_amount = CC_PER_SHEET_DEFAULT, material_type)
 	if(material_type)
 		sheet_material = material_type
 	starting_materials = list("[sheet_material]" = material_amount)
-	. = ..(location)
+	. = ..(loc)
 	var/datum/material/mat = materials.getMaterial(sheet_material)
 	sheet_type = mat.sheettype
 	var/material_name = lowertext(mat.name)
@@ -32,7 +32,7 @@
 		var/datum/material/mat = materials.getMaterial(sheet_material)
 		if(materials.getAmount(sheet_material) >= mat.cc_per_sheet && WT.remove_fuel(1,user))
 			to_chat(user, "<span class='notice'>You weld \the [src] into sheets of [lowertext(mat.name)]</span>")
-			materials.makeSheets(loc,TRUE)
+			materials.makeSheets(get_turf(src),TRUE)
 			if(materials.getAmount(sheet_material) <= 0)
 				qdel(src)
 				return

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -14,7 +14,7 @@
 	var/age = 1 //For map persistence. +1 per round that this item has survived. After a certain amount, it will not carry on to the next round anymore.
 	//var/global/list/trash_items = list()
 
-/obj/item/trash/New(var/loc, var/age, var/icon_state, var/color, var/dir, var/pixel_x, var/pixel_y, var/obj/item/source)
+/obj/item/trash/New(loc, age, icon_state, color, dir, pixel_x, pixel_y, obj/item/source)
 	if(age)
 		setPersistenceAge(age)
 	if(icon_state)


### PR DESCRIPTION
[bugfix][runtime]

## What this does
Closes #38501.
Fixes the trash persistence runtime.

## How it was tested
Welding scrap metal in-hand.

## Changelog
:cl:
 * bugfix: Welding scrap metal in-hand no longer makes it vanish into... somewhere.
 * bugfix: Trash persistent metal scraps now load their materials right.