### PR TITLE
alt fried egg recipe

### DIFF
--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -358,6 +358,10 @@
 	items = list(/obj/item/weapon/reagent_containers/food/snacks/egg)
 	result = /obj/item/weapon/reagent_containers/food/snacks/friedegg
 
+/datum/recipe/friedeggalt
+	reagents = list(SODIUMCHLORIDE = 1, BLACKPEPPER = 1, EGGYOLK = 4) //one egg worth
+	result = /obj/item/weapon/reagent_containers/food/snacks/friedegg
+
 /datum/recipe/boiledegg
 	reagents = list(WATER = 5)
 	items = list(/obj/item/weapon/reagent_containers/food/snacks/egg)


### PR DESCRIPTION
## What this does
Adds an alt recipe for cooking fried eggs, using 1 egg-worth of egg yolk reagent, instead of a whole egg.
## Why it's good
You can't cook FRIED eggs in a FRYING pan, you break the eggs into them, leading to only the reagents transferring and the mix never cooking. This fixes that.
:cl:
 * rscadd: Adds an alt fried egg recipe that uses the egg yolk reagent instead of the whole egg, so you can now cook fried eggs in a frying pan as well.