### PR TITLE
Adds a lightswitch to Boxstation's Telecommunications Server Room

### DIFF
--- a/maps/tgstation.dmm
+++ b/maps/tgstation.dmm
@@ -63797,6 +63797,9 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/light_switch{
+	pixel_y = 28
+	},
 /turf/simulated/floor/bluegrid{
 	icon_state = "dark";
 	name = "Mainframe Floor";


### PR DESCRIPTION
So it looks nice and dark by default

![tcomms](https://github.com/user-attachments/assets/9eed791c-a23a-49a5-8040-53afa1617260)
it's not visible on this gif because I recorded it beforehand to showcase dark tcomms.

<img width="422" height="291" alt="image" src="https://github.com/user-attachments/assets/045cc673-d038-47fe-8007-aa450cd62d5a" />

This has been in the back of my mind ever since I gave those machines moody lights

:cl:
* rscadd: Boxstation's Telecommunications Server Room now has a light switch in its entrance airlock that's off by default.