### PR TITLE
Pathogen HUD overlay now uses BLEND_MULTIPLY

### DIFF
--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -199,6 +199,7 @@
 	icon = 'icons/mob/screen1.dmi'
 	screen_loc = "WEST,SOUTH to EAST,NORTH"
 	icon_state = "science"
+	blend_mode = BLEND_MULTIPLY
 
 /obj/abstract/screen/fullscreen/snowfall_blizzard
 	icon_state = "oxydamageoverlay7"


### PR DESCRIPTION
<img width="1768" height="808" alt="image" src="https://github.com/user-attachments/assets/09df1dfb-43d0-4a7f-831d-6f56e80f4ea2" />

I would have designed it this way in the first place if I knew of blend modes back then

:cl:
* imageadd: The Pathogen HUD enabled by Science Goggles and the CMO's advanced health scanner HUD are much easier on the eyes now and help the diseases stand out without making the rest of the world much harder to see for no reason.