### PR TITLE
Fix transparent pipes lagging out renderers in vicinity 

### DIFF
--- a/code/game/machinery/ATMOSPHERICS/atmospherics.dm
+++ b/code/game/machinery/ATMOSPHERICS/atmospherics.dm
@@ -165,8 +165,9 @@ Pipelines + Other Objects -> Pipe network
 	for (var/obj/machinery/atmospherics/connected_node in node_list)
 		var/con_dir = get_dir(src, connected_node)
 		missing_nodes -= con_dir // finds all the directions that aren't pointed to by a node
-		var/image/nodecon = icon_node_con(con_dir)
-		if(nodecon)
+		var/image/nodecon_ref = icon_node_con(con_dir)
+		if(nodecon_ref)
+			var/image/nodecon = image(nodecon_ref)
 			nodecon.color = node_color_for(connected_node)
 			nodecon.alpha = node_alpha_for(connected_node)
 			nodecon.plane = node_plane()


### PR DESCRIPTION
## What this does
Fixes the stupid pipe lag and renderer breaking

<img width="1026" height="1214" alt="image" src="https://github.com/user-attachments/assets/e6638734-a0a7-47bc-a36b-8c23516504c6" />

Hmm why the fuck are these underlays appearing in a separate pipe net???

<img width="2047" height="2045" alt="image" src="https://github.com/user-attachments/assets/16edca3f-ab48-4241-a23c-64c564d1064d" />

What the fuck why is the renderer bailing out???

<img width="1509" height="1352" alt="image" src="https://github.com/user-attachments/assets/dd57de75-5f97-4901-a5ac-8527dda790c2" />

what are thooooose??

<img width="482" height="283" alt="image" src="https://github.com/user-attachments/assets/05fbed3d-663c-4d92-b652-335d49487cb1" />

oh god oh fuck

Basically what was happening was that `nodecon` was always a copy of an entry in a STATIC cache so the image in the STATIC cache underlays grew endlessly
Now we do a proper deep copy the thing instead of a shallow copy

## Why it's good
Fixes the stupid pipe lag and renderer breaking

## How it was tested
Checking `nodecon.underlays.len` after painting a bunch of pipes transparent

<img width="1320" height="960" alt="image" src="https://github.com/user-attachments/assets/b9de356e-0ba6-496d-af5e-67ad34814f40" />


## Changelog
:cl:
 * bugfix: Fixed transparent pipes lagging the fuck out 

