### PR TITLE
This kills the darkness

### DIFF
--- a/__DEFINES/planes+layers.dm
+++ b/__DEFINES/planes+layers.dm
@@ -375,30 +375,6 @@ var/obj/abstract/screen/plane_master/overdark_planemaster/overdark_planemaster =
 
 var/obj/abstract/screen/plane_master/overdark_planemaster_target/overdark_planemaster_target = new()
 
-// DARKNESS PLANEMASTER
-// One planemaster for each client, which they gain during mob/login()
-/obj/abstract/screen/plane_master/darkness_planemaster
-	plane = LIGHTING_PLANE
-	blend_mode = BLEND_MULTIPLY
-
-/obj/abstract/screen/plane_master/darkness_planemaster_dummy
-	alpha = 0
-	appearance_flags = 0
-	plane = LIGHTING_PLANE
-
-/client/proc/initialize_darkness_planemaster()
-	if(darkness_planemaster)
-		screen -= darkness_planemaster
-		qdel(darkness_planemaster)
-	if(darkness_planemaster_dummy)
-		screen -= darkness_planemaster_dummy
-		qdel(darkness_planemaster_dummy)
-	darkness_planemaster = new /obj/abstract/screen/plane_master/darkness_planemaster
-	screen |= darkness_planemaster
-	darkness_planemaster_dummy = new /obj/abstract/screen/plane_master/darkness_planemaster_dummy
-	screen |= darkness_planemaster_dummy
-
-
 /obj/abstract/screen/plane_master/fakecamera_screen_planemaster
 	plane = FAKE_CAMERA_SCREEN_PLANE
 	alpha = 0

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_mobs_and_constructs.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_mobs_and_constructs.dm
@@ -826,9 +826,9 @@ var/list/astral_projections = list()
 
 /mob/living/simple_animal/astral_projection/update_perception()
 	if(client)
