### PR TITLE
Fix DPI scaling messing up NanoUI windows

### DIFF
--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -12,6 +12,9 @@ nanoui is used to open and update nano browser uis
 #define STATUS_DISABLED 0 // RED Visability
 #define STATUS_CLOSE -1 // Close the window
 
+// Post-Byond 516 DPI scaling settings affect the opened window.
+// Rather than e.g. 100x100 you get (window size / scale), so for 125% scaling you get 80x80.
+// This messes up a lot of interfaces so this value is cached and applied to opening windows to correct for scaling.
 /client/var/dpiScale = 1
 
 /datum/nanoui

--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -460,7 +460,6 @@ nanoui is used to open and update nano browser uis
 
 	var/window_size = ""
 	if (width && height)
-		window_size = "size=[width]x[height];"
 		var/effective_width = width
 		var/effective_height = height
 		if (user.client.dpiScale && user.client.dpiScale != 1)
@@ -543,7 +542,7 @@ nanoui is used to open and update nano browser uis
 				user.client.dpiScale = scale
 			if (user && width && height)
 				var/adjusted_width = round(width * scale)
-				var/adjusted_height = round (height * scale)
+				var/adjusted_height = round(height * scale)
 				winset(user, window_id, "size=[adjusted_width]x[adjusted_height]")
 
 	update_status(0) // update the status

--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -11,6 +11,9 @@ nanoui is used to open and update nano browser uis
 #define STATUS_UPDATE 1 // ORANGE Visability
 #define STATUS_DISABLED 0 // RED Visability
 #define STATUS_CLOSE -1 // Close the window
+
+/client/var/dpiScale = 1
+
 /datum/nanoui
 	// the user who opened this ui
 	var/mob/user
@@ -458,6 +461,12 @@ nanoui is used to open and update nano browser uis
 	var/window_size = ""
 	if (width && height)
 		window_size = "size=[width]x[height];"
+		var/effective_width = width
+		var/effective_height = height
+		if (user.client.dpiScale && user.client.dpiScale != 1)
+			effective_width = round(width * user.client.dpiScale)
+			effective_height = round(height * user.client.dpiScale)
+		window_size = "size=[effective_width]x[effective_height]"
 	update_status(0)
 	user << browse(get_html(), "window=[window_id];[window_size][window_options]")
 	winset(user, "mapwindow.map", "focus=true") // return keyboard focus to map
@@ -523,6 +532,20 @@ nanoui is used to open and update nano browser uis
   * @return nothing
   */
 /datum/nanoui/Topic(href, href_list)
+	if (href_list["nanoui_dpr"])
+		var/scale = text2num(href_list["nanoui_dpr"])
+		if (!scale && href_list["nanoui_inner_w"] && width)
+			var/inner_width = text2num(href_list["nanoui_inner_w"])
+			if (inner_width > 0)
+				scale = width / inner_width
+		if (scale)
+			if (user && user.client)
+				user.client.dpiScale = scale
+			if (user && width && height)
+				var/adjusted_width = round(width * scale)
+				var/adjusted_height = round (height * scale)
+				winset(user, window_id, "size=[adjusted_width]x[adjusted_height]")
+
 	update_status(0) // update the status
 	if (status != STATUS_INTERACTIVE || user != usr) // If UI is not interactive or usr calling Topic is not the UI user
 		return

--- a/nano/templates/layout_default.tmpl
+++ b/nano/templates/layout_default.tmpl
@@ -28,3 +28,31 @@
 <div id='uiContent' unselectable="on">
 	<div id='uiLoadingNotice'>Initiating...</div>
 </div>
+
+<script type="text/javascript">
+(function () {
+	if (window.__nanouiViewportReported) {
+		return;
+	}
+	window.__nanouiViewportReported = true;
+	var raw = document.body.getAttribute('data-url-parameters');
+	if (!raw) {
+		return;
+	}
+	try {
+		var params = JSON.parse(raw);
+		if (!params.src) {
+			return;
+		}
+		var query = [
+			"src=" + encodeURIComponent(params.src),
+			"nanoui_dpr=" + encodeURIComponent(window.devicePixelRatio || 1)
+		];
+		if (window.innerWidth) {
+			query.push("nanoui_inner_w=" + Math.round(window.innerWidth));
+		}
+		window.location.href = "byond://?" + query.join("&");
+	} catch (e) {
+	}
+})();
+</script>


### PR DESCRIPTION
## What this does
Unlike Byond 515, Byond 516 uses WebView which seems to be aware of the system DPI scaling setting. As a result, the client area of created windows is now affected by DPI settings (in Windows, this is the value you set in Settings->Display, something like 125% or 150% or whatever) which results in windows not actually being created at exactly that size. I use 125% scaling and it resulted in a window with client area 312x504 being created when opening the chem dispenser. This is exactly 80% (1.0/1.25) of 390x630, the size of the chem dispenser interface.

This PR extends the NanoUI JS a bit to store the inner width, which is then used to calculate the user's DPI scaling, which is then cached on `/client`. This value is used to scale window size in `open()` such that windows appear at the correct size regardless of the user's DPI setting.

**I used AI to help with the JavaScript part because I don't know JS. It looks okay to me but if anyone knows what they're doing with JS please double-check it.**

## Why it's good
Chemistry/Medbay players won't whine about their muscle memory screwing up their ability to make mix without first resizing the window every time

Also no need for the user to change their Windows settings to make it bearable

## How it was tested
`world.log` when opening a window in Byond 515 vs. Byond 516 to check size, figured out scaling. Screenshots of pre-fix and post-fix in Byond 516:

<img width="1074" height="963" alt="image" src="https://github.com/user-attachments/assets/83198ca3-284b-452f-bcbb-ec737d3c06d7" />
<img width="1294" height="1079" alt="image" src="https://github.com/user-attachments/assets/653c62a5-fc12-460c-b1bc-e876542959d8" />


## Changelog
:cl:
 * bugfix: Fixed DPI scaling messing with NanoUI 