### PR TITLE
Fixes bricked pipenets

### DIFF
--- a/code/game/machinery/ATMOSPHERICS/atmospherics.dm
+++ b/code/game/machinery/ATMOSPHERICS/atmospherics.dm
@@ -172,10 +172,17 @@ Pipelines + Other Objects -> Pipe network
 			nodecon.plane = node_plane()
 			nodecon.layer = node_layer()
 			if(nodecon.alpha < 255)
-				var/list/node_gases = connected_node.get_visible_gases()
-				if(node_gases)
-					for(var/nodegas in node_gases)
-						nodecon.underlays += image('icons/obj/atmospherics/gas_overlays.dmi',src,nodegas,nodecon.layer,con_dir)
+				var/should_show_gases = TRUE
+				if(istype(connected_node, /obj/machinery/atmospherics/pipe))
+					var/obj/machinery/atmospherics/pipe/connected_pipe = connected_node
+					if(!connected_pipe.parent)
+						should_show_gases = FALSE
+
+				if(should_show_gases)
+					var/list/node_gases = connected_node.get_visible_gases()
+					if(node_gases)
+						for(var/nodegas in node_gases)
+							nodecon.underlays += image('icons/obj/atmospherics/gas_overlays.dmi',src,nodegas,nodecon.layer,con_dir)
 			underlays += nodecon
 		if (!adjacent_procd && connected_node.update_icon_ready && !(istype(connected_node,/obj/machinery/atmospherics/pipe/simple)))
 			connected_node.update_icon(1)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Fixes a bug caused by #38522 which bricked atmos entirely due to the get_visible_gases proc now calling on /obj/machinery/atmospherics instead of /obj/machinery/atmospherics/pipe. This proc includes a return_air() call which is **not** ready-only and creates a new pipeline if the pipe doesn't have a parent yet. As this was called during mapload which occurs before pipenet init, this was leading to all pipes having their own isolated single-member pipelines at roundstart. This fix only calls get_visible_gases on pipes if a parent pipeline already exists.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
This game was built around atmospheric simulation and this PR allows for atmospheric simulation

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Medbay freezer + cryo pipenet as this was the driving issue

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed every pipe creating its own pipenet thus bricking atmos.