### PR TITLE
jungle patches

### DIFF
--- a/code/modules/mob/living/complex_animal/base.dm
+++ b/code/modules/mob/living/complex_animal/base.dm
@@ -52,7 +52,9 @@
 	var/pacify_aura=FALSE
 	var/kin_check_type_path=null //for mobs with many subtypes. set to the parent mob type. leave null if not needed
 	var/petable=FALSE
-	var/max_local_population=5 //to prevent total overpopulation
+	var/lastmate=0
+	var/matingcooldown=30 //1 minute
+	var/max_local_population=3 //to prevent total overpopulation
 	var/icon_living = ""
 	var/icon_dead = ""
 	var/healthregen=0.01
@@ -99,6 +101,8 @@
 		
 	icon_state=icon_living
 	nutrition-=max_food*food_per_tick
+	
+	lastmate--
 	
 	if(lasthealth<=health && health<maxHealth)
 		health=min(maxHealth,health+maxHealth*healthregen)
@@ -187,7 +191,7 @@
 	abort_target()
 	
 	//attempt reproduction only while full
-	if(nutrition >= (max_food- get_offspring_cost()*2) && get_offspring_cost() && prob(20))
+	if(nutrition >= (max_food- get_offspring_cost()*2) && get_offspring_cost() && prob(20) && lastmate<=0)
 		behavior_state=ANIMAL_STATE_MATING
 		return FALSE
 	
@@ -319,6 +323,9 @@
 				
 					nutrition-=get_offspring_cost()
 					abort_target()
+					
+					M.lastmate=M.matingcooldown
+					src.lastmate=src.matingcooldown
 					return FALSE
 	return TRUE
 
@@ -624,6 +631,7 @@
 			localcount++
 	if(localcount>max_local_population)
 		return FALSE
+	if(mob_age>mob_max_age || mob_age<mob_max_age*0.1) //too young or too old? no can do.
 	if((src.gender=="male" && mate.gender=="female") || (mate.gender=="male" && src.gender=="female"))
 		return TRUE
 	return FALSE

--- a/code/modules/mob/living/complex_animal/base.dm
+++ b/code/modules/mob/living/complex_animal/base.dm
@@ -97,12 +97,12 @@
 	if(stat == DEAD)
 		ticks_dead++
 		if(ticks_dead==15)
-			visible_message("bugs start flying around <b>\the [src]</b>'s corpse")
+			visible_message("Bugs start flying around <b>\the [src]</b>'s corpse")
 		if(ticks_dead==30)
-			visible_message("<b>\the [src]</b>'s corpse starts to smell...")	
+			visible_message("<b>\The [src]</b>'s corpse starts to smell...")	
 		if(ticks_dead>30) //1 minute delay
 			if(prob(5))
-				visible_message("<b>\the [src]</b>'s corpse rots away into nothing...")
+				visible_message("<b>\The [src]</b>'s corpse rots away into nothing...")
 				qdel(src)
 		return 0
 	ticks_dead=0

--- a/code/modules/mob/living/complex_animal/base.dm
+++ b/code/modules/mob/living/complex_animal/base.dm
@@ -42,7 +42,7 @@
 	var/last_state = -1
 	var/ticks_this_state=0
 	var/mob_age = 0
-	var/mob_max_age = 300 //10 minutes. above this, the mob will start rolling to die of old age.
+	var/mob_max_age = 450 //15 minutes. above this, the mob will start rolling to die of old age.
 	var/atom/target = null
 	var/turf/territory=null //turf location
 	var/list/family = list() //list of mobs. avoid attacking them and whatnot. also can be used for taming.
@@ -54,11 +54,12 @@
 	var/petable=FALSE
 	var/lastmate=0
 	var/matingcooldown=30 //1 minute
-	var/max_local_population=3 //to prevent total overpopulation
+	var/max_local_population=6 //to prevent total overpopulation
 	var/icon_living = ""
 	var/icon_dead = ""
 	var/healthregen=0.01
 	var/lasthealth=0.0
+	var/ticks_dead=0
 	
 	//these are here because we, for some reason that i don't know, call attack_animal. that sounds good, until you realize that attack_animal wants a simple_animal. this causes a lot of runtimes, and i can't find where attack_animal is actually called, or why it's called when we're not even a simple_animal, so instead, we define some of the important variables here so it doesn't totally break. it's still a good practice to revise the code, as was done with most of the common objects that will be broken, like windows and lockers.
 	var/environment_smash_flags = 0xFFFFFF
