### PR TITLE
undoes the swapping of roidstation's ai and telecomms rooms

### DIFF
--- a/maps/RoidStation.dmm
+++ b/maps/RoidStation.dmm
@@ -16074,6 +16074,7 @@
 /obj/machinery/door/firedoor/border_only{
 	name = "Firelock South"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor/plating,
 /area/maintenance/ghettobar)
 "aGM" = (
@@ -17816,6 +17817,9 @@
 /obj/structure/window/barricade{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
 /turf/simulated/floor{
 	icon_state = "bar"
 	},
@@ -17831,7 +17835,9 @@
 	dir = 1;
 	invisibility = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "damaged5"
@@ -18865,10 +18871,8 @@
 /area/engine/magma_engine)
 "aLE" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 1;
-	external_pressure_bound = 100;
-	on = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
 /turf/simulated/floor{
 	icon_state = "bar"
@@ -19078,6 +19082,9 @@
 /area/hallway/primary/fore)
 "aLX" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "bar"
 	},
@@ -19613,7 +19620,7 @@
 "aMZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "bar"
@@ -20465,7 +20472,6 @@
 	name = "Firelock South"
 	},
 /obj/structure/window/barricade/full/block,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor/plating,
 /area/maintenance/ghettobar)
 "aOI" = (
@@ -20521,7 +20527,6 @@
 /obj/structure/window/reinforced,
 /obj/structure/grille,
 /obj/structure/window/barricade/full/block,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor/plating,
 /area/maintenance/ghettobar)
 "aOO" = (
@@ -21492,6 +21497,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
 	icon_state = "asteroidfloor"
@@ -21575,7 +21583,6 @@
 	icon_state = "cigs-broken";
 	stat = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
 	icon_state = "bar"
 	},
@@ -22465,6 +22472,11 @@
 /turf/simulated/floor/asteroid/air,
 /area/maintenance/port)
 "aSk" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8;
+	external_pressure_bound = 100;
+	on = 1
+	},
 /turf/simulated/floor{
 	icon_state = "bar"
 	},
@@ -22491,9 +22503,15 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/ghettobar)
 "aSn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /obj/structure/window/barricade{
 	dir = 8
 	},
@@ -26061,28 +26079,14 @@
 	},
 /area/gateway)
 "aYT" = (
-/obj/structure/table,
-/obj/item/weapon/aiModule/core/asimov{
-	pixel_x = -4;
-	pixel_y = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/item/weapon/aiModule/core/lazymov{
-	pixel_x = -2;
-	pixel_y = 2
+/turf/simulated/floor{
+	icon_state = "dark"
 	},
-/obj/item/weapon/aiModule/core/nanotrasen,
-/obj/item/weapon/aiModule/reset{
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/weapon/aiModule/freeform/core{
-	pixel_x = 4;
-	pixel_y = -4
-	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "bcircuitoff"
-	},
-/area/turret_protected/ai_upload)
+/area/turret_protected/tcomms_control_room)
 "aYU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor/plating{
@@ -31577,15 +31581,18 @@
 	},
 /area/tcomms/chamber)
 "biF" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/message_server,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 4
 	},
 /turf/simulated/floor/bluegrid{
-	icon_state = "bcircuitoff"
+	icon_state = "dark";
+	name = "Mainframe Floor";
+	nitrogen = 100;
+	oxygen = 0;
+	temperature = 80
 	},
-/area/turret_protected/ai)
+/area/tcomms/chamber)
 "biG" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
@@ -31625,18 +31632,13 @@
 	},
 /area/tcomms/chamber)
 "biI" = (
-/obj/machinery/telecomms/server/presets/medical,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
 	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "dark";
-	name = "Mainframe Floor";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
 	},
-/area/tcomms/chamber)
+/area/maintenance/port)
 "biJ" = (
 /mob/living/simple_animal/crab/kickstool{
 	name = "Cubanelle"
@@ -32683,25 +32685,28 @@
 	},
 /area/tcomms/chamber)
 "bkM" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/telecomms/broadcaster/preset_left,
+/turf/simulated/floor/bluegrid{
+	icon_state = "dark";
+	name = "Mainframe Floor";
+	nitrogen = 100;
+	oxygen = 0;
+	temperature = 80
 	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	on = 1
-	},
-/turf/simulated/floor/dark,
-/area/turret_protected/ai)
+/area/tcomms/chamber)
 "bkO" = (
-/obj/machinery/recharge_station,
-/obj/effect/landmark/start{
-	name = "Cyborg"
+/obj/machinery/blackbox_recorder,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 4
 	},
 /turf/simulated/floor/bluegrid{
-	icon_state = "bcircuitoff"
+	icon_state = "dark";
+	name = "Mainframe Floor";
+	nitrogen = 100;
+	oxygen = 0;
+	temperature = 80
 	},
-/area/turret_protected/ai)
+/area/tcomms/chamber)
 "bkP" = (
 /obj/structure/hanging_lantern/dim{
 	dir = 8
@@ -34128,38 +34133,36 @@
 /turf/simulated/floor/plating,
 /area/tcomms/storage2)
 "bnB" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/sign/nosmoking_2{
+	pixel_x = -32
+	},
+/obj/machinery/telecomms/bus/preset_two,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/he_manifold{
 	dir = 4
 	},
-/obj/machinery/door/poddoor{
-	desc = "A pair of heavy reinforced plasteel doors.";
-	id_tag = "AIcore";
-	name = "AI Chamber Blast Door"
+/turf/simulated/floor/bluegrid{
+	name = "Mainframe Base";
+	nitrogen = 100;
+	oxygen = 0;
+	temperature = 80
 	},
-/turf/simulated/floor/dark,
-/area/turret_protected/ai)
+/area/tcomms/chamber)
 "bnC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/insulated/visible/blue{
+	dir = 4;
+	tag = "icon-intact (EAST)"
 	},
-/turf/simulated/floor/dark,
-/area/turret_protected/ai)
+/turf/simulated/floor/plating,
+/area/tcomms/storage2)
 "bnD" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction/hidden{
 	dir = 4
 	},
-/turf/simulated/floor/dark,
-/area/turret_protected/ai)
+/turf/simulated/wall/r_wall,
+/area/tcomms/chamber)
 "bnE" = (
 /obj/machinery/telecomms/hub/preset,
 /obj/structure/cable{
@@ -34197,8 +34200,16 @@
 	},
 /area/tcomms/chamber)
 "bnH" = (
-/turf/space,
-/area/turret_protected/ai)
+/obj/machinery/telecomms/bus/preset_four,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/turf/simulated/floor/bluegrid{
+	icon_state = "dark";
+	name = "Mainframe Floor";
+	nitrogen = 100;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/tcomms/chamber)
 "bnI" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -35594,16 +35605,9 @@
 /turf/simulated/floor/plating,
 /area/engineering/supermatter_room)
 "bqn" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "bcircuitoff"
-	},
-/area/turret_protected/ai)
+/obj/machinery/atmospherics/pipe/manifold4w/insulated/visible/blue,
+/turf/simulated/floor/plating,
+/area/tcomms/storage2)
 "bqp" = (
 /obj/machinery/atmospherics/unary/cold_sink/freezer{
 	current_temperature = 73.15;
@@ -35614,18 +35618,18 @@
 /turf/simulated/floor/plating,
 /area/tcomms/storage2)
 "bqq" = (
-/obj/item/device/radio/intercom/aiprivate{
-	broadcasting = 1;
-	name = "Private AI Channel";
-	pixel_x = 28;
-	pixel_y = -28
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/dark,
-/area/turret_protected/ai)
+/turf/simulated/floor/bluegrid{
+	name = "Mainframe Base";
+	nitrogen = 100;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/tcomms/chamber)
 "bqr" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/simulated/floor/bluegrid{
@@ -37232,36 +37236,15 @@
 /turf/simulated/floor,
 /area/engineering/supermatter_room)
 "btn" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/insulated/visible/blue{
+	dir = 9;
+	tag = "icon-intact (NORTHWEST)"
 	},
-/obj/machinery/door/window{
-	name = "AI Core Door";
-	req_access_txt = "16"
-	},
-/obj/machinery/door_control{
-	id_tag = "AIcore";
-	name = "AI Core Lockdown";
-	pixel_x = -23;
-	pixel_y = 23;
-	range = 5;
-	req_access_txt = "29"
-	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "bcircuitoff"
-	},
-/area/turret_protected/ai)
+/turf/simulated/floor/plating,
+/area/tcomms/storage2)
 "btp" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/ai_slipper,
-/turf/simulated/floor/dark,
-/area/turret_protected/ai)
+/turf/simulated/floor/plating,
+/area/tcomms/storage2)
 "btq" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -37307,9 +37290,18 @@
 	},
 /area/tcomms/chamber)
 "btu" = (
-/obj/structure/lattice,
-/turf/space,
-/area/turret_protected/ai)
+/obj/machinery/telecomms/server/presets/security,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 9
+	},
+/turf/simulated/floor/bluegrid{
+	icon_state = "dark";
+	name = "Mainframe Floor";
+	nitrogen = 100;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/tcomms/chamber)
 "btw" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating{
@@ -38813,15 +38805,19 @@
 /turf/simulated/floor/plating,
 /area/tcomms/storage2)
 "bwc" = (
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/machinery/power/battery/smes{
-	charge = 5e+006
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai)
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 6
+	},
+/turf/simulated/floor/plating,
+/area/tcomms/chamber)
 "bwd" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -38889,15 +38885,15 @@
 /turf/simulated/floor/plating,
 /area/tcomms/chamber)
 "bwi" = (
-/obj/structure/mannequin/cyber{
-	desc = "A model of a robotic prototype.";
-	icon_state = "mannequin_primitive";
-	name = "Cyborg model"
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "bcircuitoff"
+/obj/structure/window/reinforced,
+/turf/simulated/floor{
+	icon_state = "dark"
 	},
-/area/turret_protected/ai_upload)
+/area/tcomms/chamber)
 "bwj" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -40241,18 +40237,24 @@
 /turf/simulated/floor/plating,
 /area/tcomms/storage2)
 "byM" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/computer/message_monitor,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 9
 	},
-/obj/machinery/power/terminal{
-	dir = 1
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "dark brown stripe";
+	tag = "icon-dark brown stripe (NORTHWEST)"
 	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai)
+/area/turret_protected/tcomms_control_room)
 "byO" = (
-/turf/simulated/floor/dark,
-/area/turret_protected/ai)
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4;
+	icon_state = "intact_on";
+	on = 1
+	},
+/turf/simulated/floor/plating,
+/area/tcomms/storage2)
 "byP" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
@@ -40260,18 +40262,25 @@
 /turf/simulated/wall/r_wall,
 /area/turret_protected/tcomms_control_room)
 "byQ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/tcomms/chamber)
+"byR" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/dark,
-/area/turret_protected/ai_upload)
-"byR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/simulated/floor/dark,
-/area/turret_protected/ai_upload)
+/turf/simulated/floor/plating,
+/area/tcomms/chamber)
 "byS" = (
 /obj/machinery/computer/telecomms/server{
 	network = "tcommsat"
@@ -40283,58 +40292,38 @@
 	},
 /area/turret_protected/tcomms_control_room)
 "byT" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4;
