### PR TITLE
Reduces the lotto ballcount again

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -3954,7 +3954,7 @@ var/station_jackpot = 1000000
 		to_chat(user,"<span class='notice'>The winning numbers are [english_list(winning_numbers)]</span>")
 
 #define LOTTO_SAMPLE 6
-#define LOTTO_BALLCOUNT 18 //lottery is a topdefine/bottomdefine system
+#define LOTTO_BALLCOUNT 9 //lottery is a topdefine/bottomdefine system
 #if LOTTO_BALLCOUNT < LOTTO_SAMPLE
 #define LOTTO_BALLCOUNT LOTTO_SAMPLE
 #endif


### PR DESCRIPTION
[tweak]

## What this does
Increases the odds again from #36938.

## Why it's good
Player feedback indicates people still weren't winning anything off this.

## How it was tested
Factorial 9 divided by (factorial 4 times factorial 5), all multiplied by 6. 1 in 756 tickets, down from 54,108. This should mean that the jackpot is most likely to appear at least once every 38 times this event is called, down from a whopping ***2,706***.

## Changelog
:cl:
 * tweak: Lotto tickets with numbers from the random event are now even more likely to be winners, as the highest ballcount is now 9 and not 18.