### PR TITLE
Revert "Removes Ash Overlays"

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -226,7 +226,7 @@
 
 #define isrealobject(A) (istype(A, /obj/item) || istype(A, /obj/structure) || istype(A, /obj/machinery) || istype(A, /obj/mecha))
 
-#define iscleanaway(A) (istype(A,/obj/effect/decal/cleanable) || (istype(A,/obj/effect/overlay) && !istype(A,/obj/effect/overlay/puddle) && !istype(A, /obj/effect/overlay/hologram)) || istype(A,/obj/effect/rune_legacy) || (A.ErasableRune()))
+#define iscleanaway(A) (istype(A,/obj/effect/decal/cleanable) || (istype(A,/obj/effect/overlay) && !istype(A,/obj/effect/overlay/puddle) && !istype(A, /obj/effect/overlay/hologram)) || istype(A,/obj/effect/rune_legacy) || (A.ErasableRune()) || istype(A,/obj/effect/ash))
 
 #define ismatrix(A) (istype(A, /matrix))
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -473,6 +473,8 @@ its easier to just keep the beam vertical.
 	if(on_fire)
 		user.simple_message("<span class='danger'>OH SHIT! IT'S ON FIRE!</span>",\
 			"<span class='info'>It's on fire, man.</span>")
+	if(charred_overlay)
+		to_chat(user, span_info("It's covered in ash."))
 	if(min_harm_label && harm_labeled)
 		if(harm_labeled < min_harm_label)
 			to_chat(user, harm_label_examine[1])
@@ -555,6 +557,8 @@ its easier to just keep the beam vertical.
 /atom/proc/clean_act(var/cleanliness)//1 = contact with water (splashed with water, removes glue from objs), 2 = space cleaner or efficient cleaning (showers, sink, soap), 3 = bleach
 	if (cleanliness >= CLEANLINESS_SPACECLEANER)
 		clean_blood()
+		if(charred_overlay)
+			cut_overlay(charred_overlay)
 	if (cleanliness >= CLEANLINESS_BLEACH)
 		color = ""
 	if (cleanliness >= CLEANLINESS_WATER)//I mean, not sure why we'd ever add a rank below water but, futur-proofing and all that jazz

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -53,6 +53,8 @@ BREATHALYZER
 			if(istype(A,/obj/))
 				var/obj/O = A
 				O.t_scanner_expose()
+			else if(istype(A,/obj/effect/ash))
+				continue
 			else if(istype(A,/mob/living/carbon))
 				var/mob/living/carbon/C = A
 				if(C.alpha < OPAQUE || (C.invisibility > 0 && C.invisibility < INVISIBILITY_OBSERVER) || length(C.body_alphas))

--- a/code/game/objects/items/trader.dm
+++ b/code/game/objects/items/trader.dm
@@ -249,6 +249,12 @@
 		else if(P.wet == TURF_WET_WATER)
 			reagents.add_reagent(WATER,1)
 		qdel(P)