-	on = 1
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/simulated/floor/dark,
-/area/turret_protected/ai_upload)
+/turf/simulated/floor/plating,
+/area/tcomms/chamber)
 "byU" = (
-/obj/structure/filingcabinet/chestdrawer,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "dark brown stripe";
-	tag = "icon-dark brown stripe (NORTHEAST)"
+/obj/structure/closet/firecloset,
+/obj/machinery/light{
+	dir = 8
 	},
-/area/turret_protected/tcomms_control_room)
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellowsiding";
+	tag = "icon-yellowsiding"
+	},
+/area/hallway/primary/port)
 "byV" = (
 /obj/structure/table,
-/obj/item/weapon/aiModule/standard/oxygen{
-	pixel_x = -4;
-	pixel_y = 4
+/obj/item/device/multitool,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/item/device/radio/off,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "dark brown stripe";
+	tag = "icon-dark brown stripe (NORTHWEST)"
 	},
-/obj/item/weapon/aiModule/standard/teleporterOffline{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/weapon/aiModule/core/antimov,
-/obj/item/weapon/aiModule/purge{
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/weapon/aiModule/targetted/oneHuman{
-	pixel_x = 4;
-	pixel_y = -4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "High-Risk Modules";
-	req_access_txt = "20"
-	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "bcircuitoff"
-	},
-/area/turret_protected/ai_upload)
+/area/turret_protected/tcomms_control_room)
 "byW" = (
 /obj/machinery/computer/telecomms/monitor{
 	network = "tcommsat"
@@ -40346,9 +40335,9 @@
 	},
 /area/turret_protected/tcomms_control_room)
 "byX" = (
-/obj/machinery/message_server,
+/obj/machinery/telecomms/server/presets/science,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6
+	dir = 5
 	},
 /turf/simulated/floor/bluegrid{
 	icon_state = "dark";
@@ -40368,9 +40357,9 @@
 /turf/simulated/floor/beach/water,
 /area/maintenance/port)
 "byZ" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
-/area/maintenance/port)
+/obj/structure/sign/securearea,
+/turf/simulated/wall/r_wall,
+/area/turret_protected/ai)
 "bza" = (
 /obj/machinery/camera{
 	dir = 10;
@@ -41113,13 +41102,11 @@
 	},
 /area/supply/office)
 "bAr" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/turret_protected/tcomms_control_room)
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_upload)
 "bAs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41282,13 +41269,18 @@
 	name = "\improper Research and Mining Hallway"
 	})
 "bAG" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/machinery/telecomms/server/presets/medical,
+/turf/simulated/floor/bluegrid{
+	icon_state = "dark";
+	name = "Mainframe Floor";
+	nitrogen = 100;
+	oxygen = 0;
+	temperature = 80
 	},
-/area/turret_protected/tcomms_control_room)
+/area/tcomms/chamber)
 "bAH" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -41740,19 +41732,14 @@
 /area/tcomms/storage2)
 "bBA" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/turret{
-	dir = 8
+/turf/simulated/floor{
+	icon_state = "dark"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai)
+/area/turret_protected/tcomms_control_room)
 "bBB" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -41762,13 +41749,16 @@
 	},
 /area/turret_protected/tcomms_control_room)
 "bBD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "bcircuitoff"
+/obj/machinery/power/apc{
+	name = "_South APC";
+	pixel_y = -24
 	},
-/area/turret_protected/ai)
+/turf/simulated/floor/plating,
+/area/tcomms/storage2)
 "bBE" = (
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Server Room";
@@ -41815,22 +41805,29 @@
 /turf/simulated/floor/plating,
 /area/turret_protected/tcomms_control_room)
 "bBI" = (
-/obj/machinery/media/receiver/boombox/wallmount/muzak{
-	on = 0;
-	pixel_x = 28
+/obj/machinery/power/apc{
+	dir = 8;
+	pixel_x = -24
 	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
 /area/turret_protected/tcomms_control_room)
 "bBJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/turf/simulated/floor/bluegrid{
+	icon_state = "bcircuitoff"
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/turret_protected/tcomms_control_room)
+/area/turret_protected/ai_upload)
 "bBK" = (
 /obj/machinery/atmospherics/unary/tank/air,
 /obj/effect/decal/cleanable/cobweb2,
@@ -41849,40 +41846,29 @@
 /turf/simulated/floor/beach/water,
 /area/maintenance/port)
 "bBN" = (
-/obj/machinery/telecomms/broadcaster/preset_left,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/turf/simulated/floor/bluegrid{
-	icon_state = "dark";
-	name = "Mainframe Floor";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/area/tcomms/chamber)
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
 "bBP" = (
-/obj/machinery/telecomms/broadcaster/preset_right,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/turf/simulated/floor/bluegrid{
-	icon_state = "dark";
-	name = "Mainframe Floor";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/tcomms/chamber)
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
 "bBS" = (
-/obj/machinery/telecomms/server/presets/common,
-/obj/machinery/light{
-	dir = 1
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "dark";
-	name = "Mainframe Floor";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
-/area/tcomms/chamber)
+/turf/simulated/wall/r_wall,
+/area/turret_protected/ai)
 "bBT" = (
 /obj/item/clothing/under/shorts/green,
 /turf/simulated/floor/beach/sand,
@@ -43277,33 +43263,43 @@
 /turf/simulated/floor/plating,
 /area/turret_protected/tcomms_control_room)
 "bEm" = (
+/obj/machinery/computer/borgupload,
+/obj/machinery/camera/flawless{
+	name = "AI Upload"
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_upload)
+"bEn" = (
+/obj/machinery/door/airlock/glass_command{
+	name = "Control Room";
+	req_access_txt = "61"
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor,
 /area/turret_protected/tcomms_control_room)
-"bEn" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+"bEo" = (
+/obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/dark,
+/obj/machinery/recharge_station,
+/obj/effect/landmark/start{
+	name = "Cyborg"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_upload)
-"bEo" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8;
-	on = 1
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/turret_protected/tcomms_control_room)
 "bEp" = (
 /obj/structure/sign/science,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -43326,7 +43322,7 @@
 	},
 /area/maintenance/port)
 "bEs" = (
-/obj/effect/decal/cleanable/scattered_sand,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
 	icon_state = "asteroidfloor"
 	},
@@ -43356,38 +43352,31 @@
 	},
 /area/maintenance/port)
 "bEx" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 9
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/bluegrid{
-	name = "Mainframe Base";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
-/area/tcomms/chamber)
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
 "bEz" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+/obj/structure/table,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/folder/blue,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/turf/simulated/floor/bluegrid{
-	name = "Mainframe Base";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
-/area/tcomms/chamber)
-"bEA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/simulated/floor{
+/obj/item/weapon/pen/blue,
+/obj/machinery/alarm{
 	dir = 4;
-	icon_state = "yellowcornersiding";
-	tag = "icon-yellowcornersiding"
+	pixel_x = -22
 	},
-/area/hallway/primary/port)
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "dark brown stripe";
+	tag = "icon-dark brown stripe (SOUTHWEST)"
+	},
+/area/turret_protected/tcomms_control_room)
 "bEB" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -43922,18 +43911,45 @@
 /turf/simulated/floor,
 /area/hallway/primary/starboard)
 "bFB" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "AI Upload";
-	req_access_txt = "16"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/dark,
-/area/turret_protected/ai_upload)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/door/window/brigdoor{
+	base_state = "left";
+	dir = 1;
+	req_access = null;
+	req_access_txt = "61";
+	req_one_access_txt = ""
+	},
+/obj/machinery/turretid{
+	ailock = 1;
+	control_area = /area/turret_protected/tcomms_control_room;
+	desc = "A firewall prevents AIs from interacting with this device.";
+	name = "Telecomms Control Room turret control";
+	pixel_x = 25;
+	pixel_y = -28;
+	req_access = null;
+	req_access_txt = "61"
+	},
+/obj/effect/decal/warning_stripes{
+	dir = 1;
+	icon_state = "warning";
+	tag = "icon-warning (NORTH)"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/turret_protected/tcomms_control_room)
 "bFC" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	default_scrubbed_gases = list("plasma");
@@ -44411,99 +44427,60 @@
 /turf/space,
 /area)
 "bGB" = (
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/turret_protected/tcomms_control_room)
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_upload)
 "bGC" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4;
+	on = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/simulated/floor/plating,
-/area/turret_protected/tcomms_control_room)
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_upload)
 "bGD" = (
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/area/turret_protected/tcomms_control_room)
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
 "bGE" = (
 /obj/structure/closet/crate,
 /obj/abstract/map/spawner/maint,
-/obj/effect/decal/cleanable/scattered_sand,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
 	icon_state = "asteroidfloor"
 	},
 /area/maintenance/port)
 "bGF" = (
 /obj/machinery/atmospherics/binary/valve,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/port)
 "bGI" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/air_sensor{
-	id_tag = "tcomms_sensor";
-	metrics_monitored = list("pressure", "temperature", "oxygen", "plasma", "nitrogen", "carbon_dioxide")
-	},
-/turf/simulated/floor/bluegrid{
-	name = "Mainframe Base";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
-/area/tcomms/chamber)
+/turf/simulated/wall,
+/area/turret_protected/ai)
 "bGJ" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/obj/structure/sign/nosmoking_2{
-	pixel_x = 32
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/bluegrid{
-	name = "Mainframe Base";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
-/area/tcomms/chamber)
+/turf/simulated/wall/r_wall,
+/area/turret_protected/ai)
 "bGO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -45582,107 +45559,79 @@
 /turf/simulated/wall/r_wall,
 /area/engine/storage)
 "bIK" = (
-/obj/item/device/radio/intercom{
-	dir = 8;
-	freerange = 1;
-	name = "Station Intercom (Telecoms)";
-	pixel_y = -28
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -24
 	},
-/obj/machinery/light,
-/obj/structure/closet/malf/suits,
-/obj/item/toy/gasha/AI,
-/turf/simulated/floor{
-	icon_state = "dark brown stripe";
-	tag = "icon-dark brown stripe"
+/obj/item/weapon/planning_frame,
+/turf/simulated/floor/bluegrid{
+	icon_state = "bcircuitoff"
 	},
-/area/turret_protected/tcomms_control_room)
+/area/turret_protected/ai_upload)
 "bIL" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/item/device/radio/intercom/aiprivate{
+	broadcasting = 1;
+	name = "Private AI Channel";
+	pixel_x = 28;
+	pixel_y = -28
 	},
-/obj/machinery/door/window/brigdoor{
-	base_state = "left";
-	dir = 1;
-	req_access = null;
-	req_access_txt = "61";
-	req_one_access_txt = ""
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_upload)
+"bIM" = (
+/obj/machinery/light/small,
+/obj/machinery/flasher{
+	id_tag = "PCell 1";
+	pixel_y = -28
+	},
+/turf/simulated/floor/bluegrid{
+	icon_state = "bcircuitoff"
+	},
+/area/turret_protected/ai_upload)
+"bIN" = (
+/obj/machinery/ai_slipper,
+/obj/machinery/door_control{
+	id_tag = "AIcore";
+	name = "AI Core Lockdown";
+	pixel_x = -23;
+	pixel_y = 23;
+	range = 5;
+	req_access_txt = "29"
 	},
 /obj/machinery/turretid{
-	ailock = 1;
-	control_area = /area/turret_protected/tcomms_control_room;
-	desc = "A firewall prevents AIs from interacting with this device.";
-	name = "Telecomms Control Room turret control";
-	pixel_x = 25;
-	pixel_y = -28;
-	req_access = null;
-	req_access_txt = "61"
+	name = "AI Chamber turret control";
+	pixel_x = 24;
+	pixel_y = 24
 	},
-/obj/effect/decal/warning_stripes{
-	dir = 1;
-	icon_state = "warning";
-	tag = "icon-warning (NORTH)"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/area/turret_protected/tcomms_control_room)
-"bIM" = (
-/obj/machinery/camera{
-	dir = 1;
-	name = "Telecomms Monitoring"
+/obj/machinery/door/window{
+	dir = 2;
+	name = "AI Core Door";
+	req_access_txt = "16"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 2;
-	tag = ""
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	tag = ""
-	},
-/obj/effect/decal/warning_stripes{
-	dir = 5;
-	icon_state = "warning";
-	tag = "icon-warning (NORTHEAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/turret_protected/tcomms_control_room)
-"bIN" = (
-/obj/machinery/requests_console{
-	department = "Telecomms";
-	pixel_y = -32
-	},
-/obj/structure/closet/malf/suits,
-/obj/item/clothing/accessory/pinksquare,
-/turf/simulated/floor{
-	icon_state = "dark brown stripe";
-	tag = "icon-dark brown stripe"
-	},
-/area/turret_protected/tcomms_control_room)
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
 "bIO" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/turret_protected/tcomms_control_room)
+/obj/structure/sign/securearea,
+/turf/simulated/wall/r_wall,
+/area/turret_protected/ai_upload)
 "bIP" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -45695,16 +45644,9 @@
 	},
 /area/turret_protected/tcomms_control_room)
 "bIQ" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "dark brown stripe";