@@ -83,11 +84,28 @@
 	melee_damage_upper=base_damage+damage_variance
 	melee_damage_lower=base_damage-damage_variance
 
+/mob/living/complex_animal/update_icon()
+	..()
+	icon_state=icon_living
+	if (stat==DEAD)
+		icon_state=icon_dead
+
 /mob/living/complex_animal/Life()
+	update_icon()
 	if(!..())
 		return 0
 	if(stat == DEAD)
+		ticks_dead++
+		if(ticks_dead==15)
+			visible_message("bugs start flying around <b>\the [src]</b>'s corpse")
+		if(ticks_dead==30)
+			visible_message("<b>\the [src]</b>'s corpse starts to smell...")	
+		if(ticks_dead>30) //1 minute delay
+			if(prob(5))
+				visible_message("<b>\the [src]</b>'s corpse rots away into nothing...")
+				qdel(src)
 		return 0
+	ticks_dead=0
 	
 	if(last_state!=behavior_state)
 		ticks_this_state=0
@@ -97,9 +115,8 @@
 	
 	cache_objects_in_view = view(src,7) //refresh it every life tick.
 	
-	reagents?.metabolize(src)
-		
-	icon_state=icon_living
+	reagents?.metabolize(src)	
+	
 	nutrition-=max_food*food_per_tick
 	
 	lastmate--
@@ -122,6 +139,7 @@
 		//basically, the older you are, the more likley you are to die.
 		//if you are twice as old as the max age, you have a 50% chance to die.
 		//this is ran every tick, by the way, so the probabilities add up.
+		chancetokeelover*=0.25 //ok nevermind reduce the chance a bit it happens a bit too fast.
 		if(rand() < chancetokeelover)
 			emote("deathgasp")
 			health=0
@@ -678,7 +696,7 @@
 		emote("deathgasp", message = TRUE)
 	health = 0 
 	stat = DEAD
-	icon_state = icon_dead
+	update_icon()
 	walk(src,0)
 	setDensity(FALSE)
 

--- a/code/modules/mob/living/complex_animal/base.dm
+++ b/code/modules/mob/living/complex_animal/base.dm
@@ -632,6 +632,9 @@
 	if(localcount>max_local_population)
 		return FALSE
 	if(mob_age>mob_max_age || mob_age<mob_max_age*0.1) //too young or too old? no can do.
+		return FALSE
+	if(lastmate>0)
+		return FALSE
 	if((src.gender=="male" && mate.gender=="female") || (mate.gender=="male" && src.gender=="female"))
 		return TRUE
 	return FALSE

--- a/code/modules/mob/living/complex_animal/jungle_mobs/bears.dm
+++ b/code/modules/mob/living/complex_animal/jungle_mobs/bears.dm
@@ -59,6 +59,7 @@
 	maxHealth=250
 	armor=list(melee=10,bullet=30,laser=40,energy=0,bomb=0,bio=0,rad=0)
 	max_food=200
+	mob_max_age=9999999
 	healthregen=0.02
 	food_per_tick = 0.0005
 	base_damage = 35
@@ -136,6 +137,7 @@
 	behavior_flags = ANIMAL_BEHAVIOR_TERRITORIAL | ANIMAL_BEHAVIOR_RETALIATE | ANIMAL_BEHAVIOR_DESTRUCTIVE | ANIMAL_BEHAVIOR_AVOID_CAPTURE
 	movespeed=4
 	health=100
+	mob_max_age=9999999
 	base_damage=35
 	damage_variance=15
 	maxHealth=100

--- a/code/modules/mob/living/complex_animal/jungle_mobs/capybara_wild.dm
+++ b/code/modules/mob/living/complex_animal/jungle_mobs/capybara_wild.dm
@@ -8,6 +8,7 @@
 	health=25
 	maxHealth=25
 	max_food=30
+	mob_max_age=9999999 //a long time.
 	food_flags = ANIMAL_HERBIVORE
 	behavior_flags = ANIMAL_BEHAVIOR_PACK_DYNAMICS | ANIMAL_BEHAVIOR_AVOID_CAPTURE
 	movespeed=1

--- a/code/modules/mob/living/complex_animal/jungle_mobs/gorilla.dm
+++ b/code/modules/mob/living/complex_animal/jungle_mobs/gorilla.dm
@@ -13,7 +13,6 @@
 	movespeed=5
 	base_damage=20 //gorilla grip strong as shit
 	damage_variance=4
