### PR TITLE
Buffs cryotheum production slightly

### DIFF
--- a/code/game/machinery/ATMOSPHERICS/hvac/cryotheum_resonator.dm
+++ b/code/game/machinery/ATMOSPHERICS/hvac/cryotheum_resonator.dm
@@ -127,11 +127,11 @@
 	var/amount = 0
 	if(crystal != null)
 		if(istype(crystal, /obj/item/bluespace_crystal/artificial))
-			amount = 120
+			amount = 250
 		else if(istype(crystal, /obj/item/bluespace_crystal/flawless))
-			amount = 950
+			amount = 1250
 		else
-			amount = 240
+			amount = 500
 	if(emagged)
 		amount *= 1.2
 	return amount


### PR DESCRIPTION
## What this does
Buffs cryotheum production slightly.
Artificial and natural crystals now make 2.08x as much as they did before, while flawless crystals now make 1.3x as much.
## Why it's good
Cryotheum production is very slow compared to how quickly it gets used, even with natural crystals, so you have to stack tons of the machines to barely get some production going. This should alleviate that somewhat.
:cl:
 * tweak: Cryotheum resonators have been upgraded and will now produce 2.08x more cryotheum with natural and artificial crystals, while flawless crystals can now resonate at 1.3x the rate.