### PR TITLE
Makes odd coins always lucky

### DIFF
--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -442,13 +442,7 @@
 		// Something about this coin stands out...
 		luckiness_validity = LUCKINESS_WHEN_GENERAL_RECURSIVE
 		overlays += image('icons/obj/items.dmi', "shine")
-		if (prob(20))
-			// Sometimes it's very lucky!
-			luckiness = 500 * credits
-		else
-			// But most of the time, it's just our imagination.
-			luckiness = 0
-
+		luckiness = 500 * credits
 
 /obj/item/weapon/coin/recycle(var/datum/materials/rec)
 	if(material==null)


### PR DESCRIPTION
## What this does
Currently, there's a 1% chance for any one coin to be odd, and a 20% chance for any odd coin to be lucky, for an aggregate 0.2% for any coin. This is way too low, you rarely see odd coins, and lucky ones even less so. (10 of every 1000 coins are odd, but only 2 out of those 10 are lucky).
This PR makes it so ALL odd coins are lucky. It might seem like a lot, but this is still only a 1% chance per coin, meaning that out of 1000 coins, only 10 would be lucky, or a 1:100 chance.
Does NOT increase the chance for coins to be odd, that is still only 1%.
## Why it's good
Makes the odd coins that seem lucky actually lucky and makes them viable to find ingame without powergaming lucky coins.
:cl:
 * tweak: Odd coins (the ones with the glisten that only appear 1% of the time) will now always be lucky, instead of only having a 20% chance to be lucky.