-		if(client.darkness_planemaster)
-			client.darkness_planemaster.blend_mode = BLEND_MULTIPLY
-			client.darkness_planemaster.alpha = 180
+		if(dark_plane)
+			dark_plane.alphas["astralprojection"] = 75
+		check_dark_vision()
 		if(!tangibility)
 			client.color = list(
 						1,0,0,0,

--- a/code/datums/hud/night_hud.dm
+++ b/code/datums/hud/night_hud.dm
@@ -13,24 +13,24 @@
 	if(!M.client)
 		return
 	M.client.color = "#33FF33"
-	if (M.master_plane)
-		M.master_plane.blend_mode = BLEND_ADD
+	if (M.lighting_planemaster)
+		M.lighting_planemaster.blend_mode = BLEND_ADD
 	M.update_perception()
 	M.update_darkness()
 	M.check_dark_vision()
 
 /datum/visioneffect/night/process_update_perception(var/mob/M)
 	..()
-	if (M.master_plane)
-		M.master_plane.blend_mode = BLEND_ADD
+	if (M.lighting_planemaster)
+		M.lighting_planemaster.blend_mode = BLEND_ADD
 
 /datum/visioneffect/night/on_remove(var/mob/M)
 	..()
 	if(!M.client)
 		return
 	M.client.color = null
-	if (M.master_plane)
-		M.master_plane.blend_mode = BLEND_MULTIPLY
+	if (M.lighting_planemaster)
+		M.lighting_planemaster.blend_mode = BLEND_MULTIPLY
 	M.update_perception()
 	M.update_darkness()
 	M.check_dark_vision()

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -78,8 +78,6 @@
 	var/obj/abstract/screen/plane_master/parallax_spacemaster/parallax_spacemaster = null
 	var/obj/abstract/screen/plane_master/ghost_planemaster/ghost_planemaster = null
 	var/obj/abstract/screen/plane_master/ghost_planemaster_dummy/ghost_planemaster_dummy = null
-	var/obj/abstract/screen/plane_master/ghost_planemaster/darkness_planemaster = null
-	var/obj/abstract/screen/plane_master/ghost_planemaster_dummy/darkness_planemaster_dummy = null
 	var/obj/abstract/screen/plane_master/ghost_planemaster/fakecamera_screen_planemaster = null
 	var/obj/abstract/screen/plane_master/ghost_planemaster_dummy/fakecamera_screen_planemaster_dummy = null
 	var/obj/abstract/screen/plane_master/ghost_planemaster_dummy/fakecamera_button_planemaster = null

--- a/code/modules/lighting/light_mob.dm
+++ b/code/modules/lighting/light_mob.dm
@@ -1,8 +1,8 @@
 /mob
-	var/obj/abstract/screen/plane/master/master_plane
+	var/obj/abstract/screen/plane/master/lighting_planemaster
 	var/obj/abstract/screen/plane/self_vision/self_vision
 	var/obj/abstract/screen/plane/dark/dark_plane
-	var/seedarkness = 1
+	var/seedarkness = TRUE
 
 /mob/proc/create_lighting_planes()
 
@@ -10,16 +10,16 @@
 		client.screen -= dark_plane
 		QDEL_NULL(dark_plane)
 
-	if (master_plane)
-		client.screen -= master_plane
-		QDEL_NULL(master_plane)
+	if (lighting_planemaster)
+		client.screen -= lighting_planemaster
+		QDEL_NULL(lighting_planemaster)
 
 	if (self_vision)
 		client.screen -= self_vision
 		QDEL_NULL(self_vision)
 
 	dark_plane = new(client)
-	master_plane = new(client)
+	lighting_planemaster = new(client)
 	self_vision = new(client)
 
 	update_darkness()
@@ -27,6 +27,7 @@
 
 /mob/proc/update_darkness()
 	if(seedarkness)
-		master_plane?.color = LIGHTING_PLANEMASTER_COLOR
+		lighting_planemaster?.LIGHTING_PLANEMASTER_COLOR
 	else
-		master_plane?.color = ""
+		lighting_planemaster?.color = ""
+

--- a/code/modules/lighting/light_mob.dm
+++ b/code/modules/lighting/light_mob.dm
@@ -27,7 +27,7 @@
 
 /mob/proc/update_darkness()
 	if(seedarkness)
-		lighting_planemaster?.LIGHTING_PLANEMASTER_COLOR
+		lighting_planemaster?.color = LIGHTING_PLANEMASTER_COLOR
 	else
 		lighting_planemaster?.color = ""
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1619,6 +1619,9 @@ var/datum/record_organ //This is just a dummy proc, not storing any variables he
 		lighting_planemaster.blend_mode = BLEND_MULTIPLY
 
 	if(client && dark_plane)
+		if(dna && (dna.mutantrace == "shadow"))
+			dark_plane.alphas["shadow"] = 155
+
 		var/datum/organ/internal/eyes/E = src.internal_organs_by_name["eyes"]
 		if(E)
 			E.update_perception(src)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1615,8 +1615,8 @@ var/datum/record_organ //This is just a dummy proc, not storing any variables he
 		dark_plane.colours = null
 		dark_plane.blend_mode = BLEND_ADD
 
-	if (master_plane)
-		master_plane.blend_mode = BLEND_MULTIPLY
+	if (lighting_planemaster)
+		lighting_planemaster.blend_mode = BLEND_MULTIPLY
 
 	if(client && dark_plane)
 		var/datum/organ/internal/eyes/E = src.internal_organs_by_name["eyes"]

--- a/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
@@ -42,9 +42,6 @@
 				see_in_dark = 3
 				see_invisible = SEE_INVISIBLE_LEVEL_ONE
 			if("shadow")
-				if(dark_plane)
-					dark_plane.alphas["shadow"] = 155
-				check_dark_vision()
 				see_in_dark = 8
 				see_invisible = SEE_INVISIBLE_LEVEL_ONE
 	if(M_THERMALS in mutations)

--- a/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
@@ -42,8 +42,9 @@
 				see_in_dark = 3
 				see_invisible = SEE_INVISIBLE_LEVEL_ONE
 			if("shadow")
-				if(client)
-					client.darkness_planemaster.alpha = 100
+				if(dark_plane)
+					dark_plane.alphas["shadow"] = 155
+				check_dark_vision()
 				see_in_dark = 8
 				see_invisible = SEE_INVISIBLE_LEVEL_ONE
 	if(M_THERMALS in mutations)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -950,7 +950,9 @@ var/static/list/ai_icon_states = list(
 	icon_state = chosen_core_icon_state
 
 /mob/living/silicon/ai/update_perception()
-	if(ai_flags & HIGHRESCAMS)
-		client?.darkness_planemaster.alpha = 150
-	else
-		client?.darkness_planemaster.alpha = 255
+	if(dark_plane)
+		if(ai_flags & HIGHRESCAMS)
+			dark_plane.alphas["ai"] = 105
+		else
+			dark_plane.alphas["ai"] = 10
+	check_dark_vision()

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
@@ -65,7 +65,7 @@
 	held_items = list()
 
 	avoids_poisonous=TRUE
-	
+
 	//keeping this here for later color matrix testing
 	var/a_matrix_testing_override = FALSE
 	var/a_11 = 1
@@ -185,9 +185,9 @@
 		return
 
 	if(dark_plane)
-		if (master_plane)
-			master_plane.blend_mode = BLEND_ADD
-		dark_plane.alphas["spider"] = 0 // with the master_plane at BLEND_ADD, shadows appear well lit while actually well lit places appear blinding.
+		if (lighting_planemaster)
+			lighting_planemaster.blend_mode = BLEND_ADD
+		dark_plane.alphas["spider"] = 0 // with the lighting_planemaster at BLEND_ADD, shadows appear well lit while actually well lit places appear blinding.
 		client.color = list(
 			1,0,0,0,
 			0,0.2,0,0,

--- a/code/modules/mob/living/simple_animal/hostile/grue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue.dm
@@ -428,9 +428,9 @@
 	if(!client)
 		return
 	if(dark_plane)
-		if(master_plane)
-			master_plane.blend_mode = BLEND_ADD
-		dark_plane.alphas["grue"] = 0 // with the master_plane at BLEND_ADD, shadows appear well lit while actually well lit places appear blinding.
+		if(lighting_planemaster)
+			lighting_planemaster.blend_mode = BLEND_ADD
+		dark_plane.alphas["grue"] = 0 // with the lighting_planemaster at BLEND_ADD, shadows appear well lit while actually well lit places appear blinding.
 		client.color = list(
 				1,0,0,0,
 				-1,0.2,0.2,0,

--- a/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
@@ -125,8 +125,11 @@
 
 /mob/living/simple_animal/hostile/pulse_demon/update_perception()
 	// So we can see in maint better
-	if(client && client.darkness_planemaster)
-		client.darkness_planemaster.alpha = 192
+
+	if(dark_plane)
+		dark_plane.alphas["pulsedemon"] = 63
+	check_dark_vision()
+
 	update_cableview()
 
 /mob/living/simple_animal/hostile/pulse_demon/regular_hud_updates()

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -73,7 +73,6 @@
 	client.screen += overdark_planemaster
 	client.screen += overdark_planemaster_target
 	client.initialize_ghost_planemaster() //We want to explicitly reset the planemaster's visibility on login() so if you toggle ghosts while dead you can still see cultghosts if revived etc.
-	client.initialize_darkness_planemaster()
 	client.initialize_fakecamera_planemaster()
 	update_perception()
 	create_lighting_planes()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -56,7 +56,7 @@
 
 	dark_plane = null
 	self_vision = null
-	master_plane = null
+	lighting_planemaster = null
 
 	QDEL_NULL(hud_used)
 	for(var/atom/movable/leftovers in src)
@@ -1610,7 +1610,7 @@ Use this proc preferably at the end of an equipment loadout
 	if (self_vision)
 		if (isturf(loc))
 			var/turf/T = loc
-			if (T.get_lumcount() <= 0 && (dark_plane.alpha <= 15) && (master_plane.blend_mode == BLEND_MULTIPLY))
+			if (T.get_lumcount() <= 0 && (dark_plane.alpha <= 15) && (lighting_planemaster.blend_mode == BLEND_MULTIPLY))
 				animate(self_vision, alpha = self_vision.target_alpha, time = 0)
 			else
 				animate(self_vision, alpha = 0, time = 0)

--- a/code/modules/organs/internal/eyes/eyes.dm
+++ b/code/modules/organs/internal/eyes/eyes.dm
@@ -67,7 +67,7 @@
 
 /datum/organ/internal/eyes/mushroom/update_perception(var/mob/living/carbon/human/M)
 	if (dark_mode)
-		M.master_plane.blend_mode = BLEND_SUBTRACT
+		M.lighting_planemaster.blend_mode = BLEND_SUBTRACT
 		M.dark_plane.alphas["mushroom_inverted"] = 100
 		M.dark_plane.blend_mode = BLEND_MULTIPLY
 		M.dark_plane.colours = "#FF0000"
@@ -78,7 +78,7 @@
 			0,-0.1,0,1,
 			0,0,0,0)
 	else
-		M.master_plane.blend_mode = BLEND_MULTIPLY
+		M.lighting_planemaster.blend_mode = BLEND_MULTIPLY
 		M.dark_plane.blend_mode = BLEND_ADD
 		M.dark_plane.colours = null
 		M.client.color = list(


### PR DESCRIPTION
Removed the darkness_planemaster which was de facto unused and rendered obsolete by both master_plane (now renamed to lighting_planemaster) and dark_plane. While at it, converted the few instances of darkness_planemaster alpha manipulation done for nothing, so they now actually serve their purpose.

<img width="960" height="484" alt="image" src="https://github.com/user-attachments/assets/c1f3870f-d60a-4e2f-8dc7-f7b186f4e404" />

:cl:
* bugfix: Pulse Demons, Malf AIs with Highres Camera hackability, Humans with the shadow mutation, as well as Astral Projections now benefit from the enhanced dark vision they were each meant to have.