### PR TITLE
Fixes wheelchair suicide text immulsions

### DIFF
--- a/code/game/objects/structures/vehicles/vehicle.dm
+++ b/code/game/objects/structures/vehicles/vehicle.dm
@@ -402,6 +402,8 @@
 		die()
 
 /obj/structure/bed/chair/vehicle/suicide_act(var/mob/living/user)
+	if(!keytype)
+		return ..()
 	if(occupant == user)
 		to_chat(viewers(user), "<span class='danger'>[user] is licking the keyhole of the [src]! It looks like \he's trying to commit suicide.</span>")
 		return(SUICIDE_ACT_FIRELOSS)


### PR DESCRIPTION
[grammar][immulsions][oversight]

## What this does
Closes #38475.
Does this by making these messages only show up if the vehicle takes a key, which wheelchairs do not. Anything that does not just gives the default structure actions.

## Why it's good
IMMULSIONS

## How it was tested
Saying *suicide on and near a wheelchair and a gokart, confirming the dialog boxes.

## Changelog
:cl:
 * bugfix: Wheelchairs no longer give keyhole or exhaust related suicide messages.