+	for(var/obj/effect/ash/A in T)
+		if(reagents.is_full())
+			visible_message(span_warning("\The [src] sputters, wet tank full!"))
+			break
+		reagents.add_reagent(CARBON,1)
+		qdel(A)
 	T.clean_blood()
 	for(var/obj/item/trash/R in T)
 		if(trash.len >= max_trash)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -65,6 +65,9 @@ var/global/list/reagents_to_always_log = list(AMUTATIONTOXIN, CYANIDE, CHEFSPECI
 	var/is_cooktop //If true, the object can be used in conjunction with a cooking vessel, eg. a frying pan, to cook food.
 	var/obj/item/weapon/reagent_containers/pan/cookvessel //The vessel being used to cook food in. If generalized out to other types of vessels, make sure to also generalize the frying pan's cook_start(), etc. as well.
 
+	//Is the object covered in ash?
+	var/ash_covered = FALSE
+
 	var/verb_rotates = FALSE
 	var/alt_click_rotates = FALSE
 	var/ghost_can_rotate = FALSE
@@ -353,6 +356,7 @@ var/global/list/reagents_to_always_log = list(AMUTATIONTOXIN, CYANIDE, CHEFSPECI
 	..()
 	if (cleanliness >= CLEANLINESS_WATER)
 		unglue()
+		ash_covered = FALSE
 
 /obj/proc/cultify()
 	qdel(src)
@@ -500,6 +504,7 @@ var/global/list/reagents_to_always_log = list(AMUTATIONTOXIN, CYANIDE, CHEFSPECI
 
 /obj/ignite()
 	if(..())
+		ash_covered = TRUE
 		remove_particles(PS_SMOKE)
 
 /obj/item/checkburn()
@@ -665,6 +670,12 @@ a {
 	user << browse(HTML_SKELETON(dat), "window=mtcomputer")
 	user.set_machine(src)
 	onclose(user, "mtcomputer")
+
+/obj/update_icon()
+	if(ash_covered)
+		cut_overlay(charred_overlay)
+		process_charred_overlay()
+	return
 
 /mob/proc/unset_machine()
 	if(machine)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -101,6 +101,8 @@
 	..()
 	if(bullet_marks)
 		to_chat(user, "It has [bullet_marks > 1 ? "some holes" : "a hole"] in it.")
+	if(locate(/obj/effect/ash) in src)
+		to_chat(user, "It is covered in ashes.")
 
 /turf/proc/process()
 	set waitfor = FALSE

--- a/code/modules/ZAS/Fire.dm
+++ b/code/modules/ZAS/Fire.dm
@@ -93,6 +93,9 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 	var/fire_sprite = "fire"
 	var/fire_overlay = null
 
+	var/mutable_appearance/charred_overlay
+	var/last_char = 0
+
 	var/atom/movable/firelightdummy/firelightdummy
 
 /atom/movable/New()
@@ -159,6 +162,54 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 	if(reagents?.total_volume)
 		return TRUE
 
+/atom/proc/set_charred_overlay()
+	return
+
+/atom/proc/process_charred_overlay()
+	return
+
+/obj/set_charred_overlay(char_alpha = 96)
+	REMOVE_KEEP_TOGETHER(src, "ash_charred")
+	cut_overlay(charred_overlay)
+	var/mutable_appearance/new_charred_overlay = mutable_appearance('icons/effects/effects.dmi', "char", alpha = char_alpha, appearance_flags = RESET_COLOR|RESET_ALPHA)
+	new_charred_overlay.blend_mode = BLEND_INSET_OVERLAY
+	charred_overlay = new_charred_overlay
+	ADD_KEEP_TOGETHER(src, "ash_charred")
+	add_overlay(charred_overlay)
+
+/obj/process_charred_overlay()
+	if(thermal_mass)
+		var/c_alpha = 96 + clamp((64*(1-(thermal_mass/initial_thermal_mass))),0,64)
+		set_charred_overlay(c_alpha)
+		last_char = world.time
+	else
+		if(prob(10)) //10% chance each tick of item getting charred
+			set_charred_overlay()
+
+/obj/effect/process_charred_overlay()
+	return
+
+/turf/process_charred_overlay()
+	if(locate(/obj/effect/ash) in src)
+		var/obj/effect/ash/A = locate(/obj/effect/ash) in src
+		if(flammable)
+			A.alpha = clamp((80*(1-(thermal_mass/initial_thermal_mass))),0,80) //turf's char overlays aren't as harsh as objects'
+		else
+			A.alpha = 40
+	else
+		new /obj/effect/ash(src)
+
+/obj/effect/ash
+	name = "ash"
+	icon_state = "char"
+	alpha = 0
+	anchored = 1
+	mouse_opacity = 0
+
+/obj/effect/ash/clean_act(var/cleanliness)
+	if(cleanliness >= CLEANLINESS_WATER)
+		qdel(src)
+
 /**
  * Burns solid objects and produces heat.
  *
@@ -207,6 +258,9 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 	var/delta_m = 0.20 * burnrate * ZAS_mass_consumption_multiplier
 	useThermalMass(delta_m)
 	genSmoke(oxy_ratio,temperature,T)
+
+	if(world.time - last_char >= 10 SECONDS)
+		process_charred_overlay()
 
 	//Change in internal energy = energy produced by combustion (assuming perfect combustion).
 	heat_out = material.heating_value * delta_m
@@ -342,6 +396,9 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 	if(flammable && !on_fire)
 		ignite()
 		return TRUE
+	else
+		process_charred_overlay()
+	return FALSE
 
 /atom/proc/checkburn()
 	if(on_fire)


### PR DESCRIPTION
Reverts vgstation-coders/vgstation13#38575
Reinstates the ash overlays, cause they were NOT the source of the laghell, but rather the transparent pipes code (fixed partially here: #38591)

:cl:
* rscadd: Restores the ash overlays.