-	tag = "icon-dark brown stripe"
-	},
-/area/turret_protected/tcomms_control_room)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_upload)
 "bIS" = (
 /turf/simulated/floor{
 	icon_state = "asteroidfloor"
@@ -45745,82 +45687,122 @@
 	},
 /area/maintenance/port)
 "bIV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/port)
 "bIY" = (
-/obj/machinery/telecomms/bus/preset_one,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "dark";
-	name = "Mainframe Floor";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/area/tcomms/chamber)
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
 "bIZ" = (
-/obj/machinery/telecomms/bus/preset_four,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 5
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/landmark{
+	name = "tripai"
+	},
+/obj/item/device/radio/intercom{
+	freerange = 1;
+	listening = 0;
+	name = "Custom Channel";
+	pixel_y = 20
+	},
+/obj/item/device/radio/intercom/aiprivate{
+	freerange = 1;
+	name = "Private Channel";
+	pixel_y = -26
+	},
+/obj/item/device/radio/intercom{
+	freerange = 1;
+	name = "Common Channel";
+	pixel_x = -25;
+	pixel_y = -4
 	},
 /turf/simulated/floor/bluegrid{
-	icon_state = "dark";
-	name = "Mainframe Floor";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
+	icon_state = "bcircuitoff"
 	},
-/area/tcomms/chamber)
+/area/turret_protected/ai)
 "bJa" = (
-/obj/machinery/telecomms/processor/preset_four,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/he_manifold{
-	dir = 1
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/window{
+	name = "AI Core Door";
+	req_access_txt = "16"
 	},
 /turf/simulated/floor/bluegrid{
-	icon_state = "dark";
-	name = "Mainframe Floor";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
+	icon_state = "bcircuitoff"
 	},
-/area/tcomms/chamber)
+/area/turret_protected/ai)
 "bJc" = (
-/obj/machinery/telecomms/server/presets/science,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/landmark{
+	name = "tripai"
+	},
+/obj/item/device/radio/intercom{
+	freerange = 1;
+	listening = 0;
+	name = "Custom Channel";
+	pixel_y = 19
+	},
+/obj/item/device/radio/intercom/aiprivate{
+	freerange = 1;
+	name = "Private Channel";
+	pixel_y = -26
+	},
+/obj/item/device/radio/intercom{
+	freerange = 1;
+	name = "Common Channel";
+	pixel_x = 27;
+	pixel_y = -3
 	},
 /turf/simulated/floor/bluegrid{
-	icon_state = "dark";
-	name = "Mainframe Floor";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
+	icon_state = "bcircuitoff"
 	},
-/area/tcomms/chamber)
+/area/turret_protected/ai)
 "bJe" = (
-/obj/machinery/telecomms/server/presets/supply,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
+/obj/machinery/door/window{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "AI Core Door";
+	req_access_txt = "16"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/bluegrid{
-	icon_state = "dark";
-	name = "Mainframe Floor";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
+	icon_state = "bcircuitoff"
 	},
-/area/tcomms/chamber)
+/area/turret_protected/ai)
 "bJg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -46919,43 +46901,37 @@
 /turf/simulated/floor/plating,
 /area/engine/storage)
 "bLb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/airlock/engineering{
-	name = "Telecommunications";
-	req_access_txt = "61"
+/obj/machinery/door/airlock/highsecurity{
+	name = "AI Upload Access";
+	req_access_txt = "16"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor/border_only{
 	name = "Firelock South"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'SERVER ROOM'.";
-	name = "SERVER ROOM";
-	pixel_x = -32
+/turf/simulated/floor/bluegrid{
+	icon_state = "bcircuitoff"
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/turret_protected/tcomms_control_room)
+/area/turret_protected/ai_upload)
 "bLc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/wall/r_wall,
 /area/turret_protected/tcomms_control_room)
 "bLd" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/telecomms/broadcaster/preset_right,
+/turf/simulated/floor/bluegrid{
+	icon_state = "dark";
+	name = "Mainframe Floor";
+	nitrogen = 100;
+	oxygen = 0;
+	temperature = 80
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/simulated/floor/plating,
-/area/maintenance/port)
+/area/tcomms/chamber)
 "bLe" = (
 /obj/item/device/flashlight/lantern,
 /obj/item/device/flashlight/lantern,
@@ -46969,30 +46945,22 @@
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bLg" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
 	},
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 6
+/turf/simulated/floor/bluegrid{
+	icon_state = "bcircuitoff"
 	},
-/turf/simulated/floor/plating,
-/area/tcomms/chamber)
+/area/turret_protected/ai)
 "bLi" = (
-/obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 4
 	},
 /obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
+/turf/simulated/floor/bluegrid{
+	icon_state = "bcircuitoff"
 	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction/hidden{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/tcomms/chamber)
+/area/turret_protected/ai)
 "bLp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending,
@@ -48363,63 +48331,48 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellowsiding";
+	tag = "icon-yellowsiding"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/dark,
-/area/turret_protected/ai_upload_foyer)
+/area/hallway/primary/port)
 "bNz" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/item/device/radio/intercom{
+	pixel_y = 25
 	},
-/turf/simulated/floor/dark,
-/area/turret_protected/ai_upload_foyer)
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "yellowsiding";
+	tag = "icon-yellowsiding"
+	},
+/area/hallway/primary/port)
 "bNA" = (
-/obj/machinery/computer/aiupload/longrange,
+/obj/machinery/atmospherics/unary/vent_pump{
+	on = 1
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/sign/kiddieplaque{
-	pixel_x = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/simulated/floor/bluegrid{
 	icon_state = "bcircuitoff"
 	},
-/area/turret_protected/ai_upload)
+/area/turret_protected/ai)
 "bNB" = (
-/obj/machinery/power/apc{
-	cell_type = 5000;
-	dir = 8;
-	name = "_West APC";
-	pixel_x = -25
+/obj/machinery/status_display{
+	pixel_y = 32
 	},
-/obj/machinery/light/small,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/structure/closet/emcloset,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "yellowsiding";
+	tag = "icon-yellowsiding"
 	},
-/obj/machinery/camera/flawless{
-	dir = 1;
-	name = "AI Upload Access";
-	network = list("SS13","RD")
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/dark,
-/area/turret_protected/ai_upload_foyer)
+/area/hallway/primary/port)
 "bNC" = (
 /obj/structure/table,
 /obj/item/weapon/stock_parts/subspace/transmitter,
@@ -48441,42 +48394,32 @@
 	},
 /area/tcomms/storage)
 "bND" = (
-/obj/structure/table,
-/obj/item/weapon/stock_parts/subspace/analyzer,
-/obj/item/weapon/stock_parts/subspace/analyzer,
-/obj/item/weapon/stock_parts/subspace/analyzer,
-/obj/machinery/light_switch{
-	pixel_y = 26
+/obj/machinery/telecomms/server/presets/service,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 6
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/turf/simulated/floor/bluegrid{
+	icon_state = "dark";
+	name = "Mainframe Floor";
+	nitrogen = 100;
+	oxygen = 0;
+	temperature = 80
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/tcomms/storage)
+/area/tcomms/chamber)
 "bNE" = (
 /turf/simulated/wall/r_wall,
 /area/tcomms/storage)
 "bNF" = (
-/obj/structure/rack,
-/obj/item/weapon/circuitboard/telecomms/processor,
-/obj/item/weapon/circuitboard/telecomms/processor,
-/obj/item/weapon/circuitboard/telecomms/receiver,
-/obj/item/weapon/circuitboard/telecomms/server,
-/obj/item/weapon/circuitboard/telecomms/server,
-/obj/item/weapon/circuitboard/telecomms/bus,
-/obj/item/weapon/circuitboard/telecomms/bus,
-/obj/item/weapon/circuitboard/telecomms/broadcaster,
-/obj/machinery/camera{
-	dir = 4;
-	name = "Telecomms Storage"
+/obj/machinery/door/airlock/maintenance{
+	name = "Grotto Access"
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/tcomms/storage)
+/turf/simulated/floor/plating,
+/area/maintenance/port)
 "bNH" = (
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -48494,36 +48437,22 @@
 	},
 /area/turret_protected/ai)
 "bNL" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/turret_protected/tcomms_control_room)
+/obj/machinery/light,
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
 "bNM" = (
-/obj/structure/table,
-/obj/item/device/multitool,
-/obj/item/device/radio/off,
-/obj/abstract/map/spawner/pick_spawner/yellowgloves/tcomms_storage,
-/turf/simulated/floor{
-	dir = 9;
-	icon_state = "dark brown stripe";
-	tag = "icon-dark brown stripe (NORTHWEST)"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/camera/flawless{
+	dir = 1;
+	name = "AI Core"
 	},
-/area/turret_protected/tcomms_control_room)
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
 "bNN" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/turret_protected/tcomms_control_room)
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
 "bNO" = (
 /obj/machinery/turret{
 	dir = 8
@@ -48547,7 +48476,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bNQ" = (
-/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/closet/crate{
+	icon_state = "crateopen";
+	opened = 1
+	},
+/obj/item/tool/wirecutters,
+/obj/item/tool/weldingtool,
+/obj/machinery/light/small{
+	dir = 8;
+	flickering = 1
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bNS" = (
@@ -49636,26 +49574,22 @@
 /turf/simulated/floor,
 /area/engine/storage)
 "bPR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only{
-	name = "Firelock South"
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/highsecurity{
-	name = "AI Upload Access";
-	req_access_txt = "16"
-	},
-/obj/effect/decal/warning_stripes{
-	dir = 4;
-	icon_state = "unloading"
-	},
-/turf/simulated/floor/dark,
-/area/turret_protected/ai_upload_foyer)
+/turf/simulated/floor,
+/area/hallway/primary/port)
 "bPS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -49676,32 +49610,24 @@
 /turf/simulated/wall/r_wall,
 /area/hallway/primary/port)
 "bPU" = (
+/obj/structure/sign/electricshock,
 /turf/simulated/wall/r_wall,
-/area/turret_protected/ai_upload_foyer)
+/area/hallway/primary/port)
 "bPV" = (
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/tcomms/storage)
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
 "bPW" = (
-/obj/structure/table,
-/obj/item/weapon/stock_parts/subspace/treatment,
-/obj/item/weapon/stock_parts/subspace/treatment,
-/obj/item/weapon/stock_parts/subspace/treatment,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	one_way = 1
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/tcomms/storage)
+/turf/simulated/floor/plating,
+/area/maintenance/port)
 "bPX" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Telecomms Storage";
@@ -49724,27 +49650,27 @@
 	},
 /area/tcomms/storage)
 "bPY" = (
-/obj/effect/landmark{
-	name = "xeno_spawn";
-	pixel_x = -1
+/obj/machinery/door/airlock/atmos{
+	name = "Telecomms Auxiliary Storage";
+	req_access_txt = "24"
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8;
-	on = 1
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	name = "Firelock East"
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/tcomms/storage)
-"bQa" = (
-/obj/machinery/atmospherics/pipe/manifold/insulated/visible/blue,
 /turf/simulated/floor/plating,
-/area/tcomms/storage2)
+/area/turret_protected/tcomms_control_room)
+"bQa" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/port)
 "bQc" = (
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai_upload)
@@ -50889,14 +50815,11 @@
 /turf/simulated/floor/plating,
 /area/engine/storage)
 "bSc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor{
+	icon_state = "dark"
 	},
-/turf/simulated/floor,
-/area/hallway/primary/port)
+/area/turret_protected/tcomms_control_room)
 "bSd" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -50925,51 +50848,28 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/obj/structure/sign/securearea{
-	pixel_y = 32
-	},
-/obj/machinery/newscaster{
-	dir = 4;
-	pixel_x = -28;
-	pixel_y = 1
-	},
 /turf/simulated/floor{
-	dir = 9;
+	dir = 8;
 	icon_state = "yellowsiding";
 	tag = "icon-yellowsiding"
 	},
 /area/hallway/primary/port)
 "bSg" = (
-/obj/structure/table,
-/obj/item/weapon/stock_parts/micro_laser,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/capacitor,
-/obj/item/weapon/stock_parts/micro_laser/high,
-/obj/item/weapon/stock_parts/micro_laser/high,
-/obj/item/weapon/stock_parts/micro_laser/high,
-/obj/item/weapon/stock_parts/micro_laser/high,
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+/obj/machinery/atmospherics/unary/vent_pump{
+	on = 1
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/tcomms/storage)
+/turf/simulated/floor,
+/area/storage/tools)
 "bSh" = (
-/obj/structure/table,
-/obj/item/weapon/stock_parts/subspace/filter,
-/obj/item/weapon/stock_parts/subspace/filter,
-/obj/item/weapon/stock_parts/subspace/filter,
-/obj/item/weapon/stock_parts/subspace/filter,
-/obj/item/weapon/stock_parts/subspace/filter,
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/tcomms/storage)
+/obj/structure/closet/toolcloset,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor,
+/area/storage/tools)
 "bSi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -50992,70 +50892,56 @@
 	},
 /area/tcomms/storage)
 "bSl" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/tcomms/storage2)