-	max_local_population=2
 
 
 /mob/living/complex_animal/gorilla/get_idle_sounds()

--- a/code/modules/mob/living/complex_animal/jungle_mobs/gorilla.dm
+++ b/code/modules/mob/living/complex_animal/jungle_mobs/gorilla.dm
@@ -13,6 +13,7 @@
 	movespeed=5
 	base_damage=20 //gorilla grip strong as shit
 	damage_variance=4
+	max_local_population=2
 
 
 /mob/living/complex_animal/gorilla/get_idle_sounds()

--- a/maps/junglestation.dmm
+++ b/maps/junglestation.dmm
@@ -30764,8 +30764,11 @@
 	},
 /area/security/lobby)
 "lSC" = (
-/turf/simulated/wall/shuttle/unsmoothed,
-/area/surface/jungle)
+/obj/machinery/light_switch{
+	pixel_y = -25
+	},
+/turf/simulated/floor/wood,
+/area/surface/jungle/underground/zoned/speakeasy)
 "lSF" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -32223,11 +32226,9 @@
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/atmos)
 "mtY" = (
-/obj/machinery/light_switch{
-	pixel_y = -25
-	},
-/turf/simulated/floor/wood,
-/area/surface/jungle/underground/zoned/speakeasy)
+/obj/structure/bed/chair/shuttle,
+/turf/simulated/floor/plating,
+/area/surface/jungle)
 "mub" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/simulated/floor{
@@ -41366,10 +41367,6 @@
 	icon_state = "chapel"
 	},
 /area/chapel/main)
