### PR TITLE
RCD and RPD send assets when picked up

### DIFF
--- a/code/modules/RCD/RPD.dm
+++ b/code/modules/RCD/RPD.dm
@@ -86,6 +86,11 @@
 /obj/item/device/rcd/rpd/pickup(var/mob/living/L)
 	..()
 	L.register_event(/event/clickon, src, nameof(src::mob_onclickon()))
+	if(L.client)
+		for(var/cat in schematics)
+			var/list/S = schematics[cat]
+			for(var/datum/rcd_schematic/C in S)
+				C.send_list_assets(L.client)
 
 /obj/item/device/rcd/rpd/dropped(var/mob/living/L)
 	..()
@@ -105,10 +110,10 @@
 
 /obj/item/device/rcd/rpd/attack_self(var/mob/user)
 	..()
-	for(var/cat in schematics)
-		var/list/L = schematics[cat]
-		for(var/datum/rcd_schematic/C in L)
-			for(var/client/client in interface.clients)
+	for(var/client/client in interface.clients)
+		for(var/cat in schematics)
+			var/list/L = schematics[cat]
+			for(var/datum/rcd_schematic/C in L)
 				C.send_list_assets(client)
 	
 

--- a/code/modules/RCD/engie.dm
+++ b/code/modules/RCD/engie.dm
@@ -32,7 +32,14 @@
 	
 		current_menu=schem_groups[1]?.name
 		schem_groups[1]?.switch_to()
-	
+
+/obj/item/device/rcd/matter/engineering/pickup(var/mob/living/L)
+	..()
+	if(L.client)
+		for(var/datum/rcd_scematic_grouping/schemgroup in schem_groups)
+			schemgroup.send_assets(L.client)
+			for(var/datum/rcd_grouped_schematic/sch)
+				sch.send_assets(L.client)	
 
 /obj/item/device/rcd/matter/engineering/Destroy()
 	. = ..()
@@ -230,6 +237,13 @@
 	current_menu=schem_groups[1]?.name
 	schem_groups[1]?.switch_to()
 
+/obj/item/device/rcd/borg/engineering/pickup(var/mob/living/L)
+	..()
+	if(L.client)
+		for(var/datum/rcd_scematic_grouping/schemgroup in schem_groups)
+			schemgroup.send_assets(L.client)
+			for(var/datum/rcd_grouped_schematic/sch)
+				sch.send_assets(L.client)
 	
 /obj/item/device/rcd/borg/engineering/attack_self(var/mob/user)
 	if(!isrobot(user))


### PR DESCRIPTION
[qol]

## What this does
when picked up, the RCD and RPD now send assets, instead of waiting for them to be clicked on and the UI opened.

## Why it's good
offsets the loading delay, hopefully before the user wants the UI opened

## How it was tested
went into game, picked up the RPD and RCD. i waited a moment, then opened the UI and saw that the icons had loaded in. i also started a fresh instance and immedietly opened their UIs to confirm that existing loading was not broken

## Changelog
 * experiment: The RCD and RPD now attempt to load assets when picked up instead of waiting for the UI to be opened first. Please report any issues with icon loading you experience.