-"bSm" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4;
-	on = 1
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/turret_protected/tcomms_control_room)
-"bSo" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/turret_protected/tcomms_control_room)
-"bSr" = (
-/obj/machinery/door/airlock/glass_command{
-	name = "Control Room";
-	req_access_txt = "61"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/turret_protected/tcomms_control_room)
-"bSt" = (
-/obj/effect/decal/cleanable/scattered_sand,
+/obj/structure/closet/emcloset/vox,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
+"bSm" = (
+/obj/item/device/radio/intercom/aiprivate{
+	broadcasting = 1;
+	name = "Private AI Channel";
+	pixel_y = 28
+	},
+/turf/simulated/floor/bluegrid{
+	icon_state = "bcircuitoff"
+	},
+/area/turret_protected/ai_upload)
+"bSo" = (
+/obj/structure/table,
+/obj/item/weapon/aiModule/freeform,
+/obj/item/weapon/aiModule/core/paladin,
+/obj/item/weapon/aiModule/core/corp,
+/obj/item/weapon/aiModule/core/asimov,
+/obj/item/weapon/aiModule/reset,
+/obj/item/weapon/aiModule/core/nanotrasen,
+/obj/item/weapon/aiModule/core/robocop,
+/obj/machinery/door/window{
+	name = "High-Risk Modules";
+	req_access_txt = "20"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_upload)
+"bSr" = (
+/obj/machinery/turret,
+/turf/simulated/floor/bluegrid{
+	icon_state = "bcircuitoff"
+	},
+/area/turret_protected/ai_upload)
 "bSu" = (
-/obj/machinery/light/small{
-	dir = 8;
-	flickering = 1
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -52170,16 +52056,21 @@
 /turf/simulated/floor,
 /area/engine/storage)
 "bUq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/status_display{
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/sign/nosmoking_2{
 	pixel_x = 32
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "yellowsiding";
-	tag = "icon-yellowsiding"
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/machinery/telecomms/processor/preset_four,
+/turf/simulated/floor/bluegrid{
+	name = "Mainframe Base";
+	nitrogen = 100;
+	oxygen = 0;
+	temperature = 80
 	},
-/area/hallway/primary/port)
+/area/tcomms/chamber)
 "bUs" = (
 /obj/structure/flora/pottedplant/random,
 /turf/simulated/floor{
@@ -52213,70 +52104,69 @@
 	},
 /area/hallway/primary/port)
 "bUw" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	icon_state = "intact_on";
-	on = 1
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/tcomms/storage2)
-"bUx" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 9
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/turret_protected/tcomms_control_room)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/port)
+"bUx" = (
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_upload)
 "bUy" = (
-/obj/structure/rack{
+/obj/machinery/flasher{
+	id_tag = "PCell 1";
+	pixel_x = 6;
+	pixel_y = 28
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
+"bUz" = (
+/obj/structure/table,
+/obj/item/weapon/aiModule/standard/protectStation,
+/obj/item/weapon/aiModule/standard/quarantine,
+/obj/item/weapon/aiModule/freeform/core,
+/obj/item/weapon/aiModule/targetted/oneHuman,
+/obj/item/weapon/aiModule/purge,
+/obj/machinery/door/window{
+	name = "High-Risk Modules";
+	req_access_txt = "20"
+	},
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/item/weapon/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/sign/kiddieplaque{
+	pixel_x = -32
 	},
-/obj/abstract/map/spawner/pick_spawner/yellowgloves/tcomms_storage,
-/turf/simulated/floor{
-	icon_state = "dark brown stripe";
-	tag = "icon-dark brown stripe"
+/turf/simulated/floor/bluegrid{
+	icon_state = "bcircuitoff"
 	},
-/area/turret_protected/tcomms_control_room)
-"bUz" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/turret_protected/tcomms_control_room)
-"bUA" = (
-/obj/machinery/hologram/holopad,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/dark,
 /area/turret_protected/ai_upload)
+"bUA" = (
+/obj/machinery/telecomms/processor/preset_three,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/turf/simulated/floor/bluegrid{
+	icon_state = "dark";
+	name = "Mainframe Floor";
+	nitrogen = 100;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/tcomms/chamber)
 "bUE" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -53532,7 +53422,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "yellowsiding";
@@ -53564,25 +53453,11 @@
 	},
 /area/hallway/primary/port)
 "bWO" = (
-/obj/structure/table,
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/folder/blue,
-/obj/item/weapon/pen/blue,
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
+/obj/machinery/turret{
+	dir = 4
 	},
-/obj/abstract/map/spawner/pick_spawner/yellowgloves/tcomms_storage,
-/obj/machinery/light_switch{
-	pixel_x = 6;
-	pixel_y = -26
-	},
-/turf/simulated/floor{
-	dir = 10;
-	icon_state = "dark brown stripe";
-	tag = "icon-dark brown stripe (SOUTHWEST)"
-	},
-/area/turret_protected/tcomms_control_room)
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_upload)
 "bWR" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/bluegrid{
@@ -54748,6 +54623,9 @@
 "bYR" = (
 /obj/structure/table,
 /obj/item/clothing/head/cakehat,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "yellowsiding";
@@ -54755,12 +54633,22 @@
 	},
 /area/hallway/primary/port)
 "bYT" = (
-/obj/structure/closet/toolcloset,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+/obj/effect/landmark{
+	name = "xeno_spawn";
+	pixel_x = -1
 	},
-/turf/simulated/floor,
-/area/storage/tools)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/tcomms/storage)
 "bYV" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -54800,18 +54688,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bZa" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/dark,
+/turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_upload)
 "bZc" = (
 /obj/structure/closet/emcloset,
@@ -56048,22 +55931,18 @@
 	},
 /area/hallway/primary/port)
 "cbl" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/telecomms/server/presets/command,
+/turf/simulated/floor/bluegrid{
+	icon_state = "dark";
+	name = "Mainframe Floor";
+	nitrogen = 100;
+	oxygen = 0;
+	temperature = 80
 	},
-/turf/simulated/floor/plating,
-/area/storage/tools)
+/area/tcomms/chamber)
 "cbm" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -56079,7 +55958,6 @@
 	},
 /area/hallway/primary/port)
 "cbn" = (
-/obj/structure/closet/emcloset,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "yellowsiding";
@@ -56126,14 +56004,15 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/structure/window/full/reinforced,
 /obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor/plating,
 /area/hallway/primary/port)
 "cbt" = (
 /obj/structure/flora/pottedplant/random{
 	icon_state = "plant-16"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "yellowsiding";
@@ -56151,6 +56030,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/structure/window/full/reinforced,
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/primary/port)
@@ -56167,7 +56047,17 @@
 	dir = 4;
 	icon_state = "unloading"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/turretid{
+	control_area = "\improper AI Upload Chamber";
+	name = "AI Upload turret control";
+	pixel_x = -24;
+	pixel_y = 24
+	},
+/obj/machinery/door/window{
+	dir = 2;
+	name = "AI Core Door";
+	req_access_txt = "16"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -57498,13 +57388,13 @@
 /area/engineering/break_room)
 "cdI" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/disposalpipe/sortjunction/Telecomms/mirrored{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
@@ -57557,8 +57447,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -57721,7 +57614,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/hallway/primary/port)
 "ceb" = (
@@ -58969,7 +58861,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/hallway/primary/port)
 "cgu" = (
@@ -59428,18 +59319,15 @@
 /turf/simulated/floor/carpet,
 /area/engineering/ce)
 "cho" = (
-/obj/machinery/telecomms/processor/preset_two,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/computer/aiupload/longrange,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "dark";
-	name = "Mainframe Floor";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
-/area/tcomms/chamber)
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_upload)
 "chp" = (
 /obj/structure/table/reinforced,
 /obj/item/device/assembly/infra{
@@ -59462,11 +59350,19 @@
 	},
 /area/science/mixing)
 "chq" = (
-/obj/machinery/camera/motion{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/turf/space,
-/area)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellowsiding";
+	tag = "icon-yellowsiding"
+	},
+/area/hallway/primary/port)
 "chr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -60175,42 +60071,19 @@
 	tag = "icon-yellowsiding"
 	},
 /area/hallway/primary/port)
-"cir" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
-/turf/simulated/floor{
-	icon_state = "yellowsiding";
-	tag = "icon-yellowsiding"
-	},
-/area/hallway/primary/port)
 "cis" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "yellowsiding";
@@ -60263,10 +60136,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/simulated/floor{
 	icon_state = "yellowsiding";
 	tag = "icon-yellowsiding"
@@ -60463,9 +60338,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/simulated/floor{
 	icon_state = "yellowsiding";
 	tag = "icon-yellowsiding"
@@ -75262,19 +75135,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "cIV" = (
-/obj/structure/window/reinforced{
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/tank/carbon_dioxide/coldroom{
 	dir = 4
 	},
-/obj/structure/window/reinforced,
-/obj/machinery/flasher{
-	id_tag = "AI";
-	pixel_x = -23;
-	pixel_y = -4
-	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "bcircuitoff"
-	},
-/area/turret_protected/ai)
+/turf/simulated/floor/plating,
+/area/tcomms/storage2)
 "cIW" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -77708,18 +77576,14 @@
 	},
 /area/crew_quarters/sleep)
 "cNG" = (
-/obj/machinery/telecomms/server/presets/command,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
+/obj/machinery/turret,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "dark";
-	name = "Mainframe Floor";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
-/area/tcomms/chamber)
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
 "cNH" = (
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
@@ -79109,6 +78973,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -29
@@ -79117,9 +78984,6 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/sortjunction/Telecomms{
-	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "yellowsiding";
@@ -79887,10 +79751,6 @@
 	tag = "icon-yellowsiding"
 	},
 /area/hallway/primary/central)
-"cSm" = (
-/obj/structure/sign/securearea,
-/turf/simulated/wall/r_wall,
-/area/turret_protected/tcomms_control_room)
 "cSn" = (
 /turf/simulated/floor/asteroid/air,
 /area/crew_quarters/sleep)
@@ -80678,9 +80538,9 @@
 /turf/simulated/floor/asteroid/air,
 /area/crew_quarters/sleep)
 "cTP" = (
-/obj/machinery/ai_slipper,
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/simulated/floor/bluegrid{
 	icon_state = "bcircuitoff"
@@ -108957,13 +108817,15 @@
 	},
 /area/prison/cell_block/A)
 "dSS" = (
-/obj/machinery/turret{
-	dir = 4
+/obj/machinery/door/poddoor{
+	id_tag = "AIcore";
+	name = "AI blast door"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor/bluegrid{
 	icon_state = "bcircuitoff"
 	},
-/area/turret_protected/ai_upload)
+/area/turret_protected/ai)
 "dSU" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4
@@ -115701,15 +115563,20 @@
 /turf/simulated/floor/shuttle,
 /area/shuttle/supply)
 "efz" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "bcircuitoff"
+/obj/machinery/requests_console{
+	department = "Telecomms";
+	pixel_y = -32
 	},
-/area/turret_protected/ai)
+/obj/structure/closet/malf/suits,
+/obj/item/clothing/accessory/pinksquare,
+/turf/simulated/floor{
+	icon_state = "dark brown stripe";
+	tag = "icon-dark brown stripe"
+	},
+/area/turret_protected/tcomms_control_room)
 "efA" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4
