### PR TITLE
sliime lamp map oversight fix

### DIFF
--- a/maps/randomvaults/dungeons/habitation.dmm
+++ b/maps/randomvaults/dungeons/habitation.dmm
@@ -1519,7 +1519,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/table,
-/obj/item/device/flashlight/lamp/slime,
+/obj/item/device/flashlight/slime,
 /turf/unsimulated/floor/ayy/maint,
 /area/vault/mothership_lab/habitation)
 "ne" = (
@@ -3406,7 +3406,7 @@
 	dir = 8
 	},
 /obj/structure/table,
-/obj/item/device/flashlight/lamp/slime,
+/obj/item/device/flashlight/slime,
 /turf/unsimulated/floor/ayy/maint,
 /area/vault/mothership_lab/habitation)
 "Ec" = (
@@ -4099,7 +4099,7 @@
 /area/vault/mothership_lab/cave)
 "Ji" = (
 /obj/structure/table/reinforced,
-/obj/item/device/flashlight/lamp/slime,
+/obj/item/device/flashlight/slime,
 /turf/unsimulated/floor/ayy/fancy,
 /area/vault/mothership_lab/administration)
 "Jo" = (
@@ -5089,7 +5089,7 @@
 /area/vault/mothership_lab/habitation)
 "SL" = (
 /obj/structure/table,
-/obj/item/device/flashlight/lamp/slime,
+/obj/item/device/flashlight/slime,
 /turf/unsimulated/floor/ayy/maint,
 /area/vault/mothership_lab/habitation)
 "SO" = (

--- a/maps/randomvaults/dungeons/research.dmm
+++ b/maps/randomvaults/dungeons/research.dmm
@@ -1412,7 +1412,7 @@
 /area/vault/mothership_lab/maintenance)
 "nL" = (
 /obj/structure/table/reinforced,
-/obj/item/device/flashlight/lamp/slime,
+/obj/item/device/flashlight/slime,
 /turf/unsimulated/floor/ayy/fancy,
 /area/vault/mothership_lab/research)
 "nQ" = (

--- a/maps/randomvaults/thestranger.dmm
+++ b/maps/randomvaults/thestranger.dmm
@@ -108,7 +108,7 @@
 /area/vault/thestranger)
 "lG" = (
 /obj/structure/table/reinforced/clockwork,
-/obj/item/device/flashlight/lamp/slime{
+/obj/item/device/flashlight/slime{
 	color = "#00ccff";
 	name = "dreaming lamp";
 	desc = "There is yet life.";
@@ -220,7 +220,7 @@
 	icon_state = "jmwt3";
 	pixel_y = 30
 	},
-/obj/item/device/flashlight/lamp/slime{
+/obj/item/device/flashlight/slime{
 	color = "#00ccff";
 	name = "dreaming lamp";
 	desc = "There is yet life.";
@@ -232,7 +232,7 @@
 /turf/unsimulated/floor/lab_underplating,
 /area/vault/thestranger)
 "zd" = (
-/obj/item/device/flashlight/lamp/slime{
+/obj/item/device/flashlight/slime{
 	color = "#00ccff";
 	name = "dreaming lamp";
 	desc = "There is yet life.";
@@ -393,7 +393,7 @@
 	icon_state = "sunset";
 	pixel_x = -30
 	},
-/obj/item/device/flashlight/lamp/slime{
+/obj/item/device/flashlight/slime{
 	color = "#00ccff";
 	name = "dreaming lamp";
 	desc = "There is yet life.";
@@ -416,7 +416,7 @@
 	icon_state = "wizard";
 	pixel_x = 30
 	},
-/obj/item/device/flashlight/lamp/slime{
+/obj/item/device/flashlight/slime{
 	color = "#00ccff";
 	name = "dreaming lamp";
 	desc = "There is yet life.";
@@ -478,7 +478,7 @@
 	icon_state = "sunset";
 	pixel_x = -30
 	},
-/obj/item/device/flashlight/lamp/slime{
+/obj/item/device/flashlight/slime{
 	color = "#00ccff";
 	name = "dreaming lamp";
 	desc = "There is yet life.";
@@ -488,7 +488,7 @@
 /area/vault/thestranger)
 "Ug" = (
 /obj/structure/table/reinforced/clockwork,
-/obj/item/device/flashlight/lamp/slime{
+/obj/item/device/flashlight/slime{
 	color = "#00ccff";
 	name = "dreaming lamp";
 	desc = "There is yet life.";


### PR DESCRIPTION
## What this does
These 3 map files did NOT get updated when the slime lamps went from flashlight/lamp/slime to flashlight/slime
## Why it's good
Keeping the lights on, pun intended.
:cl:
 * bugfix: Fixes the slime lamp not appearing on the mothership vault and the "The Stranger" vault.