-"qcN" = (
-/obj/machinery/vending/dinnerware,
-/turf/unsimulated/floor/jungle/path,
-/area/surface/jungle/zoned/outdoor_bar)
 "qcV" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -51312,8 +51309,7 @@
 	},
 /area/crew_quarters/kitchen)
 "tNb" = (
-/obj/structure/bed/chair/shuttle,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/shuttle/unsmoothed,
 /area/surface/jungle)
 "tNm" = (
 /obj/structure/bed/chair{
@@ -117568,11 +117564,11 @@ lIK
 pWq
 bRe
 iww
-lSC
+tNb
 fQX
 fQX
 fQX
-lSC
+tNb
 qIH
 bRe
 wlz
@@ -117920,11 +117916,11 @@ lIK
 wlz
 lpV
 kIa
-lSC
+tNb
 rqe
 aaq
 eTw
-lSC
+tNb
 mqz
 bRe
 pWq
@@ -118271,13 +118267,13 @@ uXL
 uXL
 wlz
 lpV
-lSC
+tNb
 hkY
 xgw
 hkY
 hkY
 hkY
-lSC
+tNb
 acE
 pWq
 lIK
@@ -118625,7 +118621,7 @@ bRe
 bRe
 uXC
 hkY
-tNb
+mtY
 wos
 xgw
 hkY
@@ -118975,13 +118971,13 @@ uXL
 uXL
 pWq
 bRe
-lSC
+tNb
 xbQ
 hkY
 olm
 hkY
 bDn
-lSC
+tNb
 acE
 wlz
 lIK
@@ -119327,13 +119323,13 @@ lIK
 lIK
 wlz
 lpV
-lSC
+tNb
 dxb
 crp
 cTq
 xgw
 hkY
-lSC
+tNb
 bRe
 wlz
 lIK
@@ -120383,13 +120379,13 @@ lIK
 lIK
 wlz
 lpV
-lSC
+tNb
 iyK
 hkY
 xgw
 hkY
 bDn
-lSC
+tNb
 acE
 wlz
 lIK
@@ -120735,13 +120731,13 @@ lIK
 lIK
 wlz
 bRe
-lSC
+tNb
 hkY
 aXo
 aXo
 eFF
 xgw
-lSC
+tNb
 acE
 wlz
 lIK
@@ -124747,7 +124743,7 @@ edD
 edD
 edD
 edD
-qcN
+edD
 edD
 edD
 hjm
@@ -228606,7 +228602,7 @@ tWM
 bfb
 erp
 tWM
-mtY
+lSC
 kze
 kze
 xJG

--- a/maps/junglestation.dmm
+++ b/maps/junglestation.dmm
@@ -30764,11 +30764,8 @@
 	},
 /area/security/lobby)
 "lSC" = (
-/obj/machinery/light_switch{
-	pixel_y = -25
-	},
-/turf/simulated/floor/wood,
-/area/surface/jungle/underground/zoned/speakeasy)
+/turf/simulated/wall/shuttle/unsmoothed,
+/area/surface/jungle)
 "lSF" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -32226,9 +32223,11 @@
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/atmos)
 "mtY" = (
-/obj/structure/bed/chair/shuttle,
-/turf/simulated/floor/plating,
-/area/surface/jungle)
+/obj/machinery/light_switch{
+	pixel_y = -25
+	},
+/turf/simulated/floor/wood,
+/area/surface/jungle/underground/zoned/speakeasy)
 "mub" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/simulated/floor{
@@ -51309,7 +51308,8 @@
 	},
 /area/crew_quarters/kitchen)
 "tNb" = (
-/turf/simulated/wall/shuttle/unsmoothed,
+/obj/structure/bed/chair/shuttle,
+/turf/simulated/floor/plating,
 /area/surface/jungle)
 "tNm" = (
 /obj/structure/bed/chair{
@@ -117564,11 +117564,11 @@ lIK
 pWq
 bRe
 iww
-tNb
+lSC
 fQX
 fQX
 fQX
-tNb
+lSC
 qIH
 bRe
 wlz
@@ -117916,11 +117916,11 @@ lIK
 wlz
 lpV
 kIa
-tNb
+lSC
 rqe
 aaq
 eTw
-tNb
+lSC
 mqz
 bRe
 pWq
@@ -118267,13 +118267,13 @@ uXL
 uXL
 wlz
 lpV
-tNb
+lSC
 hkY
 xgw
 hkY
 hkY
 hkY
-tNb
+lSC
 acE
 pWq
 lIK
@@ -118621,7 +118621,7 @@ bRe
 bRe
 uXC
 hkY
-mtY
+tNb
 wos
 xgw
 hkY
@@ -118971,13 +118971,13 @@ uXL
 uXL
 pWq
 bRe
-tNb
+lSC
 xbQ
 hkY
 olm
 hkY
 bDn
-tNb
+lSC
 acE
 wlz
 lIK
@@ -119323,13 +119323,13 @@ lIK
 lIK
 wlz
 lpV
-tNb
+lSC
 dxb
 crp
 cTq
 xgw
 hkY
-tNb
+lSC
 bRe
 wlz
 lIK
@@ -120379,13 +120379,13 @@ lIK
 lIK
 wlz
 lpV
-tNb
+lSC
 iyK
 hkY
 xgw
 hkY
 bDn
-tNb
+lSC
 acE
 wlz
 lIK
@@ -120731,13 +120731,13 @@ lIK
 lIK
 wlz
 bRe
-tNb
+lSC
 hkY
 aXo
 aXo
 eFF
 xgw
-tNb
+lSC
 acE
 wlz
 lIK
@@ -178435,11 +178435,11 @@ tdB
 srt
 roR
 tdB
-dhZ
-dhZ
+tdB
+tdB
 oeU
-dhZ
-dhZ
+tdB
+tdB
 qvz
 dhZ
 dhZ
@@ -178791,7 +178791,7 @@ wRR
 jeN
 vrk
 irV
-dhZ
+tdB
 xIy
 wRV
 xjN
@@ -179143,7 +179143,7 @@ wRR
 jeN
 vrk
 irV
-dhZ
+tdB
 xIy
 xIy
 xIy
@@ -179495,7 +179495,7 @@ wRR
 bjd
 vrk
 qeP
-dhZ
+tdB
 xIy
 xIy
 xIy
@@ -179847,7 +179847,7 @@ wRR
 bjd
 vel
 gUP
-dhZ
+tdB
 iHv
 xIy
 iHv
@@ -180196,10 +180196,10 @@ upF
 lEE
 lEE
 wRR
-dhZ
-dhZ
-dhZ
-dhZ
+tdB
+tdB
+tdB
+tdB
 dhZ
 dhZ
 dhZ
@@ -228602,7 +228602,7 @@ tWM
 bfb
 erp
 tWM
-lSC
+mtY
 kze
 kze
 xJG

--- a/maps/junglestation.dmm
+++ b/maps/junglestation.dmm
@@ -9,7 +9,7 @@
 /obj/structure/bed/chair/shuttle/blue{
 	dir = 1
 	},
-/turf/unsimulated/floor/jungle/concrete,
+/turf/simulated/floor/plating,
 /area/surface/jungle)
 "aar" = (
 /turf/simulated/wall,
@@ -147,7 +147,7 @@
 	one_way = 1;
 	dir = 1
 	},
-/turf/unsimulated/floor/jungle/concrete,
+/turf/simulated/floor/plating,
 /area/surface/jungle)
 "adw" = (
 /obj/item/weapon/gun/energy/pulse_rifle/destroyer{
@@ -2114,7 +2114,7 @@
 	name = "reinforced one-way window";
 	one_way = 1
 	},
-/turf/unsimulated/floor/jungle/concrete,
+/turf/simulated/floor/plating,
 /area/surface/jungle)
 "aPp" = (
 /obj/structure/table/woodentable,
@@ -2404,6 +2404,9 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "whitegreen"
 	},