@@ -118583,18 +118450,9 @@
 	},
 /area/centcom/ert)
 "enn" = (
-/obj/machinery/blackbox_recorder,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10
-	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "dark";
-	name = "Mainframe Floor";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
-/area/tcomms/chamber)
+/obj/machinery/ai_status_display,
+/turf/simulated/wall/r_wall,
+/area/turret_protected/ai)
 "eno" = (
 /obj/machinery/suit_dispenser/ert,
 /turf/unsimulated/floor{
@@ -121379,13 +121237,13 @@
 /turf/simulated/floor/bluegrid,
 /area/shuttle/ert/centcom)
 "etk" = (
-/obj/machinery/requests_console{
-	department = "AI";
-	departmentType = 5;
-	pixel_y = 29
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/dark,
-/area/turret_protected/ai)
+/turf/simulated/floor/plating,
+/area/maintenance/port)
 "etl" = (
 /obj/machinery/light{
 	dir = 1
@@ -122089,32 +121947,16 @@
 	icon_state = "green"
 	},
 /area/centcom/control)
-"euT" = (
-/obj/machinery/computer/message_monitor,
-/obj/machinery/atmospherics/pipe/simple/insulated/visible/blue,
-/obj/machinery/power/apc{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 1
-	},
-/turf/simulated/floor{
-	dir = 9;
-	icon_state = "dark brown stripe";
-	tag = "icon-dark brown stripe (NORTHWEST)"
-	},
-/area/turret_protected/tcomms_control_room)
 "euU" = (
-/obj/structure/table,
-/obj/abstract/map/spawner/pick_spawner/yellowgloves/tcomms_storage,
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/telecomms/server/presets/common,
+/turf/simulated/floor/bluegrid{
+	icon_state = "dark";
+	name = "Mainframe Floor";
+	nitrogen = 100;
+	oxygen = 0;
+	temperature = 80
 	},
-/turf/simulated/floor/plating,
-/area/tcomms/storage2)
+/area/tcomms/chamber)
 "euV" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -122365,16 +122207,19 @@
 /turf/simulated/floor/shuttle,
 /area/shuttle/escape/centcom)
 "evA" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+/obj/structure/table,
+/obj/item/weapon/stock_parts/subspace/filter,
+/obj/item/weapon/stock_parts/subspace/filter,
+/obj/item/weapon/stock_parts/subspace/filter,
+/obj/item/weapon/stock_parts/subspace/filter,
+/obj/item/weapon/stock_parts/subspace/filter,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
-/obj/item/tool/wirecutters,
-/obj/item/tool/weldingtool,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
+/turf/simulated/floor{
+	icon_state = "dark"
 	},
-/area/maintenance/port)
+/area/tcomms/storage)
 "evB" = (
 /obj/structure/closet/emcloset/vox,
 /turf/simulated/floor/shuttle{
@@ -125863,12 +125708,16 @@
 /turf/unsimulated/beach/water,
 /area/centcom/holding)
 "eDT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light/small,
-/turf/simulated/floor/bluegrid{
-	icon_state = "bcircuitoff"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/area/turret_protected/ai_upload)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellowcornersiding";
+	tag = "icon-yellowcornersiding"
+	},
+/area/hallway/primary/port)
 "eDU" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -130213,261 +130062,76 @@
 "fvS" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/simulated/floor/plating,
 /area/turret_protected/tcomms_control_room)
 "fvT" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/bluegrid{
-	icon_state = "bcircuitoff"
-	},
-/area/turret_protected/ai)
-"fvU" = (
-/obj/machinery/telecomms/bus/preset_two,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
-	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "dark";
-	name = "Mainframe Floor";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
-/area/tcomms/chamber)
-"fwa" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/scattered_sand,
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/beach/sand,
 /area/maintenance/port)
 "fwd" = (
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/item/device/radio/intercom{
-	freerange = 1;
-	listening = 0;
-	name = "Custom Channel";
-	pixel_x = -6;
-	pixel_y = 20
-	},
-/obj/item/device/radio/intercom/aiprivate{
-	freerange = 1;
-	name = "Private Channel";
-	pixel_x = -6;
-	pixel_y = -26
-	},
-/obj/item/device/radio/intercom{
-	freerange = 1;
-	name = "Common Channel";
-	pixel_x = -25;
-	pixel_y = -4
-	},
-/obj/item/device/radio/intercom{
-	freerange = 1;
-	listening = 0;
-	name = "Custom Channel";
-	pixel_x = -6;
-	pixel_y = 20
-	},
-/obj/machinery/media/receiver/boombox/wallmount{
-	pixel_y = 40
-	},
-/obj/machinery/turretid{
-	name = "AI Chamber turret control";
-	pixel_x = 8;
-	pixel_y = -22
-	},
-/obj/effect/landmark/start{
-	name = "AI"
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "bot"
-	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "bcircuitoff"
-	},
-/area/turret_protected/ai)
-"fwt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/turf/space,
-/area/mine/explored)
-"fwW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/dark,
-/area/turret_protected/ai_upload)
-"fxf" = (
-/obj/machinery/computer/telecomms/traffic{
-	network = "tcommsat"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "dark brown stripe";
-	tag = "icon-dark brown stripe (NORTH)"
-	},
-/area/turret_protected/tcomms_control_room)
-"fxI" = (
-/obj/structure/sign/securearea{
-	pixel_y = 32
-	},
-/turf/simulated/wall/r_wall,
-/area/turret_protected/ai)
-"fxZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/sign/securearea{
-	pixel_y = 32
-	},
-/obj/machinery/firealarm{
-	dir = 4;
+/obj/machinery/media/receiver/boombox/wallmount/muzak{
+	on = 0;
 	pixel_x = 28
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "yellowsiding";
-	tag = "icon-yellowsiding"
+	icon_state = "dark"
 	},
-/area/hallway/primary/port)
-"fyf" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/dark,
-/area/turret_protected/ai)
-"fyk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/ai_status_display{
-	pixel_y = 32
-	},
-/turf/simulated/floor/dark,
-/area/turret_protected/ai_upload_foyer)
-"fyr" = (
-/obj/machinery/atmospherics/pipe/simple/insulated/visible/blue{
-	dir = 4;
-	tag = "icon-intact (EAST)"
-	},
-/obj/machinery/computer/general_air_control/large_tank_control{
-	name = "Telecomms Room Monitoring";
-	sensors = list("tcomms_sensor"="Server Room")
-	},
-/turf/simulated/floor/plating,
-/area/tcomms/storage2)
-"fyu" = (
+/area/turret_protected/tcomms_control_room)
+"fwt" = (
 /obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/turret_protected/ai)
-"fyA" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/obj/structure/sign/nosmoking_2{
-	pixel_x = -32
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/bluegrid{
-	name = "Mainframe Base";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
-/area/tcomms/chamber)
-"fyK" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/simulated/floor/plating,
 /area/storage/tools)
-"fyL" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/scattered_sand,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/port)
-"fyO" = (
+"fwW" = (
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4;
-	on = 1
+/obj/structure/table,
+/obj/item/weapon/circuitboard/airlock,
+/obj/item/device/assembly/signaler{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/device/deskbell_assembly{
+	build_step = 1;
+	icon_state = "deskbell_1";
+	pixel_x = -2;
+	pixel_y = -2
 	},
 /turf/simulated/floor,
 /area/storage/tools)
-"fyT" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/dark,
-/area/turret_protected/ai)
-"fyZ" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+"fxf" = (
+/obj/machinery/turret{
+	dir = 8
 	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "bcircuitoff"
-	},
-/area/turret_protected/ai)
-"fza" = (
-/obj/machinery/telecomms/server/presets/service,
-/obj/machinery/light{
-	dir = 1
-	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_upload)
+"fxI" = (
+/obj/machinery/telecomms/bus/preset_one,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/simulated/floor/bluegrid{
 	icon_state = "dark";
 	name = "Mainframe Floor";
@@ -130476,34 +130140,206 @@
 	temperature = 80
 	},
 /area/tcomms/chamber)
-"fze" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/airlock/highsecurity{
-	name = "AI Core Access";
-	req_access_txt = "19"
+"fxZ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/structure/cable/yellow{
+/turf/simulated/floor/plating,
+/area/maintenance/port)
+"fyk" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor/border_only{
+	name = "Firelock South"
+	},
+/obj/machinery/door/airlock/glass{
+	name = "Auxiliary Tool Storage";
+	req_access_txt = "12"
+	},
+/turf/simulated/floor,
+/area/storage/tools)
+"fyr" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "_East APC";
+	pixel_x = 27;
+	pixel_y = 2
+	},
+/obj/structure/cable,
+/turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
-"fzt" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+"fyu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/sign/securearea,
+/turf/simulated/wall/r_wall,
+/area/turret_protected/ai_upload)
+"fyA" = (
+/obj/structure/rack{
+	dir = 8
+	},
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/dark,
-/area/turret_protected/ai_upload)
-"fzG" = (
+/turf/simulated/floor{
+	icon_state = "dark brown stripe";
+	tag = "icon-dark brown stripe"
+	},
+/area/turret_protected/tcomms_control_room)
+"fyK" = (
+/obj/structure/table,
+/obj/item/weapon/stock_parts/subspace/analyzer,
+/obj/item/weapon/stock_parts/subspace/analyzer,
+/obj/item/weapon/stock_parts/subspace/analyzer,
+/obj/machinery/light_switch{
+	pixel_y = 26
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/tcomms/storage)
+"fyL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/turret_protected/tcomms_control_room)
+"fyO" = (
+/obj/structure/rack,
+/obj/item/weapon/circuitboard/telecomms/processor,
+/obj/item/weapon/circuitboard/telecomms/processor,
+/obj/item/weapon/circuitboard/telecomms/receiver,
+/obj/item/weapon/circuitboard/telecomms/server,
+/obj/item/weapon/circuitboard/telecomms/server,
+/obj/item/weapon/circuitboard/telecomms/bus,
+/obj/item/weapon/circuitboard/telecomms/bus,
+/obj/item/weapon/circuitboard/telecomms/broadcaster,
+/obj/machinery/camera{
+	dir = 4;
+	name = "Telecomms Storage"
+	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	on = 1
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/tcomms/storage)
+"fyT" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "_North APC";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/recharge_station,
+/obj/effect/landmark/start{
+	name = "Cyborg"
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/turf/simulated/floor/bluegrid{
+	icon_state = "bcircuitoff"
+	},
+/area/turret_protected/ai_upload)
+"fyZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = 27
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowsiding";
+	tag = "icon-yellowsiding"
+	},
+/area/hallway/primary/port)
+"fza" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/tank/nitrogen/coldroom{
 	dir = 4
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/floor/plating,
+/area/tcomms/storage2)
+"fze" = (
+/obj/machinery/turret,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/bluegrid{
+	icon_state = "bcircuitoff"
+	},
 /area/turret_protected/ai_upload)
