### PR TITLE
Adds missing o2 tank to the space ranch hobo shack

### DIFF
--- a/maps/misc/hoboshack_spaceranch.dmm
+++ b/maps/misc/hoboshack_spaceranch.dmm
@@ -140,6 +140,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/landmark/hobostart,
 /turf/simulated/floor/wood,
 /area/shack)
 "ia" = (
@@ -589,10 +590,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/hobostart,
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/wood,
 /area/shack)
 "TR" = (


### PR DESCRIPTION
Closes #38552
[hotfix]
:cl:
 * bugfix: The space ranch hobo shack should have an o2 tank now.