### PR TITLE
Fixes Internal Bleeds Not Bleeding on Fully Healed Limbs

### DIFF
--- a/code/datums/diseases/appendicitis.dm
+++ b/code/datums/diseases/appendicitis.dm
@@ -54,4 +54,5 @@
 			var/datum/wound/W = new /datum/wound/internal_bleeding(20)
 			H.adjustToxLoss(25)
 			groin.wounds += W
+			groin.internally_bleeding = TRUE
 			src.cure()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1147,6 +1147,7 @@
 	if(prob(10)) //I'M SO ANEMIC I COULD JUST -DIE-.
 		var/datum/wound/internal_bleeding/I = new (15)
 		affected.wounds += I
+		affected.internally_bleeding = TRUE
 		custom_pain("Something tears wetly in your [affected] as [selection] is pulled free!", 1)
 	return 1
 

--- a/code/modules/mob/living/carbon/human/life/handle_mutations_and_radiation.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_mutations_and_radiation.dm
@@ -151,6 +151,7 @@
 							to_chat(src, "<span class = 'danger'>You feel something tear in your [victim.display_name]</span>")
 						var/datum/wound/internal_bleeding/I = new (1*major_rad_multiplier)
 						victim.wounds += I
+						victim.internally_bleeding = TRUE
 		if(rad_tick > RADDOSEADVANCED)
 			if(prob(5*rad_multiplier))
 				//Organ damage

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -49,6 +49,8 @@
 
 	//How often wounds should be updated, a higher number means less often
 	var/wound_update_accuracy = 1
+	//Cache for if limb has a bleeding wound. If true, will force-process the limb's wounds regardless of damage.
+	var/internally_bleeding = FALSE
 
 	var/has_fat = 0 //Has a _fat variant
 	var/cosmetic_only = FALSE
@@ -398,6 +400,7 @@
 		if(!internal_bleeding)
 			var/datum/wound/internal_bleeding/I = new (15)
 			wounds += I
+			internally_bleeding = TRUE
 			owner.custom_pain("You feel something rip in your [display_name]!", 1)
 
 	//Check whether we can add the wound to an existing wound
@@ -451,6 +454,8 @@
 
 /datum/organ/external/proc/need_process()
 	if(status && !is_organic()) //If it's non-organic, that's fine it will have a status.
+		return 1
+	if(internally_bleeding)
 		return 1
 	if(brute_dam || burn_dam)
 		return 1
@@ -648,10 +653,12 @@ Note that amputating the affected organ does in fact remove the infection from t
 		return
 
 	var/datum/species/species = src.species || owner.species
+	internally_bleeding = FALSE
 
 	for(var/datum/wound/W in wounds)
 		//Internal wounds get worse over time, and you lose blood
 		if(W.internal && !W.is_treated() && !(species && species.anatomy_flags & NO_BLOOD))
+			internally_bleeding = TRUE
 			var/blood_factor = owner.calcbloodloss() //Calls helper function to determine amount of blood loss.
 
 			owner.vessel.remove_reagent(BLOOD, W.damage * wound_update_accuracy * 0.07 * max(0, blood_factor))

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -148,6 +148,7 @@
 		to_chat(user, "<span class='warning'>You tear some vessels trying to fit such big object in this cavity.")
 		var/datum/wound/internal_bleeding/I = new (15)
 		affected.wounds += I
+		affected.internally_bleeding = TRUE
 		affected.owner.custom_pain("You feel something rip in your [affected.display_name]!", 1, scream=TRUE)
 	user.drop_item(tool)
 	affected.hidden = tool


### PR DESCRIPTION

## What this does
This fixes a bug introduced by #36706 where internally bleeding external organs would stop bleeding if the organ was fully healed of brute/burn damage. Specifically, this adds a cached variable in the limb for quick needs_process checking, as going through full wound lists on every limb for every mob on every life tick can be laggy.

## Why it's good
Returns internal bleeds to the life-threatening injury a spaceman should fear.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->

<img width="250" height="166" alt="image" src="https://github.com/user-attachments/assets/3abddddb-f06a-4184-bae7-0b135d5d97e2" />

<img width="338" height="550" alt="image" src="https://github.com/user-attachments/assets/77c85b33-cc7f-4b6c-8ed1-a9c3451c7cab" />

<img width="438" height="221" alt="image" src="https://github.com/user-attachments/assets/de0473f6-0e4b-42e4-bbbf-c42d1a14cef0" />

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Internal Bleeds no longer stop bleeding when all the burn and brute damage on a limb is healed.