### PR TITLE
improved SMES experience

### DIFF
--- a/code/modules/power/battery.dm
+++ b/code/modules/power/battery.dm
@@ -199,10 +199,6 @@ var/global/list/battery_online =	list(
 
 		add_avail(output) // Add output to powernet (smes side)
 
-		if (charge < 0.0001)
-			online = FALSE
-			output = 0
-
 	// Reflect state change
 	if(_charging != charging || _online != online || _chargedisplay != chargedisplay())
 		update_icon()

--- a/nano/templates/smes.tmpl
+++ b/nano/templates/smes.tmpl
@@ -20,8 +20,8 @@
 		Charge Mode:
 	</div>
 	<div class="itemContent">
-		{{:helper.link('Auto', 'refresh', {'cmode' : 'auto'}, data.chargeMode == 2 ? 'selected' : null)}}
-		{{:helper.link('Manual', 'refresh', {'cmode' : 'manual'}, data.chargeMode == 1 ? 'selected' : null)}}
+		{{:helper.link('Always', 'refresh', {'cmode' : 'auto'}, data.chargeMode == 2 ? 'selected' : null)}}
+		{{:helper.link('Exact', 'refresh', {'cmode' : 'manual'}, data.chargeMode == 1 ? 'selected' : null)}}
 		{{:helper.link('Off', 'close', {'cmode' : 'off'}, data.chargeMode ? null : 'selected')}}
 		&nbsp;
 		{{if data.charging}}


### PR DESCRIPTION
[qol] [ui]

## What this does
1. SMES no longer turn off power output when they run out of charge
2. re-labels the SMES charge modes to better describe what they actually do

<img width="979" height="546" alt="Capture" src="https://github.com/user-attachments/assets/8c681c98-ebf9-48a1-99c3-be0677ee7683" />
<img width="984" height="607" alt="Capture2" src="https://github.com/user-attachments/assets/a8ac0bd6-4356-4822-8a0e-c5e623ed9025" />
<img width="568" height="76" alt="Capture3" src="https://github.com/user-attachments/assets/31a884d3-0312-46f1-80e0-6ad5cb75f500" />


## Why it's good
the first is just kind of annoying, and doesn't actually seem to have a gameplay reason. you especially notice this when trying to set up solars.
the second is because the labels are confusing and new players especially won't know what it means

## How it was tested
went in game and verified the labels were correct, the output did not shut off, and that no extra power was being added into the grid.

## Changelog
:cl:
 * tweak: SMES no longer disable output when they run out of charge
 * spellcheck: improved SMES charge mode descriptors