+"fzt" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/turret_protected/tcomms_control_room)
+"fzG" = (
+/obj/effect/landmark/start{
+	name = "AI"
+	},
+/obj/item/device/radio/intercom/aiprivate{
+	freerange = 1;
+	name = "Private Channel";
+	pixel_x = -26
+	},
+/obj/item/device/radio/intercom{
+	freerange = 1;
+	listening = 0;
+	name = "Custom Channel";
+	pixel_x = 27
+	},
+/obj/item/device/radio/intercom{
+	freerange = 1;
+	name = "Common Channel";
+	pixel_y = 27
+	},
+/obj/machinery/media/receiver/boombox/wallmount{
+	pixel_y = 40
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
 "fzH" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -130517,25 +130353,18 @@
 /area/medical/paramedics)
 "fzT" = (
 /obj/structure/table,
-/obj/item/weapon/circuitboard/airlock,
-/obj/item/device/assembly/signaler{
-	pixel_x = 3;
-	pixel_y = 5
+/obj/item/weapon/stock_parts/subspace/treatment,
+/obj/item/weapon/stock_parts/subspace/treatment,
+/obj/item/weapon/stock_parts/subspace/treatment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/obj/item/device/deskbell_assembly{
-	build_step = 1;
-	icon_state = "deskbell_1";
-	pixel_x = -2;
-	pixel_y = -2
+/turf/simulated/floor{
+	icon_state = "dark"
 	},
-/obj/item/tool/screwdriver{
-	pixel_y = 15
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/storage/tools)
+/area/tcomms/storage)
 "fzX" = (
 /obj/structure/particle_accelerator/particle_emitter/center,
 /turf/simulated/floor/plating{
@@ -130543,406 +130372,295 @@
 	},
 /area/engineering/aux_storage)
 "fzZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "yellowsiding";
-	tag = "icon-yellowsiding"
-	},
-/area/hallway/primary/port)
-"fAe" = (
-/obj/structure/fence{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/scattered_sand,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
-/area/maintenance/port)
-"fAq" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/turretid{
-	control_area = "\improper AI Upload Chamber";
-	name = "AI Upload turret control";
-	pixel_x = -23;
-	pixel_y = 26
+/turf/simulated/floor/bluegrid{
+	icon_state = "bcircuitoff"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/dark,
-/area/turret_protected/ai_upload_foyer)
-"fAy" = (
+/area/turret_protected/ai)
+"fAe" = (
 /obj/structure/grille,
-/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/turret_protected/ai)
-"fAC" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4;
-	on = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/turf/simulated/floor/dark,
-/area/turret_protected/ai)
-"fAD" = (
-/obj/structure/cable/yellow{
+/turf/simulated/floor/plating,
+/area/hallway/primary/port)
+"fAq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/airlock/engineering{
+	name = "Telecommunications";
+	req_access_txt = "61"
+	},
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "_East APC";
-	pixel_x = 27;
-	pixel_y = 2
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/machinery/camera/all{
-	dir = 8;
-	failure_chance = 0;
-	name = "AI Chamber"
-	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "bcircuitoff"
-	},
-/area/turret_protected/ai)
-"fAX" = (
-/obj/machinery/turret{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/device/radio/intercom/aiprivate{
-	broadcasting = 1;
-	frequency = 1447;
-	pixel_x = -5;
-	pixel_y = 22
-	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "bcircuitoff"
-	},
-/area/turret_protected/ai_upload)
-"fBA" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/dark,
-/area/turret_protected/ai)
-"fBM" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/simulated/floor{
-	icon_state = "yellowsiding";
-	tag = "icon-yellowsiding"
-	},
-/area/hallway/primary/port)
-"fBV" = (
 /obj/machinery/door/firedoor/border_only{
 	name = "Firelock South"
 	},
-/obj/machinery/door/airlock/glass{
-	name = "Auxiliary Tool Storage";
-	req_access_txt = "12"
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	icon_state = "dark"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/storage/tools)
-"fCa" = (
-/obj/structure/table,
-/obj/item/toy/gasha/greyshirt,
-/turf/simulated/floor/asteroid/air,
-/area/maintenance/port)
-"fCd" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/simulated/floor/dark,
-/area/turret_protected/ai)
-"fCm" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/insulated/visible/blue{
-	dir = 4;
-	tag = "icon-intact (EAST)"
-	},
-/turf/simulated/floor/plating,
 /area/turret_protected/tcomms_control_room)
-"fCF" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+"fAy" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/dark,
-/area/turret_protected/ai)
-"fCQ" = (
-/obj/machinery/recharge_station,
-/turf/simulated/floor/bluegrid{
-	icon_state = "bcircuitoff"
-	},
-/area/turret_protected/ai)
-"fCS" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/turret_protected/tcomms_control_room)
-"fDc" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/turret_protected/ai_upload)
-"fDk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/simulated/wall/r_wall,
-/area/turret_protected/ai_upload_foyer)
-"fDm" = (
-/obj/structure/bed/chair,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "yellowsiding";
-	tag = "icon-yellowsiding"
-	},
-/area/hallway/primary/port)
-"fDz" = (
-/obj/machinery/telecomms/server/presets/security,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
-	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "dark";
-	name = "Mainframe Floor";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
-/area/tcomms/chamber)
-"fDH" = (
-/obj/machinery/atmospherics/pipe/simple/insulated/visible/blue{
-	dir = 9;
-	tag = "icon-intact (NORTHWEST)"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/turret_protected/tcomms_control_room)
-"fDJ" = (
-/obj/machinery/ai_status_display{
-	pixel_y = -32
-	},
-/obj/machinery/camera/flawless{
-	dir = 1;
-	name = "AI Core"
-	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "bcircuitoff"
-	},
-/area/turret_protected/ai)
-"fDY" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "bcircuitoff"
-	},
-/area/turret_protected/ai)
-"fEg" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/simulated/floor/dark,
-/area/turret_protected/ai)
-"fEp" = (
-/obj/item/device/radio/intercom/aiprivate{
-	broadcasting = 1;
-	frequency = 1447;
-	pixel_x = -5;
-	pixel_y = 22
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4;
-	on = 1
-	},
-/turf/simulated/floor/dark,
-/area/turret_protected/ai_upload_foyer)
-"fEt" = (
-/obj/machinery/telecomms/processor/preset_three,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
-	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "dark";
-	name = "Mainframe Floor";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
-/area/tcomms/chamber)
-"fEw" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/fire/firefighter,
-/obj/item/clothing/head/hardhat/red,
-/obj/item/clothing/mask/gas,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/port)
-"fEE" = (
-/obj/structure/fence{
-	dir = 4
-	},
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
-/area/maintenance/port)
-"fEK" = (
-/obj/machinery/computer/borgupload,
-/obj/machinery/power/apc{
-	cell_type = 5000;
-	dir = 8;
-	name = "_West APC";
-	pixel_x = -25
-	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "bcircuitoff"
-	},
-/area/turret_protected/ai_upload)
-"fEV" = (
-/obj/machinery/flasher{
-	id_tag = "PCell 1";
-	pixel_y = -28
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light/small,
-/turf/simulated/floor/bluegrid{
-	icon_state = "bcircuitoff"
-	},
-/area/turret_protected/ai)
-"fFy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/simulated/wall/r_wall,
-/area/turret_protected/ai)
-"fFH" = (
-/obj/structure/closet/toolcloset,
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/storage/tools)
-"fFV" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/turret_protected/ai_upload)
-"fGl" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/turf/simulated/floor/bluegrid{
+	icon_state = "bcircuitoff"
+	},
+/area/turret_protected/ai)
+"fAC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor,
-/area/hallway/primary/port)
-"fGo" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_y = -32
+/obj/structure/window/reinforced,
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
+"fAD" = (
+/obj/machinery/camera/flawless{
+	dir = 1;
+	name = "AI Core"
 	},
-/turf/simulated/floor/dark,
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
+"fAX" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowsiding";
+	tag = "icon-yellowsiding"
+	},
+/area/hallway/primary/port)
+"fBA" = (
+/obj/item/device/radio/intercom{
+	dir = 8;
+	freerange = 1;
+	name = "Station Intercom (Telecoms)";
+	pixel_y = -28
+	},
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/closet/malf/suits,
+/obj/item/toy/gasha/AI,
+/turf/simulated/floor{
+	icon_state = "dark brown stripe";
+	tag = "icon-dark brown stripe"
+	},
+/area/turret_protected/tcomms_control_room)
+"fBM" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
+"fCd" = (
+/obj/structure/boulder,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/beach/sand,
+/area/maintenance/port)
+"fCm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/bluegrid{
+	icon_state = "bcircuitoff"
+	},
+/area/turret_protected/ai)
+"fCF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/turf/simulated/wall,
+/area/maintenance/port)
+"fCS" = (
+/obj/machinery/ai_status_display,
+/turf/simulated/wall/r_wall,
+/area/turret_protected/ai_upload)
+"fDc" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "asteroidfloor"
+	},
+/area/maintenance/port)
+"fDm" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/r_wall,
+/area/turret_protected/ai_upload)
+"fDJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/turret_protected/tcomms_control_room)
+"fDY" = (
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/maintenance/port)
+"fEg" = (
+/obj/machinery/computer/telecomms/traffic{
+	network = "tcommsat"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "dark brown stripe";
+	tag = "icon-dark brown stripe (NORTH)"
+	},
+/area/turret_protected/tcomms_control_room)
+"fEp" = (
+/obj/structure/table,
+/obj/item/weapon/stock_parts/micro_laser,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/micro_laser/high,
+/obj/item/weapon/stock_parts/micro_laser/high,
+/obj/item/weapon/stock_parts/micro_laser/high,
+/obj/item/weapon/stock_parts/micro_laser/high,
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/tcomms/storage)
+"fEt" = (
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
+"fEw" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/fire/firefighter,
+/obj/item/clothing/head/hardhat/red,
+/obj/item/clothing/mask/gas,
+/turf/simulated/floor/plating,
+/area/maintenance/port)
+"fFH" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/tcomms/storage)
+"fFV" = (
+/obj/machinery/camera{
+	dir = 1;
+	name = "Telecomms Monitoring"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 2;
+	tag = ""
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	tag = ""
+	},
+/obj/effect/decal/warning_stripes{
+	dir = 5;
+	icon_state = "warning";
+	tag = "icon-warning (NORTHEAST)"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/turret_protected/tcomms_control_room)
+"fGl" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/storage/tools)
+"fGo" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/power/battery/smes{
+	charge = 5e+006
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "fGv" = (
 /obj/structure/cable{
@@ -130950,9 +130668,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/simulated/floor/dark,
-/area/turret_protected/ai_upload)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	req_access_txt = 1
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/turret_protected/tcomms_control_room)
 "fJh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating{
@@ -130963,10 +130685,10 @@
 	name = "Station Zoo"
 	})
 "fPM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
 	},
-/turf/simulated/floor/plating,
 /area/maintenance/port)
 "fRb" = (
 /obj/structure/table,
@@ -131570,17 +131292,15 @@
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "jTO" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+/obj/machinery/telecomms/server/presets/supply,
+/turf/simulated/floor/bluegrid{
+	icon_state = "dark";
+	name = "Mainframe Floor";
+	nitrogen = 100;
+	oxygen = 0;
+	temperature = 80
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/storage/tools)
+/area/tcomms/chamber)
 "jUi" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating{
@@ -131700,14 +131420,6 @@
 	},
 /turf/simulated/wall/r_rock/porous,
 /area/derelict/singularity_engine)
-"lfo" = (
-/obj/machinery/power/apc{
-	name = "_South APC";
-	pixel_y = -24
-	},
-/obj/structure/cable,
-/turf/simulated/floor/plating,
-/area/tcomms/storage2)
 "lfy" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
@@ -131770,8 +131482,16 @@
 /turf/simulated/floor,
 /area/engine/magma_engine)
 "lzh" = (
-/turf/space,
-/area/turret_protected/ai_upload)
+/obj/machinery/atmospherics/unary/vent_pump{
+	on = 1
+	},
+/obj/structure/filingcabinet/chestdrawer,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "dark brown stripe";
+	tag = "icon-dark brown stripe (NORTHEAST)"
+	},
+/area/turret_protected/tcomms_control_room)
 "lCZ" = (
 /obj/machinery/atmospherics/binary/circulator{
 	anchored = 1;
@@ -131805,9 +131525,14 @@
 /turf/simulated/floor/wood,
 /area/library)
 "lTr" = (
-/obj/structure/lattice,
-/turf/space,
-/area/turret_protected/ai_upload)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/port)
 "lVX" = (
 /obj/machinery/light_switch{
 	pixel_y = -28
@@ -131874,21 +131599,6 @@
 	icon_state = "dark"
 	},
 /area/medical/medbay2)