@@ -2528,7 +2531,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/unsimulated/floor/jungle/concrete,
+/turf/simulated/floor/plating,
 /area/surface/jungle)
 "aXp" = (
 /obj/structure/rack,
@@ -4245,7 +4248,7 @@
 /area/surface/jungle/fenced)
 "bDn" = (
 /obj/machinery/light/broken,
-/turf/unsimulated/floor/jungle/concrete,
+/turf/simulated/floor/plating,
 /area/surface/jungle)
 "bDx" = (
 /obj/machinery/atmospherics/miner/oxygen,
@@ -6347,7 +6350,11 @@
 /obj/structure/bed/chair/shuttle{
 	dir = 4
 	},
-/turf/unsimulated/floor/jungle/concrete,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault";
+	tag = "icon-vault (NORTHEAST)"
+	},
 /area/surface/jungle)
 "cru" = (
 /obj/structure/table/glass,
@@ -8545,7 +8552,7 @@
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4
 	},
-/turf/unsimulated/floor/jungle/concrete,
+/turf/simulated/floor/plating,
 /area/surface/jungle)
 "dhV" = (
 /obj/machinery/computer/smelting{
@@ -9288,7 +9295,7 @@
 /area/vox_trading_post/gardens)
 "dxb" = (
 /obj/structure/closet/wardrobe/black,
-/turf/unsimulated/floor/jungle/concrete,
+/turf/simulated/floor/plating,
 /area/surface/jungle)
 "dxe" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -12372,7 +12379,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/unsimulated/floor/jungle/concrete,
+/turf/simulated/floor/plating,
 /area/surface/jungle)
 "eFV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
@@ -13040,7 +13047,7 @@
 /area/engineering/engine_storage)
 "eTw" = (
 /obj/machinery/light/built,
-/turf/unsimulated/floor/jungle/concrete,
+/turf/simulated/floor/plating,
 /area/surface/jungle)
 "eTK" = (
 /obj/structure/bed/chair/wood/pew/left{
@@ -13967,7 +13974,11 @@
 	})
 "fnU" = (
 /obj/structure/bed/chair/shuttle,
-/turf/unsimulated/floor/jungle/concrete,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault";
+	tag = "icon-vault (NORTHEAST)"
+	},
 /area/surface/jungle)
 "fnW" = (
 /turf/unsimulated/wall,
@@ -20926,7 +20937,7 @@
 /obj/structure/shuttle/engine/propulsion/right{
 	dir = 4
 	},
-/turf/unsimulated/floor/jungle/concrete,
+/turf/simulated/floor/plating,
 /area/surface/jungle)
 "hZU" = (
 /obj/machinery/vending/hydroseeds,
@@ -22098,7 +22109,7 @@
 /obj/machinery/light/broken{
 	dir = 1
 	},
-/turf/unsimulated/floor/jungle/concrete,
+/turf/simulated/floor/plating,
 /area/surface/jungle)
 "iyU" = (
 /turf/simulated/wall/r_wall,
@@ -29329,7 +29340,7 @@
 	name = "reinforced one-way window";
 	one_way = 1
 	},
-/turf/unsimulated/floor/jungle/concrete,
+/turf/simulated/floor/plating,
 /area/surface/jungle)
 "ltb" = (
 /obj/structure/closet,
@@ -30753,14 +30764,8 @@
 	},
 /area/security/lobby)
 "lSC" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/folder/white,
