### PR TITLE
Fixes #38328: Purple Sunglasses now actually confer purple vision

### DIFF
--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -250,6 +250,17 @@ BLIND     // can't see anything
 	icon_state = "sun_purple"
 	species_fit = list(GREY_SHAPED)
 
+/obj/item/clothing/glasses/sunglasses/purple/equipped(mob/M, slot)
+	if(slot == slot_glasses)
+		M.overlay_fullscreen("purple", /obj/abstract/screen/fullscreen/science)
+	return ..()
+
+/obj/item/clothing/glasses/sunglasses/purple/unequipped(mob/living/carbon/human/M, from_slot)
+	if(from_slot == slot_glasses)
+		M.clear_fullscreen("purple",0)
+	return ..()
+
+
 /obj/item/clothing/glasses/sunglasses/star
 	name = "star-shaped sunglasses"
 	desc = "Novelty sunglasses, both lenses are in the shape of a star."


### PR DESCRIPTION
Fixes #38328

To only be merged following #38506

Embrace the synthwave/vaporwave/whatever

<img width="954" height="950" alt="image" src="https://github.com/user-attachments/assets/eb60e7fd-3eab-4bbf-ab29-c72c35bfeb15" />

:cl:
* rscadd: Purple Sunglasses that you can acquire from the Old Vendotron or the Cheap Glasses supply crate now actually give a purple tint to the world around you.