-"mrr" = (
-/obj/machinery/turret{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/camera/flawless{
-	name = "AI Upload"
-	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "bcircuitoff"
-	},
-/area/turret_protected/ai_upload)
 "msS" = (
 /obj/structure/closet/toolcloset,
 /obj/structure/cable{
@@ -132087,44 +131797,16 @@
 /turf/space,
 /area/shuttle/security)
 "nAl" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/grille,
-/turf/simulated/floor/plating,
-/area/turret_protected/ai_upload)
+/obj/structure/flora/rock,
+/obj/structure/flora/ausbushes/reedbush,
+/turf/simulated/floor/beach/water,
+/area/maintenance/port)
 "nDM" = (
-/obj/structure/table,
-/obj/item/weapon/aiModule/core/paladin{
-	pixel_x = -4;
-	pixel_y = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/simulated/floor{
+	icon_state = "dark"
 	},
-/obj/item/weapon/aiModule/core/robocop{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/weapon/aiModule/core/corp,
-/obj/item/weapon/aiModule/standard/quarantine{
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/weapon/aiModule/keeper{
-	pixel_x = 4;
-	pixel_y = -4
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/window{
-	dir = 8;
-	name = "High-Risk Modules";
-	req_access_txt = "20"
-	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "bcircuitoff"
-	},
-/area/turret_protected/ai_upload)
+/area/turret_protected/tcomms_control_room)
 "nIp" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -132304,8 +131986,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/fence/door/opened,
-/obj/effect/decal/cleanable/scattered_sand,
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
@@ -132343,21 +132023,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "pCd" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/newscaster/security_unit{
+	pixel_y = -28
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/ai_slipper{
-	icon_state = "motion0";
-	uses = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/dark,
-/area/turret_protected/ai_upload)
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
 "pDG" = (
 /obj/structure/window/reinforced/plasma{
 	dir = 8
@@ -132467,13 +132137,16 @@
 /turf/simulated/floor,
 /area/engine/magma_engine)
 "qmi" = (
-/obj/machinery/turret{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
 	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "bcircuitoff"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/turret_protected/ai_upload)
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
 "qod" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -132567,17 +132240,19 @@
 	},
 /area/library)
 "rac" = (
-/obj/structure/table,
-/obj/item/device/aicard,
-/obj/item/weapon/planning_frame,
-/obj/machinery/alarm{
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
-	pixel_x = -22
+	on = 1
 	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "bcircuitoff"
+/turf/simulated/floor{
+	icon_state = "dark"
 	},
-/area/turret_protected/ai_upload)
+/area/turret_protected/tcomms_control_room)
 "rff" = (
 /turf/simulated/floor{
 	dir = 9;
@@ -132733,42 +132408,19 @@
 	},
 /area/engineering/aux_storage)
 "sZA" = (
-/obj/effect/landmark{
-	name = "tripai"
+/obj/structure/closet/emcloset,
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
-/obj/item/device/radio/intercom{
-	freerange = 1;
-	name = "Common Channel";
-	pixel_y = 18
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/door/window{
-	dir = 2;
-	name = "AI Core Door";
-	req_access_txt = "16"
+/turf/simulated/floor{
+	icon_state = "dark brown stripe";
+	tag = "icon-dark brown stripe"
 	},
-/obj/item/device/radio/intercom/aiprivate{
-	freerange = 1;
-	name = "Private Channel";
-	pixel_x = -27
-	},
-/obj/item/device/radio/intercom{
-	freerange = 1;
-	listening = 0;
-	name = "Custom Channel";
-	pixel_x = 27
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "bot"
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 1
-	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "bcircuitoff"
-	},
-/area/turret_protected/ai)
+/area/turret_protected/tcomms_control_room)
 "sZZ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -132911,13 +132563,16 @@
 	},
 /area/engineering/aux_storage)
 "tZY" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/telecomms/processor/preset_two,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/simulated/floor/bluegrid{
-	icon_state = "bcircuitoff"
+	icon_state = "dark";
+	name = "Mainframe Floor";
+	nitrogen = 100;
+	oxygen = 0;
+	temperature = 80
 	},
-/area/turret_protected/ai)
+/area/tcomms/chamber)
 "uhY" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -132946,17 +132601,14 @@
 	},
 /area/chapel/main)
 "uyP" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4;
+	initialize_directions = 11
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/turf/simulated/floor/bluegrid{
+	icon_state = "bcircuitoff"
 	},
-/obj/machinery/ai_slipper,
-/turf/simulated/floor/dark,
-/area/turret_protected/ai)
+/area/turret_protected/ai_upload)
 "uzH" = (
 /obj/structure/morgue{
 	dir = 8
@@ -132998,11 +132650,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "yellowsiding";
-	tag = "icon-yellowsiding"
-	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
 /area/hallway/primary/port)
 "uJB" = (
 /obj/structure/disposalpipe/segment{
@@ -133091,8 +132740,16 @@
 	name = "Security Equipment Storage"
 	})
 "vdE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/simulated/wall,
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 1;
+	on = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
 /area/hallway/primary/port)
 "vgM" = (
 /obj/structure/bed/chair/shuttle,
@@ -133158,12 +132815,13 @@
 	},
 /area/bridge)
 "vqM" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/simulated/floor,
-/area/hallway/primary/port)
+/turf/simulated/floor/bluegrid{
+	icon_state = "bcircuitoff"
+	},
+/area/turret_protected/ai)
 "vrr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/space_heater,