-/obj/item/weapon/pen,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "whitegreen"
-	},
-/area/medical/medbay)
+/turf/simulated/wall/shuttle/unsmoothed,
+/area/surface/jungle)
 "lSF" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -32218,11 +32223,11 @@
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/atmos)
 "mtY" = (
-/obj/machinery/computer{
-	icon_state = "computer_genericb"
+/obj/machinery/light_switch{
+	pixel_y = -25
 	},
-/turf/unsimulated/floor/jungle/concrete,
-/area/surface/jungle)
+/turf/simulated/floor/wood,
+/area/surface/jungle/underground/zoned/speakeasy)
 "mub" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/simulated/floor{
@@ -33973,7 +33978,7 @@
 	name = "reinforced one-way window";
 	one_way = 1
 	},
-/turf/unsimulated/floor/jungle/concrete,
+/turf/simulated/floor/plating,
 /area/surface/jungle)
 "nfJ" = (
 /obj/structure/rack,
@@ -38784,6 +38789,9 @@
 	dir = 4
 	},
 /obj/machinery/disposal/compactor,
+/obj/machinery/light_switch{
+	pixel_x = 28
+	},
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "brown"
@@ -40979,9 +40987,6 @@
 	},
 /area/research_outpost/anomaly)
 "pVd" = (
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "whitepurple"
@@ -41361,6 +41366,10 @@
 	icon_state = "chapel"
 	},
 /area/chapel/main)
+"qcN" = (
+/obj/machinery/vending/dinnerware,
+/turf/unsimulated/floor/jungle/path,
+/area/surface/jungle/zoned/outdoor_bar)
 "qcV" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -44666,7 +44675,7 @@
 /obj/machinery/light/built{
 	dir = 1
 	},
-/turf/unsimulated/floor/jungle/concrete,
+/turf/simulated/floor/plating,
 /area/surface/jungle)
 "rqh" = (
 /obj/structure/table/reinforced,
@@ -47926,7 +47935,10 @@
 /obj/item/clothing/mask/breath/vox,
 /obj/item/weapon/tank/nitrogen,
 /obj/item/weapon/tank/nitrogen,
-/turf/unsimulated/floor/jungle/underground/crate_loot,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "whiteblue"
+	},
 /area/medical/storage)
 "sCA" = (
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -47999,7 +48011,7 @@
 	name = "reinforced one-way window";
 	one_way = 1
 	},
-/turf/unsimulated/floor/jungle/concrete,
+/turf/simulated/floor/plating,
 /area/surface/jungle)
 "sEn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -51300,8 +51312,8 @@
 	},
 /area/crew_quarters/kitchen)
 "tNb" = (
-/mob/living/complex_animal/bear/polar,
-/turf/unsimulated/floor/jungle/concrete,
+/obj/structure/bed/chair/shuttle,
+/turf/simulated/floor/plating,
 /area/surface/jungle)
 "tNm" = (
 /obj/structure/bed/chair{
@@ -56486,6 +56498,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/machinery/light,
 /turf/simulated/floor{
 	icon_state = "whitepurple"
 	},
@@ -56872,7 +56885,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/cooking/deepfryer,
+/obj/machinery/vending/dinnerware,
 /turf/unsimulated/floor/jungle/path_plated,
 /area/crew_quarters/bar)
 "vUM" = (
@@ -57814,7 +57827,11 @@
 /obj/structure/bed/chair/shuttle{
 	dir = 1
 	},
-/turf/unsimulated/floor/jungle/concrete,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault";
+	tag = "icon-vault (NORTHEAST)"
+	},
 /area/surface/jungle)
 "woG" = (
 /obj/machinery/pda_multicaster/prebuilt,
@@ -59898,7 +59915,7 @@
 /obj/machinery/light/broken{
 	dir = 1
 	},
-/turf/unsimulated/floor/jungle/concrete,
+/turf/simulated/floor/plating,
 /area/surface/jungle)
 "xcc" = (
 /obj/machinery/power/am_control_unit,
@@ -62459,6 +62476,9 @@
 	},
 /area/medical/sleeper)
 "ycm" = (
+/obj/machinery/light_switch{
+	pixel_y = -23
+	},
 /turf/simulated/floor{
 	icon_state = "whitepurple"
 	},
@@ -62544,7 +62564,7 @@
 	one_way = 1;
 	dir = 1
 	},
