### PR TITLE
Eye Surgery buff

### DIFF
--- a/code/modules/surgery/eye.dm
+++ b/code/modules/surgery/eye.dm
@@ -156,6 +156,8 @@
 	if (target.op_stage.eyes == 3)
 		target.disabilities &= ~NEARSIGHTED
 		target.sdisabilities &= ~BLIND
+		target.eye_blind = 0
+		target.eye_blurry = 0
 		eyes.damage = 0
 	target.op_stage.eyes = 0
 


### PR DESCRIPTION
eye surgery now sets eye_blind and eye_blurry immediately to zero.

:cl:
* rscadd: Eye Surgery now cures players of eye-related temporary status effects that could sometimes go on for way too long. So now you should always have your vision fully restored after undergoing it.