@@ -133201,8 +132859,8 @@
 /turf/space,
 /area/shuttle/arrival/station)
 "vPX" = (
-/obj/structure/grille,
-/turf/simulated/wall/r_wall,
+/obj/machinery/turret,
+/turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "wcz" = (
 /obj/structure/cable{
@@ -133345,17 +133003,9 @@
 /turf/simulated/wall/shuttle,
 /area/shuttle/escape/centcom)
 "xso" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Telecomms Auxiliary Storage";
-	req_access_txt = "24"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/structure/fence/door/opened,
 /turf/simulated/floor/plating,
-/area/turret_protected/tcomms_control_room)
+/area/maintenance/port)
 "xtw" = (
 /obj/machinery/computer/tetris,
 /turf/simulated/floor{
@@ -133423,8 +133073,11 @@
 /turf/simulated/floor,
 /area/engine/magma_engine)
 "xQf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/simulated/floor/plating,
+/obj/structure/closet/emcloset,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
 /area/maintenance/port)
 "xXA" = (
 /obj/structure/window/reinforced/plasma{
@@ -133445,25 +133098,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/maintenance/port)
-"yet" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/machinery/status_display{
-	pixel_x = 32
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "bcircuitoff"
-	},
-/area/turret_protected/ai)
 "ymg" = (
 /obj/effect/decal/warning_stripes/pathmarkers/red,
 /obj/effect/decal/warning_stripes/pathmarkers/red{
@@ -191495,7 +191129,7 @@ aaa
 aaa
 aaa
 aaa
-aad
+aaa
 aaa
 aaa
 aaa
@@ -191991,17 +191625,17 @@ aaa
 aaa
 aaa
 aSc
-adZ
-adZ
-aai
-aai
-adZ
-adZ
-chq
-aai
-aai
-adZ
-adZ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aad
+aaa
+aaa
+aaa
+aaa
 adZ
 bII
 bLa
@@ -192493,18 +192127,18 @@ aaa
 aaa
 aaa
 aSc
-aai
 aaa
-aai
-vPX
-vPX
-vPX
-vPX
-vPX
-vPX
-vPX
 aaa
-aai
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 bIE
 bIE
 bIE
@@ -192997,15 +192631,15 @@ aaa
 aSc
 aaa
 aaa
-fxI
-bwl
-bwl
-bwl
-bwl
-bwl
-bwl
-bwl
-fxI
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aai
 ant
@@ -193497,18 +193131,18 @@ aaa
 aaa
 aaa
 aSc
+adZ
+adZ
 aai
-vPX
-bwl
-bNK
-bNI
-bNI
-cTP
-bNI
-bNI
-bNK
-bwl
-vPX
+aai
+adZ
+adZ
+aaa
+aai
+aai
+adZ
+adZ
+aai
 aai
 ant
 bIE
@@ -193999,18 +193633,18 @@ aaa
 aaa
 aaa
 aSc
+aai
 aaa
-vPX
-bwl
-bNI
-fGo
-bwl
-bwl
-bwl
-etk
-bNI
-bwl
-vPX
+aaa
+bkI
+bkI
+bkI
+bkI
+bkI
+bkI
+bkI
+bkI
+aaa
 aaa
 aaa
 bIE
@@ -194501,19 +194135,19 @@ aaa
 aaa
 aaa
 aSc
-aai
-vPX
-bwl
-bNI
-byO
-bwl
-fwd
-bwl
-byO
-bNI
-bwl
-vPX
 aaa
+aaa
+afl
+bkI
+bnz
+cIV
+bnz
+btp
+fza
+bBy
+bkI
+aaa
+aai
 aaa
 bIE
 bPO
@@ -195002,21 +194636,21 @@ aaa
 aaa
 aaa
 aaa
-fwt
+aSc
 afl
-vPX
-bwl
-tZY
-fAC
+afl
+afl
+bkI
+bnA
 bqn
 btn
-cIV
-fyT
-fyZ
-bwl
-vPX
-aai
+bwb
+byL
+bBz
+bkI
 aaa
+aai
+aai
 bIE
 bIE
 bSb
@@ -195504,19 +195138,19 @@ adZ
 aai
 adZ
 aai
-fwt
+aSc
 ant
-vPX
-bwl
-bNI
+ant
+afl
+bkI
 bnC
-byO
+bqp
+btp
 btp
 byO
-byO
 bBD
-bwl
-vPX
+bkI
+aaa
 aai
 aai
 aai
@@ -196006,21 +195640,21 @@ aai
 aaa
 aaa
 aaa
-fwt
+aSc
 ant
-vPX
-bwl
-bNK
+bdv
+bdv
+bdv
 bnD
-fAD
-yet
-efz
-bNI
-bBD
-bwl
-vPX
-ant
-ant
+bdv
+bdv
+bdv
+byP
+bPY
+bEj
+bEj
+bEj
+bEj
 aai
 aaa
 aaa
@@ -196509,20 +196143,20 @@ aaa
 aaa
 aaa
 aRZ
-bwl
-bwl
-bwl
-bwl
+bdv
+bdv
+bND
+tZY
 bnB
-bwl
-bwl
+fxI
+byX
 bwc
 byM
 bBA
-bwl
-vPX
-ant
-ant
+bBI
+nDM
+bEz
+bEj
 ant
 aai
 aaa
@@ -197011,20 +196645,20 @@ aaa
 aaa
 aaa
 aRZ
-bwl
-bwl
-bNK
-fDY
+bdv
+jTO
+biC
+bkK
+bkK
+bkK
+biC
+bwd
+fEg
+bBB
+fzt
+bBG
 fBA
-bNK
-bwl
-bQc
-bQc
-fzG
-bQc
-bQc
-bQc
-ant
+bEj
 ant
 ant
 aai
@@ -197513,24 +197147,24 @@ aaa
 aaa
 afl
 aRZ
-bwl
-sZA
+bdv
+bdv
 biF
 bkM
-fCd
-fDJ
-bwl
-bwi
-fEK
-bNA
+bkK
+bqs
+bAG
+bwd
+byS
+bBG
 rac
-dSS
-bQc
-bPU
-bPU
+bBG
+efz
+bEj
 bPU
 bPT
 bSe
+fAe
 bWE
 bPT
 bPT
@@ -198015,22 +197649,22 @@ aaa
 afl
 afl
 aRZ
-bwl
-bwl
-bNI
-byO
-uyP
-fvT
-bwl
-fAX
+ant
+bdv
+biG
+bkK
+bnG
+bqt
+btt
+bwg
 byT
-bZa
+bBH
 bEn
-bWR
-bQc
-fEp
+fDJ
+fvS
+bEj
 bNB
-bPU
+byU
 bSf
 bUs
 bWF
@@ -198517,27 +198151,27 @@ aaa
 afl
 aIr
 aRZ
-bwl
-bwl
-bNI
-byO
-fyf
+ant
+bdv
+biD
+bkL
+bnE
 bqq
-fze
-fwW
+btq
+bwe
 byQ
-bUA
-pCd
+bBE
+bEk
 fGv
 bFB
 fAq
 bNy
 bPR
 uGW
-bSc
-fGl
-bSc
-bSc
+uGW
+uGW
+uGW
+uGW
 cdI
 cgf
 cin
@@ -199019,27 +198653,27 @@ afl
 afl
 aIr
 aRZ
-bwl
-sZA
-biF
-fCF
-fEg
-fEV
-fFy
-mrr
+aIr
+bdv
+biE
+bkK
+bnF
+bqr
+btr
+bwf
 byR
-fzt
-fzt
-eDT
-bQe
-fyk
+bBF
+bEl
+bBG
+fFV
+bLc
 bNz
-fDk
-fxZ
-fzZ
 bPS
 bSd
-bUq
+hii
+fyZ
+hii
+hii
 cdJ
 cgg
 cio
@@ -199521,27 +199155,27 @@ aUj
 aUj
 aUj
 bbc
-bwl
-bwl
+bdv
+bdv
 bkO
-bkO
-fCQ
-bNO
-bwl
+bLd
+bkK
+bqv
+cbl
 bwi
 byV
 nDM
 aYT
-qmi
-bQc
-bPU
-bPU
-bPU
-bNE
+nDM
+sZA
+bEj
 bNE
 bPX
 bSi
-bNE
+bUt
+bWI
+bWI
+bWI
 cdO
 cgj
 cit
@@ -200023,27 +199657,27 @@ aOF
 aWr
 aYG
 bbd
-bwl
-bwl
-bwl
-fyu
-fAy
-bwl
-bwl
-bQc
-fFV
-nAl
-fDc
-bQc
-bQc
-bWJ
+bdv
+euU
+biC
+bkK
+bkK
+bkK
+biC
+bwj
+byW
+bBB
+bEq
+bSc
+fyA
+bEj
 fyO
 bYT
-bNE
-bNF
-bPY
 bSj
-bNE
+bUt
+bWJ
+fwW
+fGl
 cdP
 cgk
 ciu
@@ -200525,30 +200159,30 @@ aQv
 aWp
 aYF
 aYF
-fCa
-bfW
-btu
+bdv
+bdv
+biH
 bnH
-bnH
+bUq
+bUA
 btu
-btu
+bwh
 lzh
-lzh
-lzh
-lzh
-lTr
+fwd
+fyL
+bBG
+bIP
+bEj
+bNC
+fFH
+fEp
 bUt
 bWG
-jTO
-fFH
-bNE
-bNC
-bPV
 bSg
-bNE
+fyk
 cdM
-cgu
-cir
+vdE
+cQI
 clf
 cnr
 cpA
@@ -201039,17 +200673,17 @@ bfW
 bfW
 bfW
 bfW
-bUt
-bWH
+bfW
+bfW
 fyK
 fzT
-bNE
-bND
-bPW
+evA
+bUt
+bWH
 bSh
-bNE
-cdP
-cgj
+fwt
+chq
+cgg
 cis
 clh
 clh
@@ -201540,16 +201174,16 @@ aWt
 aWt
 aWt
 aWt
+aWt
 bIU
+bfW
+bfW
+bfW
+bfW
+bUt
 bWI
 bWI
-fBV
-cbl
-bNE
-bNE
-bNE
-bNE
-bNE
+bWI
 cdS
 cgm
 ciw
@@ -202045,9 +201679,9 @@ bEt
 bGF
 bIV
 oWU
-fwa
-fyL
-bLd
+oWU
+oWU
+oWU
 bUv
 bWM
 bYX
@@ -202536,7 +202170,7 @@ aYH
 aYH
 aYH
 aYH
-evA
+aWq
 aWs
 aWs
 aWs
@@ -202546,16 +202180,16 @@ bBK
 bEr
 bEs
 bIS
-fAe
-bSt
+aWq
+aWq
 fPM
 xQf
-vdE
+bUu
 bWK
-hii
-hii
-bEA
-vqM
+fAX
+fAX
+cdQ
+cgl
 civ
 clh
 cnu
@@ -203048,10 +202682,10 @@ aWs
 bEs
 bGE
 bIT
-fEE
-bLe
-fEw
-bZc
+aQv
+aQv
+aQv
+aOF
 bUu
 bWL
 bYW
@@ -203549,14 +203183,14 @@ bgh
 aWs
 bEv
 aWs
-bfW
-bkI
-bkI
-bkI
-bkI
-bkI
-bkI
-bkI
+aWs
+aWs
+aWs
+aWs
+aWs
+aWs
+aWs
+aWs
 cbo
 cdW
 cgl
@@ -204051,14 +203685,14 @@ bfY
 bfY
 bfY
 bfY
-bgh
-bkI
-bnz
-bnz
-euU
-bBy
-bBy
-bkI
+ptz
+bLf
+bNH
+xso
+bNH
+bNH
+bNH
+aWs
 cbp
 cdX
 cgq
@@ -204534,9 +204168,9 @@ aJH
 aKN
 aLM
 aMY
-aOF
+fCF
 aQt
-aWq
+biI
 aUk
 aSj
 aSj
@@ -204553,14 +204187,14 @@ biL
 biL
 bEu
 bfZ
-bgh
-bkI
-bnA
+bfW
+bLe
+fEw
 bQa
-bwb
-byL
-bBz
-bkI
+bSl
+bNH
+bLf
+aWs
 bUu
 cdU
 cgo
@@ -205038,7 +204672,7 @@ aLN
 aFE
 aGK
 aIF
-aIF
+fDc
 aNe
 aWv
 aWv
@@ -205052,17 +204686,17 @@ biL
 biL
 biL
 biL
-bdv
-bdv
-bdv
-bdv
-bdv
-bqp
-fyr
+bBM
+bwl
+bwl
+bwl
+bwl
+byZ
+bfW
 bSl
 bUw
-lfo
-bkI
+bLf
+bYY
 cbn
 cdV
 cgp
@@ -205554,18 +205188,18 @@ biL
 biL
 biL
 byY
-bdv
-cho
-fyA
+bwl
+bwl
+bwl
 bIZ
-bdv
-bEj
-fCm
-xso
-byP
-bEj
-bEj
-fDm
+bwl
+enn
+bQc
+bQc
+bQc
+bQc
+bQc
+cbq
 cdY
 cgs
 ciD
@@ -206055,19 +205689,19 @@ biL
 bqz
 biL
 bwm
-bdv
-bdv
-fvU
-bkK
+byZ
+bwl
+bwl
+vqM
 bJa
 bLi
-euT
-fDH
+bNK
+bQc
 bSo
 bUz
 bWO
-bEj
-fDm
+fCS
+cbq
 cdY
 cgl
 ciE
@@ -206556,19 +206190,19 @@ bkQ
 biL
 biL
 bty
-bdv
-bdv
-fza
-biC
-biC
-biC
+bwl
+bwl
+bwl
+vPX
+fEt
+bNA
 bLg
-fxf
-fCS
+bNI
+bQc
 bSm
 bUx
 bIK
-bEj
+bQc
 cbq
 cdY
 cgr
@@ -207058,19 +206692,19 @@ biL
 biL
 bqy
 biL
-bdv
-byX
+bwl
+enn
 bBN
 bEx
-bqs
+fyr
 bIY
-bwd
-byS
-bBG
+bGD
+fAD
+bQc
 bEm
 bBJ
-bIN
-bEj
+bUx
+bIO
 cbr
 cdQ
 cgj
@@ -207560,19 +207194,19 @@ biL
 biL
 biL
 bqz
-bdv
-biG
-bkK
-bnG
-bqt
-btt
-bwg
-fvS
-bBH
+bwl
+bwl
+bBP
+fEt
+bGI
+bGI
+fAC
+bNL
+fCS
 bSr
 bGC
-bIO
-bEj
+bWR
+bQc
 cbu
 cdV
 cgj
@@ -208062,16 +207696,16 @@ bkT
 biL
 bqB
 btA
-bdv
-biD
-bkL
-bnE
+bwl
+bwl
+fGo
+fEt
 bGI
-btq
-bwe
+fzG
+bIN
 bNN
-bBE
-bEk
+dSS
+bZa
 bGB
 bIL
 bLb
@@ -208564,23 +208198,23 @@ biL
 biL
 biL
 btz
-bdv
-biE
-bkK
-bnF
-bqr
-btr
-bwf
+bwl
+bwl
+fBM
+pCd
+bGI
+bGI
+bUy
 bNL
-bBF
-bEl
+fCS
+fze
 bAr
 bIM
-bLc
+bQc
 cbs
-bEA
-cgg
-fBM
+cdQ
+cgj
+cit
 clp
 aGs
 nxJ
@@ -209066,22 +208700,22 @@ bkS
 biL
 bqA
 biL
-bdv
+bwl
 enn
 bBP
-bEz
-bqv
 fEt
-bwj
+fEt
+fEt
+qmi
 bNM
-bBG
-bEq
-bBJ
+bQe
+cho
+uyP
 bIQ
-bEj
+fyu
 cbt
-cdV
-cgj
+eDT
+cgg
 ciF
 clq
 tHC
@@ -209568,19 +209202,19 @@ bfY
 biL
 biL
 btB
-bdv
-bdv
+bwl
+bwl
 bBS
-biC
-bkK
-biC
-bwj
-byW
-bBB
-bEq
-bGD
-bUy
-bEj
+cNG
+bPV
+fAy
+fCm
+bNI
+bQc
+fyT
+bUx
+bBJ
+bQc
 cbq
 cdY
 cgj
@@ -210071,18 +209705,18 @@ biL
 bkQ
 biL
 biL
-bdv
-bdv
-cNG
-bkK
+byZ
+bwl
+bwl
+fzZ
 bJe
-bwh
-byU
-bBI
+cTP
+bNO
+bQc
 bEo
-bAG
-bIP
-bEj
+bBJ
+fxf
+fCS
 cbq
 ceb
 cgh
@@ -210574,17 +210208,17 @@ biL
 bqz
 biL
 bza
-bdv
-fDz
-bkK
+bwl
+bwl
+bGJ
 bJc
-bdv
-cSm
-bEj
-bEj
-bEj
-bEj
-bEj
+bwl
+enn
+bQc
+fDm
+bQc
+bQc
+bQc
 cbq
 cdY
 cgj
@@ -211076,13 +210710,13 @@ biL
 biL
 biL
 bqz
-bdv
-biH
+nAl
+bwl
 bGJ
-biI
-bdv
+bwl
+bwl
 byZ
-bNH
+bfW
 bSu
 bNH
 bNH
@@ -211577,15 +211211,15 @@ bfY
 biL
 btD
 biL
-biL
-bdv
-bdv
-bdv
-bdv
-bdv
+bzc
+bBT
+bkP
+fCd
+bfW
+bLr
 bNQ
-bNH
-bNH
+bPW
+bSu
 bUG
 bWU
 aOF
@@ -212078,16 +211712,16 @@ bfY
 bnP
 bfY
 bfY
-biL
-biL
-bBM
-bkP
-bfZ
-aWs
-bLp
-bNH
-bNH
-bNH
+bfY
+bfY
+bfY
+bfY
+fvT
+bNF
+lTr
+etk
+etk
+fxZ
 bNH
 bNH
 bZc
@@ -212581,12 +212215,12 @@ aWs
 bfY
 btC
 bfY
-bzc
-bfY
-bfY
-bfY
-ptz
-bLf
+bzb
+bgh
+aQv
+aQv
+aWs
+bLp
 bLf
 bNH
 bNH
@@ -213083,12 +212717,12 @@ aWs
 aWs
 aQv
 aQv
-bzb
-bgh
-bBT
+aQv
+aQv
+aQv
 aQv
 aWs
-bLr
+fDY
 bNP
 bQg
 bSx


### PR DESCRIPTION
## What this does
This PR undoes the controversial change from #33340, wherein the AI core and telecomms room positions were swapped.
I did my best to faithfully re-create the look, piping, wiring, etc. I made sure to include changes that have happened since the room swap, such as #36781, so no deprecated room design is included. This PR also restores auxiliary tool storage to where it was before the room swap.

Please note that this PR does _not_ revert any other changes in #33340, such as the modifications to Auxiliary Engineering.

Before this PR:
![RoidAICoreRedo5](https://user-images.githubusercontent.com/40326633/191398276-a710bf2a-b3d6-49eb-ad6e-ac3f1afd3370.PNG)
After this PR:
<img width="1286" height="765" alt="image" src="https://github.com/user-attachments/assets/68c46d23-a2c1-4c4d-9f10-89e16543efb8" />


## Why it's good
In my opinion, this change relegated the AI core to a less open and far more claustrophobic part of the map. Since one of the things that somewhat distinguishes /vg/ from other servers is the ease with which just about everybody can ask to be let into the AI core, I feel this detracts from the experience. Moving telecomms - a room almost no one will use - to a more central location also feels like the wrong step.

Another unfortunate part of the room swap was that Auxiliary Tool Storage got weirdly confined to maintenance where it's now practically unused. It also just looks... really out of place and bad, since a regular non-maintenance station room was just shoved in there, grey tiles and all.

This summarizes my thoughts pretty well:
<img width="905" height="229" alt="image" src="https://github.com/user-attachments/assets/96435d19-9cd3-444b-b86c-b76da290d488" />

## How it was tested
Main concern was the pipes and wiring here. Loaded up the map on a test server and drained air from rooms, let them refill, checked APC charging, etc. The debug verb I made for this very map some time ago also came in handy to find that nothing was wrong with the pipe system. 
[roid]

## Changelog
:cl:
 * tweak: RoidStation's AI and telecomms rooms have been returned to their original positions (circa late 2022). Auxiliary tool storage is also no longer weirdly shoved into maintenance.