-/turf/unsimulated/floor/jungle/concrete,
+/turf/simulated/floor/plating,
 /area/surface/jungle)
 "yen" = (
 /obj/machinery/alarm/vox{
@@ -117548,11 +117568,11 @@ lIK
 pWq
 bRe
 iww
-bRe
-mtY
-mtY
-mtY
-bRe
+lSC
+fQX
+fQX
+fQX
+lSC
 qIH
 bRe
 wlz
@@ -117900,11 +117920,11 @@ lIK
 wlz
 lpV
 kIa
-bRe
+lSC
 rqe
 aaq
 eTw
-bRe
+lSC
 mqz
 bRe
 pWq
@@ -118251,13 +118271,13 @@ uXL
 uXL
 wlz
 lpV
-bRe
-bRe
-bRe
-bRe
-bRe
-bRe
-bRe
+lSC
+hkY
+xgw
+hkY
+hkY
+hkY
+lSC
 acE
 pWq
 lIK
@@ -118604,11 +118624,11 @@ uXL
 bRe
 bRe
 uXC
-bRe
-fnU
+hkY
+tNb
 wos
-bRe
-bRe
+xgw
+hkY
 uXC
 acE
 pWq
@@ -118955,13 +118975,13 @@ uXL
 uXL
 pWq
 bRe
-bRe
+lSC
 xbQ
-bRe
-vfF
-bRe
+hkY
+olm
+hkY
 bDn
-bRe
+lSC
 acE
 wlz
 lIK
@@ -119307,13 +119327,13 @@ lIK
 lIK
 wlz
 lpV
-bRe
+lSC
 dxb
 crp
-hlL
-bRe
-bRe
-bRe
+cTq
+xgw
+hkY
+lSC
 bRe
 wlz
 lIK
@@ -119660,11 +119680,11 @@ lIK
 wlz
 bRe
 adi
-bRe
-bRe
-tNb
-bRe
-bRe
+hkY
+xgw
+hul
+xgw
+hkY
 ydT
 acE
 wlz
@@ -120012,11 +120032,11 @@ lIK
 pWq
 lpV
 sEg
-bRe
-bRe
+hkY
+xgw
 fnU
-bRe
-bRe
+hkY
+hkY
 ydT
 acE
 wlz
@@ -120363,13 +120383,13 @@ lIK
 lIK
 wlz
 lpV
-bRe
+lSC
 iyK
-bRe
-bRe
-bRe
+hkY
+xgw
+hkY
 bDn
-bRe
+lSC
 acE
 wlz
 lIK
@@ -120715,13 +120735,13 @@ lIK
 lIK
 wlz
 bRe
-bRe
-bRe
+lSC
+hkY
 aXo
 aXo
 eFF
-bRe
-bRe
+xgw
+lSC
 acE
 wlz
 lIK
@@ -121069,10 +121089,10 @@ xYO
 bRe
 hvx
 hZJ
-bRe
+hkY
 dhO
-bRe
-bRe
+hkY
+hkY
 qVx
 bRe
 wlz
@@ -124727,7 +124747,7 @@ edD
 edD
 edD
 edD
-edD
+qcN
 edD
 edD
 hjm
@@ -125451,7 +125471,7 @@ xMH
 gIE
 xVe
 lxA
-lSC
+iie
 cuO
 iiW
 evJ
@@ -228586,7 +228606,7 @@ tWM
 bfb
 erp
 tWM
-tWM
+mtY
 kze
 kze
 xJG


### PR DESCRIPTION
[bugfix] [mapping]

## What this does
* fixes some missing lights and switches
* fixes an erroneously placed turf in medical storage
* adds a dinnerware vendor in the kitchen
* reduces the rate of animal reproduction
* fixes dead animals not appearing as dead
* makes dead animals dissapear over time to reduce resource use

## Why it's good
fixes bugs and issues

## How it was tested
went in game to look a the rooms to see that they had better lighting, that the tile was fixed, and that the dinner vendor was there.
jungle mobs were tested to still reproduce, and VVd to make sure that the additional variables to slow it were being set properly. also looked at the animals over a long time to verify that they look dead and their corpses dissapear over time.

## Changelog
:cl:
 * bugfix: Jungle: Fixed some lighting issues
 * bugfix: Jungle: Added a missing kitchen vendor
 * bugfix: Jungle: the wildlife has been educated on the importance of abstinence
 * bugfix: Jungle: animals now decompose when dead. butcher while the meat is fresh!
 * bugfix: Jungle: animals no longer appear as alive when they are dead.
