### PR TITLE
This also kills the darkness

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1991,6 +1991,8 @@ var/list/weekend_days = list("Friday", "Saturday", "Sunday")
 #define PS_SACRED_FLAME		"Sacred Flame"
 #define PS_SACRED_FLAME2	"Sacred Flame2"
 #define PS_BIBLE_PAGE		"Bible Page"
+#define PS_SHADOW_SMOKE		"Shadow Smoke"
+#define PS_SHADOW_SMOKE2	"Shadow Smoke2"
 
 //Particles variable defines
 #define PVAR_SPAWNING	"spawning"

--- a/code/game/objects/effects/particles_system.dm
+++ b/code/game/objects/effects/particles_system.dm
@@ -183,6 +183,8 @@ var/list/particle_string_to_type = list(
 	PS_SACRED_FLAME = /particles/sacred_flame,
 	PS_SACRED_FLAME2 = /particles/sacred_flame/alt,
 	PS_BIBLE_PAGE = /particles/bible_page,
+	PS_SHADOW_SMOKE = /particles/cult_smoke,
+	PS_SHADOW_SMOKE2 = /particles/cult_smoke/alt,
 	)
 
 /particles

--- a/code/modules/mob/living/carbon/human/life/handle_chemicals_in_body.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_chemicals_in_body.dm
@@ -62,10 +62,18 @@
 			else
 				light_amount = 10
 
-		if(light_amount > 2) //If there's enough light, start dying
+		if(light_amount > 2) //If there's enough light, start dying //maybe clothing should counteract that somewhat?
 			take_overall_damage(1,1)
+			add_particles(PS_SHADOW_SMOKE)
+			add_particles(PS_SHADOW_SMOKE2)
+			adjust_particles(PVAR_SPAWNING,0.6,PS_SHADOW_SMOKE)
+			adjust_particles(PVAR_SPAWNING,0.6,PS_SHADOW_SMOKE2)
+			if (prob(1))
+				to_chat(src,"<span class='danger'>The light burns your skin!</span>")
 		else if(light_amount < 2) //Heal in the dark
 			heal_overall_damage(1,1)
+			remove_particles(PS_SHADOW_SMOKE)
+			remove_particles(PS_SHADOW_SMOKE2)
 
 	//The fucking M_FAT mutation is the greatest shit ever. It makes everyone so hot and bothered.
 	if(species.anatomy_flags & CAN_BE_FAT)


### PR DESCRIPTION
Turns out there was previously no feedback at all aside from taking damage until you died. I'm sure it led to quite a few confusing deaths.

![shadowsmoke](https://github.com/user-attachments/assets/a47770ce-f548-4a78-8711-34b384d95170)


:cl:
* rscadd: Humans with the shadow mutation (currently obtainable from the Dark Revive Xenaorch artifact) now emit some visible black smoke when they take damage from stepping into the light.