### PR TITLE
Removes All External Cycle Airlocks

### DIFF
--- a/maps/RoidStation.dmm
+++ b/maps/RoidStation.dmm
@@ -248,15 +248,6 @@
 /mob/living/simple_animal/hostile/asteroid/goliath,
 /turf/unsimulated/floor/asteroid,
 /area/mine/unexplored)
-"aaF" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_solars_ext_airlock_sensor";
-	master_tag = "vox_solars_airlock_control";
-	pixel_y = -24
-	},
-/turf/space,
-/area)
 "aaG" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -359,22 +350,6 @@
 "aaQ" = (
 /turf/simulated/wall,
 /area/vox_trading_post/solars)
-"aaR" = (
-/obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "vox_solars_airlock_exterior";
-	locked = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/vox,
-/area/vox_trading_post/solars)
 "aaS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/catwalk,
@@ -424,34 +399,6 @@
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/solars)
 "aaY" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	frequency = 1331;
-	id_tag = "vox_solars_airlock_pump"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1331;
-	id_tag = "vox_solars_airlock_control";
-	pixel_x = 24;
-	pixel_y = -5;
-	tag_airpump = "vox_solars_airlock_pump";
-	tag_chamber_sensor = "vox_solars_airlock_sensor";
-	tag_exterior_door = "vox_solars_airlock_exterior";
-	tag_exterior_sensor = "vox_solars_ext_airlock_sensor";
-	tag_interior_door = "vox_solars_airlock_interior";
-	tag_interior_sensor = "vox_solars_int_airlock_sensor"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_solars_airlock_sensor";
-	master_tag = "vox_solars_airlock_control";
-	pixel_x = 24;
-	pixel_y = 5
-	},
 /obj/effect/decal/warning_stripes{
 	dir = 9;
 	icon_state = "all";
@@ -461,6 +408,11 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/solars)
 "aaZ" = (
@@ -519,15 +471,8 @@
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/solars)
 "abf" = (
-/obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "vox_solars_airlock_interior";
-	locked = 1
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/obj/machinery/door/airlock/external,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -667,12 +612,6 @@
 	name = "Vox Outpost Solar Control";
 	track = 2
 	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_solars_int_airlock_sensor";
-	master_tag = "vox_solars_airlock_control";
-	pixel_y = 24
-	},
 /obj/effect/decal/warning_stripes{
 	dir = 1;
 	icon_state = "warning_corner";
@@ -686,7 +625,6 @@
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/solars)
 "abt" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -850,7 +788,6 @@
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/solars)
 "abG" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -1010,17 +947,10 @@
 /area/vox_trading_post/solars)
 "abS" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/solars)
 "abT" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 5;
-	tag = "icon-intact (NORTHEAST)"
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -2677,94 +2607,18 @@
 	},
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/hallway)
-"aeP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes{
-	dir = 1;
-	icon_state = "warning";
-	tag = "icon-warning (NORTH)"
-	},
-/obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "vox_dock_airlock_exterior";
-	locked = 1;
-	req_access_txt = "150"
-	},
-/turf/simulated/floor/plating/vox,
-/area/vox_trading_post/hallway)
 "aeQ" = (
 /obj/effect/decal/warning_stripes{
 	dir = 1;
 	icon_state = "warning";
 	tag = "icon-warning (NORTH)"
 	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_dock_ext_airlock_sensor";
-	master_tag = "vox_dock_airlock_control";
-	pixel_y = -24;
-	req_access_txt = "150"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	default_scrubbed_gases = list( "carbon_dioxide", "plasma", "oxygen" );
-	frequency = 1331;
-	name = "Outpost Air Scrubber";
-	on = 1
-	},
+/obj/machinery/light/small,
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/hallway)
 "aeR" = (
-/obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "vox_dock_airlock_interior";
-	locked = 1;
-	req_access_txt = "150"
-	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/vox,
-/area/vox_trading_post/hallway)
-"aeS" = (
-/obj/machinery/light/small,
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1331;
-	id_tag = "vox_dock_airlock_control";
-	pixel_x = 5;
-	pixel_y = 24;
-	req_access_txt = "150";
-	tag_airpump = "vox_dock_airlock_pump";
-	tag_chamber_sensor = "vox_dock_airlock_sensor";
-	tag_exterior_door = "vox_dock_airlock_exterior";
-	tag_exterior_sensor = "vox_dock_ext_airlock_sensor";
-	tag_interior_door = "vox_dock_airlock_interior";
-	tag_interior_sensor = "vox_dock_int_airlock_sensor"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_dock_airlock_sensor";
-	master_tag = "vox_dock_airlock_control";
-	pixel_x = -5;
-	pixel_y = 24;
-	req_access_txt = "150"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	canSpawnMice = 0;
-	dir = 4;
-	frequency = 1331;
-	id_tag = "vox_dock_airlock_pump"
-	},
-/obj/effect/decal/warning_stripes{
-	dir = 9;
-	icon_state = "all";
-	tag = "icon-all (NORTHWEST)"
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/hallway)
 "aeT" = (
@@ -2777,9 +2631,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 4
-	},
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/hallway)
 "aeU" = (
@@ -2789,17 +2640,7 @@
 	icon_state = "warning";
 	tag = "icon-warning (NORTHWEST)"
 	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_dock_int_airlock_sensor";
-	master_tag = "vox_dock_airlock_control";
-	pixel_y = 24;
-	req_access_txt = "150"
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 4
-	},
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/hallway)
 "aeV" = (
@@ -2809,9 +2650,6 @@
 	tag = "icon-warning (NORTH)"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 4
-	},
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/hallway)
 "aeW" = (
@@ -2821,9 +2659,6 @@
 	tag = "icon-warning (NORTHEAST)"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
-	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/hallway)
@@ -2993,10 +2828,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/vox,
-/area/vox_trading_post/hallway)
-"afr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/simulated/wall,
 /area/vox_trading_post/hallway)
 "afs" = (
 /obj/structure/grille,
@@ -3223,9 +3054,8 @@
 	dir = 4;
 	tag = "icon-map (EAST)"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layered{
-	dir = 4;
-	tag = "icon-map (EAST)"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
+	dir = 9
 	},
 /turf/simulated/floor/vox{
 	icon_state = "dark"
@@ -3345,14 +3175,6 @@
 	tag = "icon-cultdamage3"
 	},
 /area/mine/unexplored)
-"afW" = (
-/obj/machinery/atmospherics/unary/vent/high_volume{
-	dir = 1;
-	icon_state = "intact"
-	},
-/obj/structure/catwalk,
-/turf/space,
-/area)
 "afX" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -3570,20 +3392,12 @@
 	dir = 4;
 	tag = "icon-intact (EAST)"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
-	dir = 10;
-	tag = ""
-	},
 /turf/simulated/floor/vox{
 	icon_state = "dark"
 	},
 /area/vox_trading_post/trading_floor)
 "agp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layered{
-	dir = 5;
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
 	dir = 5;
 	tag = ""
 	},
@@ -3604,12 +3418,6 @@
 	},
 /area/vox_trading_post/trading_floor)
 "agr" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_trading_int_airlock_sensor";
-	master_tag = "vox_trading_airlock_control";
-	pixel_y = -24
-	},
 /obj/machinery/atmospherics/pipe/layer_adapter/supply/hidden{
 	dir = 4;
 	tag = "icon-adapter_2 (EAST)"
@@ -3915,24 +3723,9 @@
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/armory)
 "agT" = (
-/obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "vox_trading_airlock_interior";
-	locked = 1
-	},
-/obj/machinery/atmospherics/pipe/layer_adapter/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor/plating/vox,
-/area/vox_trading_post/trading_floor)
-"agU" = (
-/obj/machinery/atmospherics/binary/pump{
-	icon_state = "intact_on";
-	on = 1;
-	target_pressure = 900
-	},
-/turf/simulated/wall,
 /area/vox_trading_post/trading_floor)
 "agV" = (
 /obj/structure/window/reinforced,
@@ -4140,12 +3933,6 @@
 	icon_state = "dark"
 	},
 /area/vox_trading_post/armory)
-"aho" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/simulated/wall,
-/area/vox_trading_post/armory)
 "ahp" = (
 /obj/structure/closet,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -4156,7 +3943,6 @@
 	},
 /area/vox_trading_post/armory)
 "ahq" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes{
 	dir = 1;
@@ -4166,11 +3952,6 @@
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/trading_floor)
 "ahr" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 4;
-	frequency = 1331;
-	id_tag = "vox_trading_airlock_pump"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes{
 	dir = 9;
@@ -4179,37 +3960,7 @@
 	},
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/trading_floor)
-"ahs" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/vox_trading_post/trading_floor)
 "aht" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 8;
-	frequency = 1331;
-	id_tag = "vox_trading_airlock_pump"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_trading_airlock_sensor";
-	master_tag = "vox_trading_airlock_control";
-	pixel_x = -5;
-	pixel_y = 24
-	},
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1331;
-	id_tag = "vox_trading_airlock_control";
-	pixel_x = 5;
-	pixel_y = 24;
-	tag_airpump = "vox_trading_airlock_pump";
-	tag_chamber_sensor = "vox_trading_airlock_sensor";
-	tag_exterior_door = "vox_trading_airlock_exterior";
-	tag_exterior_sensor = "vox_trading_ext_airlock_sensor";
-	tag_interior_door = "vox_trading_airlock_interior";
-	tag_interior_sensor = "vox_trading_int_airlock_sensor"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes{
 	dir = 5;
@@ -4218,15 +3969,6 @@
 	},
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/trading_floor)
-"ahu" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_trading_ext_airlock_sensor";
-	master_tag = "vox_trading_airlock_control";
-	pixel_x = -24
-	},
-/turf/unsimulated/floor/asteroid,
-/area/mine/explored)
 "ahv" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 1
@@ -4391,12 +4133,6 @@
 	icon_state = "dark"
 	},
 /area/vox_trading_post/armory)
-"ahI" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/simulated/wall,
-/area/vox_trading_post/armory)
 "ahJ" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -4418,16 +4154,10 @@
 	},
 /area/vox_trading_post/armory)
 "ahK" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/trading_floor)
 "ahL" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 4;
-	frequency = 1331;
-	id_tag = "vox_trading_airlock_pump"
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -4440,26 +4170,12 @@
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/trading_floor)
 "ahM" = (
-/obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "vox_trading_airlock_exterior";
-	locked = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/trading_floor)
 "ahN" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 8;
-	frequency = 1331;
-	id_tag = "vox_trading_airlock_pump"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes{
 	dir = 4;
@@ -4594,7 +4310,6 @@
 	},
 /area/vox_trading_post/armory)
 "aic" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes{
 	icon_state = "warning";
@@ -4603,11 +4318,6 @@
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/trading_floor)
 "aid" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 4;
-	frequency = 1331;
-	id_tag = "vox_trading_airlock_pump"
-	},
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes{
@@ -4618,11 +4328,6 @@
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/trading_floor)
 "aie" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 8;
-	frequency = 1331;
-	id_tag = "vox_trading_airlock_pump"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes{
 	dir = 6;
@@ -4696,31 +4401,6 @@
 	tag = "icon-freezerfloor"
 	},
 /area/vox_trading_post/dorms)
-"ail" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/simulated/wall,
-/area/vox_trading_post/armory)
-"aim" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/simulated/wall,
-/area/vox_trading_post/trading_floor)
-"ain" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/vox_trading_post/trading_floor)
-"aio" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/simulated/wall,
-/area/vox_trading_post/trading_floor)
 "aip" = (
 /obj/structure/hanging_lantern{
 	dir = 8
@@ -20290,22 +19970,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/explored)
-"aOj" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "MINE_ext_airlock_sensor";
-	master_tag = "MINE_airlock_control";
-	pixel_y = -18
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/unsimulated/floor/airless{
-	icon_state = "asteroidplating"
-	},
-/area/mine/explored)
 "aOk" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -22212,10 +21876,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 4;
-	frequency = 1331;
-	id_tag = "MINE_airlock_pump"
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8;
+	on = 1
 	},
 /turf/simulated/floor/plating,
 /area/mine/lobby)
@@ -22225,9 +21888,6 @@
 	},
 /obj/machinery/recharger{
 	pixel_x = 29
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/mine/lobby)
@@ -23278,12 +22938,6 @@
 	icon_state = "floorgrime"
 	},
 /area/supply/sorting)
-"aTA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/simulated/floor,
-/area/mine/lobby)
 "aTB" = (
 /obj/effect/decal/warning_stripes{
 	dir = 8;
@@ -23445,11 +23099,6 @@
 	},
 /area/mine/explored)
 "aTU" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 4;
-	frequency = 1331;
-	id_tag = "MINE_airlock_pump"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -23461,35 +23110,11 @@
 /obj/machinery/recharger{
 	pixel_x = 29
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/mine/lobby)
 "aTW" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1331;
-	id_tag = "MINE_airlock_control";
-	name = "Mining Airlock Controller";
-	pixel_x = -24;
-	tag_airpump = "MINE_airlock_pump";
-	tag_chamber_sensor = "MINE_airlock_sensor";
-	tag_exterior_door = "MINE_airlock_exterior";
-	tag_exterior_sensor = "MINE_ext_airlock_sensor";
-	tag_interior_door = "MINE_airlock_interior";
-	tag_interior_sensor = "MINE_int_airlock_sensor"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "MINE_airlock_sensor";
-	master_tag = "MINE_airlock_control";
-	pixel_x = -24;
-	pixel_y = -10
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor/plating,
 /area/mine/lobby)
 "aTX" = (
@@ -24538,21 +24163,6 @@
 /obj/structure/plasticflaps/mining,
 /turf/simulated/floor/plating,
 /area/mine/production)
-"aVL" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/simulated/floor/plating,
-/area/mine/lobby)
 "aVM" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -25691,16 +25301,6 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
 	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "MINE_int_airlock_sensor";
-	master_tag = "MINE_airlock_control";
-	pixel_y = 22
-	},
-/turf/simulated/floor,
-/area/mine/lobby)
-"aXX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor,
 /area/mine/lobby)
 "aXY" = (
@@ -29433,9 +29033,6 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/simulated/floor,
 /area/mine/lobby)
 "beP" = (
@@ -29448,8 +29045,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
 	},
 /turf/simulated/floor,
 /area/mine/lobby)
@@ -102438,30 +102035,14 @@
 	name = "\improper Security E.V.A"
 	})
 "dIa" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/wall/r_wall,
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
-"dIb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
+/turf/simulated/floor,
+/area/mine/lobby)
 "dIc" = (
-/turf/simulated/wall/r_wall,
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
-"dId" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /turf/simulated/wall/r_wall,
 /area/security/range{
 	name = "\improper Security E.V.A"
@@ -102506,10 +102087,7 @@
 	name = "EXTERNAL AIRLOCK";
 	pixel_x = -32
 	},
-/obj/structure/closet/emcloset,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -102898,13 +102476,6 @@
 /area/maintenance/asmaint3)
 "dIQ" = (
 /obj/structure/catwalk,
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "sec_eva_ext_airlock_sensor";
-	master_tag = "sec_eva_airlock_control";
-	pixel_x = 24;
-	req_access_txt = "63"
-	},
 /obj/machinery/camera{
 	dir = 8;
 	name = "Security E.V.A. External"
@@ -102916,31 +102487,6 @@
 	dir = 5;
 	icon_state = "warning";
 	tag = "icon-warning (NORTHEAST)"
-	},
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1331;
-	id_tag = "sec_eva_airlock_control";
-	pixel_x = 5;
-	pixel_y = 24;
-	req_access_txt = "63";
-	tag_airpump = "sec_eva_airlock_pump";
-	tag_chamber_sensor = "sec_eva_airlock_sensor";
-	tag_exterior_door = "sec_eva_ext_airlock";
-	tag_exterior_sensor = "sec_eva_ext_airlock_sensor";
-	tag_interior_door = "sec_eva_int_airlock";
-	tag_interior_sensor = "sec_eva_int_airlock_sensor"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "sec_eva_airlock_sensor";
-	master_tag = "sec_eva_airlock_control";
-	pixel_x = -5;
-	pixel_y = 24;
-	req_access_txt = "63"
-	},
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	frequency = 1331;
-	id_tag = "sec_eva_airlock_pump"
 	},
 /turf/simulated/floor/plating,
 /area/security/range{
@@ -102955,10 +102501,7 @@
 	icon_state = "warning";
 	tag = "icon-warning (NORTHWEST)"
 	},
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	frequency = 1331;
-	id_tag = "sec_eva_airlock_pump"
-	},
+/obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
 /area/security/range{
 	name = "\improper Security E.V.A"
@@ -102973,24 +102516,7 @@
 /area/security/range{
 	name = "\improper Security E.V.A"
 	})
-"dIU" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
 "dIV" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "sec_eva_int_airlock_sensor";
-	master_tag = "sec_eva_airlock_control";
-	pixel_x = -24;
-	req_access_txt = "63"
-	},
 /obj/effect/decal/warning_stripes{
 	dir = 8;
 	icon_state = "warning_corner";
@@ -102999,7 +102525,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -103341,7 +102866,6 @@
 	icon_state = "warning";
 	tag = "icon-warning (EAST)"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /turf/simulated/floor/plating,
 /area/security/range{
 	name = "\improper Security E.V.A"
@@ -103351,15 +102875,7 @@
 	dir = 4;
 	name = "Firelock East"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "sec_eva_int_airlock";
-	locked = 1;
 	name = "Security External Airlock";
 	req_access_txt = "63"
 	},
@@ -103369,11 +102885,6 @@
 	})
 "dJG" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "sec_eva_ext_airlock";
-	locked = 1;
 	name = "Security External Airlock";
 	req_access_txt = "63"
 	},
@@ -103387,9 +102898,6 @@
 	icon_state = "warning";
 	tag = "icon-warning (WEST)"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
 /turf/simulated/floor/plating,
 /area/security/range{
 	name = "\improper Security E.V.A"
@@ -103400,28 +102908,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
-"dJJ" = (
-/obj/structure/rack,
-/obj/item/weapon/tank/jetpack,
-/obj/item/weapon/tank/jetpack,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
+/obj/structure/table,
+/obj/item/weapon/reagent_containers/food/drinks/gromitmug,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -103439,10 +102927,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -103457,9 +102941,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -103950,11 +103431,6 @@
 	icon_state = "warning";
 	tag = "icon-warning (SOUTHEAST)"
 	},
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 1;
-	frequency = 1331;
-	id_tag = "sec_eva_airlock_pump"
-	},
 /turf/simulated/floor/plating,
 /area/security/range{
 	name = "\improper Security E.V.A"
@@ -103982,11 +103458,6 @@
 	icon_state = "warning";
 	tag = "icon-warning (SOUTHWEST)"
 	},
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 1;
-	frequency = 1331;
-	id_tag = "sec_eva_airlock_pump"
-	},
 /turf/simulated/floor/plating,
 /area/security/range{
 	name = "\improper Security E.V.A"
@@ -104002,18 +103473,7 @@
 /area/security/range{
 	name = "\improper Security E.V.A"
 	})
-"dKA" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
 "dKB" = (
-/obj/machinery/meter,
 /obj/effect/decal/warning_stripes{
 	dir = 1;
 	icon_state = "warning_corner";
@@ -104024,7 +103484,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -104453,37 +103912,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/prison/engineering)
-"dLq" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/simulated/wall/r_wall,
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
-"dLr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/simulated/wall/r_wall,
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
-"dLs" = (
-/obj/machinery/suit_storage_unit/security,
-/obj/structure/window/reinforced,
-/obj/effect/decal/warning_stripes{
-	dir = 1;
-	icon_state = "warning";
-	tag = "icon-warning (NORTH)"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
 "dLt" = (
 /obj/machinery/suit_storage_unit/security,
 /obj/structure/window/reinforced,
@@ -104491,9 +103919,6 @@
 	dir = 1;
 	icon_state = "warning";
 	tag = "icon-warning (NORTH)"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -104518,7 +103943,6 @@
 	dir = 1;
 	name = "Security E.V.A."
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -104535,9 +103959,6 @@
 	dir = 1;
 	icon_state = "warning";
 	tag = "icon-warning (NORTH)"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -149746,8 +149167,8 @@ aaa
 aaa
 aeu
 aeQ
-afr
-afW
+acy
+adZ
 agA
 aaa
 aai
@@ -150247,7 +149668,7 @@ aaa
 aaa
 aaa
 aet
-aeP
+aeO
 afq
 aaa
 agz
@@ -150749,7 +150170,7 @@ aaa
 aaa
 aaa
 acy
-aeS
+aeO
 aft
 aaa
 agz
@@ -157763,7 +157184,7 @@ aaa
 aae
 aaB
 aaG
-aaR
+abf
 aaY
 abf
 abt
@@ -158264,7 +157685,7 @@ aaa
 aaa
 aaa
 aaa
-aaF
+aaa
 aaQ
 aaQ
 aaQ
@@ -161295,10 +160716,10 @@ acy
 afH
 acy
 agR
-aho
-ahI
-ahI
-ail
+agR
+agR
+agR
+agR
 aeI
 aeI
 aeI
@@ -161800,7 +161221,7 @@ adw
 ahr
 ahL
 aid
-ain
+adw
 aeI
 aeI
 aeI
@@ -162302,7 +161723,7 @@ agT
 ahq
 ahK
 aic
-aim
+adw
 aeI
 aeI
 aeI
@@ -162804,7 +162225,7 @@ adw
 aht
 ahN
 aie
-ain
+adw
 aeI
 aeI
 aeI
@@ -163302,11 +162723,11 @@ adw
 adR
 adR
 agq
-agU
-ahs
+adw
+adw
 ahM
-ahs
-aio
+adw
+adw
 aeI
 aeI
 aeI
@@ -163805,7 +163226,7 @@ adR
 afM
 ags
 agW
-ahu
+afl
 afl
 afl
 aeH
@@ -165818,7 +165239,7 @@ afl
 afl
 afl
 aeI
-aab
+aeI
 aeI
 aeI
 aab
@@ -213803,11 +213224,11 @@ dEc
 dCD
 dEc
 dCD
-dId
+dIc
 dIS
 dJH
 dKy
-dLr
+dIc
 ant
 aaa
 aaa
@@ -214305,11 +213726,11 @@ dDZ
 dEZ
 dGf
 dHf
-dIa
+dIc
 dIR
 dJE
 dKw
-dLq
+dIc
 ant
 aaa
 aaa
@@ -214807,11 +214228,11 @@ dEa
 dFa
 dGg
 dEj
-dIb
+dIc
 dIc
 dJF
 dKx
-dIb
+dIc
 ant
 aqC
 aqC
@@ -216317,7 +215738,7 @@ dIe
 dIT
 dJI
 dKz
-dLs
+dLt
 dIc
 dMC
 dNm
@@ -216816,9 +216237,9 @@ dFc
 dGj
 dEj
 dIf
-dIU
-dJJ
-dKA
+dIZ
+dJL
+dKD
 dLt
 dIc
 dMj
@@ -267419,7 +266840,7 @@ aot
 afl
 afl
 aod
-aOj
+aOk
 aPY
 aPY
 aPY
@@ -267929,7 +267350,7 @@ aVM
 aXV
 aXV
 bcE
-beN
+dIa
 bhE
 aPY
 bmt
@@ -268929,11 +268350,11 @@ afl
 aPX
 aRE
 aTV
-aVL
-aXX
-aXX
-aXX
-aTA
+aPZ
+bal
+bal
+bal
+bal
 bhC
 aPY
 bmr

--- a/maps/bagelstation.dmm
+++ b/maps/bagelstation.dmm
@@ -94035,8 +94035,8 @@
 	},
 /area/prison/medical)
 "edw" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -94150,20 +94150,6 @@
 	icon_state = "dark"
 	},
 /area/prison/hallway/aft)
-"edE" = (
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/prison/hallway/aft)
 "edF" = (
 /obj/machinery/suit_storage_unit/security,
 /turf/simulated/floor{
@@ -94234,35 +94220,9 @@
 	dir = 8
 	},
 /obj/structure/flora/pottedplant/random,
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "pris_int_airlock_sensor";
-	master_tag = "pris_airlock_control";
-	pixel_y = -24
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/prison/hallway/aft)
-"edM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/full/reinforced,
-/obj/structure/cable/orange{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
 /area/prison/hallway/aft)
 "edN" = (
 /obj/structure/cable/orange{
@@ -94281,11 +94241,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "pris_airlock_interior";
-	locked = 1
+	name = "Security External Airlock";
+	req_access_txt = "63"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -94338,11 +94295,6 @@
 	},
 /area/security/toilet)
 "edR" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 8;
-	frequency = 1331;
-	id_tag = "pris_airlock_pump"
-	},
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 2;
@@ -94352,6 +94304,10 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4;
+	on = 1
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -94381,20 +94337,6 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1331;
-	id_tag = "pris_airlock_control";
-	pixel_x = -24;
-	tag_airpump = "pris_airlock_pump";
-	tag_chamber_sensor = "pris_airlock_sensor";
-	tag_exterior_door = "pris_airlock_exterior";
-	tag_exterior_sensor = "pris_ext_airlock_sensor";
-	tag_interior_door = "pris_airlock_interior";
-	tag_interior_sensor = "pris_int_airlock_sensor"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -94441,13 +94383,6 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "pris_airlock_sensor";
-	master_tag = "pris_airlock_control";
-	pixel_x = -24;
-	pixel_y = 21
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -94544,10 +94479,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/production)
-"eem" = (
-/obj/structure/disposalpipe/segment,
-/turf/unsimulated/mineral/random,
-/area/mine/unexplored)
 "een" = (
 /turf/unsimulated/floor/asteroid/plating,
 /area/mine/production)
@@ -94558,17 +94489,6 @@
 	},
 /turf/unsimulated/floor/asteroid,
 /area/mine/explored)
-"eep" = (
-/turf/space,
-/area/research_outpost/hallway)
-"eeq" = (
-/turf/unsimulated/floor/asteroid,
-/area/research_outpost/hallway)
-"eer" = (
-/turf/unsimulated/floor/airless{
-	icon_state = "asteroidplating"
-	},
-/area/research_outpost/hallway)
 "ees" = (
 /obj/structure/sink/puddle,
 /obj/item/fish_eggs/goldfish,
@@ -94606,13 +94526,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "eex" = (
-/obj/structure/hanging_lantern,
-/turf/unsimulated/floor/asteroid,
-/area/research_outpost/hallway)
-"eey" = (
-/obj/structure/ore_box,
-/turf/unsimulated/floor/asteroid,
-/area/research_outpost/hallway)
+/turf/simulated/floor/plating,
+/area/mine/explored)
 "eez" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "warning-asteroid";
@@ -94742,21 +94657,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/research_outpost/hallway)
-"eeR" = (
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/mine/production)
 "eeS" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -94874,7 +94774,7 @@
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidplating"
 	},
-/area/research_outpost/hallway)
+/area/mine/explored)
 "eff" = (
 /obj/machinery/suit_storage_unit/mining,
 /obj/effect/decal/warning_stripes{
@@ -94950,9 +94850,22 @@
 /turf/simulated/floor,
 /area/engineering/supermatter_room)
 "efl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/simulated/floor,
-/area/mine/production)
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	icon_state = "shutter0";
+	id_tag = "bar";
+	name = "Bar Shutters";
+	opacity = 0
+	},
+/obj/item/weapon/reagent_containers/food/drinks/gromitmug,
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/crew_quarters/bar)
 "efm" = (
 /turf/simulated/floor,
 /area/mine/production)
@@ -95294,9 +95207,6 @@
 	},
 /area/mine/production)
 "efW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor,
 /area/mine/production)
@@ -103579,8 +103489,11 @@
 /turf/space,
 /area)
 "evR" = (
-/turf/unsimulated/floor/asteroid,
-/area)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/simulated/floor,
+/area/mine/production)
 "evS" = (
 /obj/structure/cable/yellow,
 /obj/structure/cable/yellow{
@@ -103589,7 +103502,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/simulated/floor/plating,
-/area)
+/area/mine/explored)
 "evT" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -104282,12 +104195,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/space,
-/area)
-"ewU" = (
-/obj/structure/hanging_lantern{
-	dir = 1
-	},
-/turf/unsimulated/floor/asteroid,
 /area)
 "ewV" = (
 /obj/structure/window/reinforced{
@@ -111639,13 +111546,6 @@
 /obj/item/clothing/accessory/rad_patch,
 /turf/simulated/floor,
 /area/engineering/supermatter_room)
-"eKZ" = (
-/obj/machinery/conveyor_switch/oneway{
-	id_tag = "mining_internal";
-	name = "mining conveyor"
-	},
-/turf/unsimulated/floor/asteroid,
-/area/research_outpost/hallway)
 "eLa" = (
 /obj/machinery/mineral/unloading_machine,
 /turf/simulated/floor/plating,
@@ -112549,53 +112449,27 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "pris_airlock_exterior";
-	locked = 1
+	name = "Security External Airlock";
+	req_access_txt = "63"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
 /area/prison/hallway/aft)
-"eNp" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "pris_ext_airlock_sensor";
-	master_tag = "pris_airlock_control";
-	pixel_x = -24;
-	pixel_y = 21
-	},
-/turf/unsimulated/floor/asteroid,
-/area/mine/explored)
 "eNq" = (
 /obj/machinery/camera{
 	dir = 1;
 	name = "Outpost Exit";
 	network = list("MINE","RD","SS13")
 	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "MINE_ext_airlock_sensor";
-	master_tag = "MINE_airlock_control";
-	pixel_y = -18
-	},
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidplating"
 	},
 /area/mine/explored)
-"eNr" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "MINE_airlock_exterior"
-	},
-/turf/simulated/floor/plating,
-/area/mine/production)
 "eNs" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 8;
-	frequency = 1331;
-	id_tag = "MINE_airlock_pump"
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4;
+	on = 1
 	},
 /turf/simulated/floor/plating,
 /area/mine/production)
@@ -112610,34 +112484,10 @@
 /area/mine/production)
 "eNu" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1331;
-	id_tag = "MINE_airlock_control";
-	name = "Mining Airlock Controller";
-	pixel_x = -24;
-	tag_airpump = "MINE_airlock_pump";
-	tag_chamber_sensor = "MINE_airlock_sensor";
-	tag_exterior_door = "MINE_airlock_exterior";
-	tag_exterior_sensor = "MINE_ext_airlock_sensor";
-	tag_interior_door = "MINE_airlock_interior";
-	tag_interior_sensor = "MINE_int_airlock_sensor"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "MINE_airlock_sensor";
-	master_tag = "MINE_airlock_control";
-	pixel_x = -24;
-	pixel_y = -10
-	},
 /turf/simulated/floor/plating,
 /area/mine/production)
 "eNv" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "MINE_airlock_interior"
-	},
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor/plating,
 /area/mine/production)
 "eNw" = (
@@ -112645,12 +112495,6 @@
 /obj/machinery/camera{
 	name = "Outpost Expedition Preperation";
 	network = list("MINE","RD","SS13")
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "MINE_int_airlock_sensor";
-	master_tag = "MINE_airlock_control";
-	pixel_y = 22
 	},
 /turf/simulated/floor,
 /area/mine/production)
@@ -114552,7 +114396,7 @@
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidplating"
 	},
-/area/research_outpost/hallway)
+/area/mine/explored)
 "vcX" = (
 /obj/structure/table,
 /obj/machinery/sewing_machine{
@@ -216476,7 +216320,7 @@ bXD
 bZI
 cbF
 cdy
-bXD
+efl
 chg
 cbI
 bZS
@@ -1213511,7 +1213355,7 @@ erz
 erz
 euT
 evw
-evR
+dRu
 aaa
 aaa
 aaa
@@ -1214013,8 +1213857,8 @@ erz
 erz
 euU
 evw
-evR
-evR
+dRu
+dRu
 aaa
 aaa
 aaa
@@ -1215017,10 +1214861,10 @@ erE
 erz
 erz
 evw
-evR
-evR
-evR
-evR
+dRu
+dRu
+dRu
+dRu
 aaa
 aaa
 aaa
@@ -1215519,11 +1215363,11 @@ erE
 euJ
 euJ
 evy
-evR
-evR
-evR
-evR
-evR
+dRu
+dRu
+dRu
+dRu
+dRu
 aaa
 aaa
 aaa
@@ -1216021,13 +1215865,13 @@ eur
 euK
 euV
 erk
-evR
-evR
-evR
-evR
-evR
-evR
-evR
+dRu
+dRu
+dRu
+dRu
+dRu
+dRu
+dRu
 aax
 aax
 aax
@@ -1216526,11 +1216370,11 @@ erk
 eeE
 eeE
 ewD
-ewU
-evR
-evR
-evR
-evR
+dSS
+dRu
+dRu
+dRu
+dRu
 aax
 aaa
 aaa
@@ -1216869,13 +1216713,13 @@ dVz
 dYI
 dVz
 edw
-edE
-dVz
-edM
+edG
+dVy
+edW
 edT
 edX
 edW
-eNp
+dRu
 dRu
 dRu
 dQU
@@ -1217028,11 +1216872,11 @@ evz
 evT
 ewn
 ewE
-evR
-evR
-evR
-evR
-evR
+dRu
+dRu
+dRu
+dRu
+dRu
 ezn
 ezn
 ezn
@@ -1217530,11 +1217374,11 @@ evA
 evU
 evU
 evA
-evR
-evR
-evR
-evR
-evR
+dRu
+dRu
+dRu
+dRu
+dRu
 ezn
 ezP
 eAn
@@ -1218032,11 +1217876,11 @@ eeE
 evV
 ewo
 ewD
-evR
-evR
-evR
-evR
-evR
+dRu
+dRu
+dRu
+dRu
+dRu
 ezn
 ezQ
 eAo
@@ -1218531,14 +1218375,14 @@ esj
 esj
 euZ
 eeE
-evR
-evR
-evR
-evR
-evR
-evR
-evR
-evR
+dRu
+dRu
+dRu
+dRu
+dRu
+dRu
+dRu
+dRu
 ezn
 ezR
 eAp
@@ -1218990,9 +1218834,9 @@ aaa
 aaa
 aaa
 aaa
-eep
-eep
-eep
+aaa
+aaa
+aaa
 eeM
 eeZ
 eeO
@@ -1219033,13 +1218877,13 @@ esj
 esj
 esj
 efu
-evR
-evR
-evR
-evR
-evR
-evR
-evR
+dRu
+dRu
+dRu
+dRu
+dRu
+dRu
+dRu
 aaa
 ezn
 ezS
@@ -1219491,10 +1219335,10 @@ aaa
 aaa
 aaa
 aaa
-eep
-eep
-eep
-eep
+aaa
+aaa
+aaa
+aaa
 eeM
 efa
 eeO
@@ -1219535,12 +1219379,12 @@ esj
 esj
 esj
 efv
-evR
-evR
-evR
-evR
-evR
-evR
+dRu
+dRu
+dRu
+dRu
+dRu
+dRu
 aaa
 aaa
 ezn
@@ -1219992,11 +1219836,11 @@ aaa
 aaa
 aaa
 aaa
-eep
-eep
-eep
-eep
-eep
+aaa
+aaa
+aaa
+aaa
+aaa
 eeM
 efb
 eeP
@@ -1220037,12 +1219881,12 @@ eNx
 esj
 esj
 efw
-evR
-evR
-evR
-evR
-evR
-evR
+dRu
+dRu
+dRu
+dRu
+dRu
+dRu
 aaa
 aaa
 ezn
@@ -1220494,11 +1220338,11 @@ aaa
 aaa
 aaa
 aaa
-eep
-eep
-eep
-eep
-eep
+aaa
+aaa
+aaa
+aaa
+aaa
 eeM
 efc
 eft
@@ -1220539,11 +1220383,11 @@ eeE
 euL
 euL
 eeE
-evR
-evR
-evR
-evR
-ade
+dRu
+dRu
+dRu
+dRu
+eex
 aax
 aaa
 aaa
@@ -1220996,11 +1220840,11 @@ aaa
 aaa
 aaa
 aaa
-eep
-eeq
-eeq
-eeq
-eeq
+aaa
+dRu
+dRu
+dRu
+dRu
 eeM
 eeX
 eeM
@@ -1221498,10 +1221342,10 @@ aaa
 aaa
 aaa
 aaa
-eeq
-eeq
-eeq
-eex
+dRu
+dRu
+dRu
+dRA
 eeE
 eeE
 efd
@@ -1222000,9 +1221844,9 @@ aaa
 aaa
 aaa
 dRu
-eer
-eer
-eer
+edd
+edd
+edd
 efe
 eLa
 eeQ
@@ -1222502,9 +1222346,9 @@ aaa
 aaa
 dRu
 dRu
-eer
-eer
-eer
+edd
+edd
+edd
 uTp
 eLa
 eeQ
@@ -1223004,10 +1222848,10 @@ dRu
 dRu
 dRu
 dRu
-eer
-eer
-eKZ
-eex
+edd
+edd
+eeo
+dRA
 eeE
 eeu
 eeu
@@ -1223506,11 +1223350,11 @@ dRu
 dRu
 dRu
 dRu
-eer
-eer
-eeq
-eey
-eey
+edd
+edd
+dRu
+dTT
+dTT
 eeu
 eff
 efm
@@ -1224008,11 +1223852,11 @@ dRu
 dRu
 dRu
 dRu
-eer
-eer
-eeq
-eey
-eey
+edd
+edd
+dRu
+dTT
+dTT
 eeu
 efg
 efx
@@ -1224511,10 +1224355,10 @@ dRu
 dRu
 dRu
 edd
-eer
-eeq
-eeq
-eey
+edd
+dRu
+dRu
+dTT
 eeu
 efh
 efy
@@ -1225014,9 +1224858,9 @@ dRu
 eeo
 edd
 edd
-eeq
-eeq
-eey
+dRu
+dRu
+dTT
 eeu
 efh
 efm
@@ -1227028,7 +1226872,7 @@ eeu
 eeu
 eNw
 efx
-efS
+evR
 egs
 egJ
 egZ
@@ -1227527,9 +1227371,9 @@ edd
 eev
 eeB
 eNu
-eeR
-efl
-efl
+eev
+efm
+efm
 efW
 egr
 egK
@@ -1228026,7 +1227870,7 @@ eef
 eef
 edd
 edd
-eNr
+eNv
 eeC
 eNs
 eNv
@@ -1259145,21 +1258989,21 @@ dQU
 dQU
 dQU
 dQU
-eem
-eem
-eem
-eem
-eem
-eem
-eem
-eem
-eem
-eem
-eem
-eem
-eem
-eem
-eem
+dQU
+dQU
+dQU
+dQU
+dQU
+dQU
+dQU
+dQU
+dQU
+dQU
+dQU
+dQU
+dQU
+dQU
+dQU
 dQU
 dQU
 dQU

--- a/maps/defficiency.dmm
+++ b/maps/defficiency.dmm
@@ -5678,14 +5678,6 @@
 /turf/simulated/wall/r_wall,
 /area/tcomms/chamber)
 "alU" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "toxins_west_ext_sensor";
-	master_tag = "toxins_west_control";
-	pixel_x = 4;
-	pixel_y = -24;
-	req_access_txt = "13"
-	},
 /obj/machinery/camera{
 	dir = 1;
 	name = "Science - Toxins Maintenance (Outside)"
@@ -6078,33 +6070,12 @@
 /area/engine/rust_control)
 "amL" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "toxins_west_ext_airlock";
-	locked = 1;
 	name = "Toxins Western External Airlock";
 	req_access_txt = "13"
 	},
 /turf/simulated/floor/plating/airless,
 /area/maintenance/fore)
 "amM" = (
-/turf/simulated/wall,
-/area/maintenance/fore)
-"amN" = (
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1331;
-	id_tag = "toxins_west_control";
-	pixel_x = -7;
-	pixel_y = 8;
-	req_access_txt = "13";
-	tag_airpump = "toxins_west_pump";
-	tag_chamber_sensor = "toxins_west_sensor";
-	tag_exterior_door = "toxins_west_ext_airlock";
-	tag_exterior_sensor = "toxins_west_ext_sensor";
-	tag_interior_door = "toxins_west_int_airlock";
-	tag_interior_sensor = "toxins_west_int_sensor"
-	},
 /turf/simulated/wall,
 /area/maintenance/fore)
 "amO" = (
@@ -6511,36 +6482,12 @@
 /turf/simulated/floor/plating/airless,
 /area/engine/rust_control)
 "anE" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "toxins_west_sensor";
-	master_tag = "toxins_west_control";
-	pixel_x = 24;
-	req_access_txt = "13"
-	},
 /obj/machinery/camera{
 	dir = 8;
 	name = "Science - Toxins Maintenance Western Airlock";
 	pixel_y = -22
 	},
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 4;
-	frequency = 1331;
-	id_tag = "toxins_west_pump"
-	},
 /turf/simulated/floor/plating,
-/area/maintenance/fore)
-"anF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/simulated/wall,
-/area/maintenance/fore)
-"anG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/simulated/wall,
 /area/maintenance/fore)
 "anH" = (
 /obj/machinery/door/poddoor{
@@ -7045,26 +6992,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/engine/rust_control)
-"aoJ" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 4;
-	frequency = 1331;
-	id_tag = "toxins_west_pump"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fore)
-"aoK" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/simulated/wall,
-/area/maintenance/fore)
-"aoL" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/maintenance/fore)
 "aoM" = (
 /obj/effect/decal/warning_stripes{
 	dir = 1;
@@ -7073,17 +7000,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/maintenance/fore)
-"aoN" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "toxins_east_ext_sensor";
-	master_tag = "toxins_east_control";
-	pixel_x = 4;
-	pixel_y = -24;
-	req_access_txt = "13"
-	},
-/turf/space,
-/area)
 "aoO" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -7631,26 +7547,10 @@
 /area/engine/turbine_control)
 "apQ" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "toxins_west_int_airlock";
-	locked = 1;
-	name = "Toxins Western Internal Airlock";
+	name = "Toxins Western External Airlock";
 	req_access_txt = "13"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fore)
-"apR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/meter{
-	desc = "A gas flow meter. If the pressure is low, the airlock will be slow to pressurize. If that happens, call your local atmos tech."
-	},
-/turf/simulated/wall,
-/area/maintenance/fore)
-"apS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/simulated/wall,
 /area/maintenance/fore)
 "apT" = (
 /turf/simulated/floor/plating/airless,
@@ -7662,31 +7562,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "toxins_east_ext_airlock";
-	locked = 1;
 	name = "Testing Eastern External Airlock";
 	req_access_txt = "13"
 	},
 /turf/simulated/floor/plating/airless,
-/area/maintenance/fpmaint)
-"apV" = (
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1331;
-	id_tag = "toxins_east_control";
-	pixel_x = -7;
-	pixel_y = 8;
-	req_access_txt = "13";
-	tag_airpump = "toxins_east_pump";
-	tag_chamber_sensor = "toxins_east_sensor";
-	tag_exterior_door = "toxins_east_ext_airlock";
-	tag_exterior_sensor = "toxins_east_ext_sensor";
-	tag_interior_door = "toxins_east_int_airlock";
-	tag_interior_sensor = "toxins_east_int_sensor"
-	},
-/turf/simulated/wall,
 /area/maintenance/fpmaint)
 "apW" = (
 /obj/structure/cable/yellow{
@@ -8412,23 +8291,12 @@
 "arq" = (
 /turf/simulated/floor/plating/airless,
 /area/engine/turbine_control)
-"arr" = (
-/obj/machinery/atmospherics/unary/portables_connector,
-/obj/effect/decal/cleanable/cobweb2,
-/obj/machinery/portable_atmospherics/canister/air{
-	volume = 4000
-	},
-/turf/simulated/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/fore)
 "ars" = (
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},
 /area/maintenance/fore)
 "art" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -8440,28 +8308,6 @@
 /obj/machinery/camera{
 	name = "Science - Toxins Maintenance West (Top)";
 	network = list("Toxins")
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1331;
-	id_tag = "toxins_west_control";
-	pixel_x = 5;
-	pixel_y = 28;
-	req_access_txt = "13";
-	tag_airpump = "toxins_west_pump";
-	tag_chamber_sensor = "toxins_west_sensor";
-	tag_exterior_door = "toxins_west_ext_airlock";
-	tag_exterior_sensor = "toxins_west_ext_sensor";
-	tag_interior_door = "toxins_west_int_airlock";
-	tag_interior_sensor = "toxins_west_int_sensor"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "toxins_west_int_sensor";
-	master_tag = "toxins_west_control";
-	pixel_x = -5;
-	pixel_y = 24;
-	req_access_txt = "13"
 	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
@@ -8520,35 +8366,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "toxins_east_sensor";
-	master_tag = "toxins_east_control";
-	pixel_x = 24;
-	req_access_txt = "13"
-	},
 /obj/machinery/camera{
 	dir = 4;
 	name = "Science - Toxins Maintenance Eastern Airlock"
 	},
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 4;
-	frequency = 1331;
-	id_tag = "toxins_east_pump"
-	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint)
-"arA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/simulated/wall,
-/area/maintenance/fpmaint)
-"arB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/simulated/wall,
 /area/maintenance/fpmaint)
 "arC" = (
 /obj/structure/cable/yellow{
@@ -9266,39 +9088,8 @@
 "asQ" = (
 /turf/simulated/wall,
 /area/derelictparts/fore)
-"asR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/atmos{
-	name = "Western Toxins Airlock Atmospherics";
-	req_access_txt = "24"
-	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
-/area/maintenance/fore)
-"asS" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 8;
-	flickering = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fore)
-"asT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
-/area/maintenance/fore)
 "asU" = (
 /obj/effect/decal/cleanable/blood/splatter,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},
@@ -9355,24 +9146,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 4;
-	frequency = 1331;
-	id_tag = "toxins_east_pump"
-	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint)
-"ata" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/simulated/wall,
-/area/maintenance/fpmaint)
-"atb" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated/wall,
 /area/maintenance/fpmaint)
 "atc" = (
 /obj/structure/disposalpipe/segment{
@@ -10017,20 +9791,6 @@
 	icon_state = "panelscorched"
 	},
 /area/derelictparts/fore)
-"auv" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 1;
-	icon_state = "intact_on";
-	on = 1;
-	target_pressure = 1500
-	},
-/obj/machinery/camera{
-	dir = 8;
-	name = "Science - Toxins Western Airlock Atmospherics";
-	pixel_y = -22
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fore)
 "auw" = (
 /obj/item/weapon/camera_assembly,
 /turf/simulated/floor{
@@ -10039,10 +9799,6 @@
 /area/maintenance/fore)
 "aux" = (
 /obj/machinery/vending/assist,
-/turf/simulated/floor/plating,
-/area/maintenance/fore)
-"auy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "auz" = (
@@ -10100,10 +9856,7 @@
 /turf/simulated/floor,
 /area/maintenance/fpmaint)
 "auD" = (
-/obj/machinery/portable_atmospherics/canister/air{
-	volume = 4000
-	},
-/obj/machinery/atmospherics/unary/portables_connector,
+/obj/item/weapon/reagent_containers/food/drinks/gromitmug,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "auE" = (
@@ -10113,26 +9866,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "toxins_east_int_airlock";
-	locked = 1;
-	name = "Toxins Eastern Internal Airlock";
+	name = "Testing Eastern External Airlock";
 	req_access_txt = "13"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint)
-"auF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/meter{
-	desc = "A gas flow meter. If the pressure is low, the airlock will be slow to pressurize. If that happens, call your local atmos tech."
-	},
-/turf/simulated/wall,
-/area/maintenance/fpmaint)
-"auG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/simulated/wall,
 /area/maintenance/fpmaint)
 "auH" = (
 /obj/structure/disposalpipe/segment,
@@ -10629,19 +10366,9 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
-"avK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/simulated/wall,
-/area/maintenance/fore)
 "avL" = (
 /obj/structure/table,
 /obj/item/device/radio,
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
-/area/maintenance/fore)
-"avM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},
@@ -10665,25 +10392,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor,
 /area/maintenance/fpmaint)
-"avR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/maintenance/fpmaint)
 "avS" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/machinery/camera{
-	dir = 8;
-	name = "Science - Toxins Eastern Airlock Atmospherics";
-	pixel_y = -22
-	},
-/obj/machinery/light/small{
-	dir = 8;
-	flickering = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -10702,9 +10411,6 @@
 	},
 /area/maintenance/fpmaint)
 "avU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -10721,33 +10427,6 @@
 /obj/structure/cable/yellow{
 	d2 = 2;
 	icon_state = "0-2"
-	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
-/area/maintenance/fpmaint)
-"avW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1331;
-	id_tag = "toxins_east_control";
-	pixel_x = 5;
-	pixel_y = 28;
-	req_access_txt = "13";
-	tag_airpump = "toxins_east_pump";
-	tag_chamber_sensor = "toxins_east_sensor";
-	tag_exterior_door = "toxins_east_ext_airlock";
-	tag_exterior_sensor = "toxins_east_ext_sensor";
-	tag_interior_door = "toxins_east_int_airlock";
-	tag_interior_sensor = "toxins_east_int_sensor"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "toxins_east_int_sensor";
-	master_tag = "toxins_east_control";
-	pixel_x = -5;
-	pixel_y = 24;
-	req_access_txt = "13"
 	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
@@ -11671,7 +11350,6 @@
 /obj/item/stack/sheet/glass/glass{
 	amount = 28
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -11699,20 +11377,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/wall,
 /area/maintenance/fpmaint)
-"axM" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Eastern Toxins Airlock Atmospherics";
-	req_access_txt = "24"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint)
 "axN" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 1;
-	icon_state = "intact_on";
-	on = 1;
-	target_pressure = 1500
-	},
+/obj/abstract/map/spawner/maint,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "axO" = (
@@ -11721,12 +11387,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
-/area/maintenance/fpmaint)
-"axP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},
@@ -12437,7 +12097,6 @@
 	},
 /area/maintenance/fore)
 "azj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor{
 	icon_state = "floorscorched2"
 	},
@@ -12450,27 +12109,10 @@
 	icon_state = "floorgrime"
 	},
 /area/maintenance/fore)
-"azl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
-/area/maintenance/fore)
 "azm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /turf/simulated/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/maintenance/fore)
-"azn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated/wall,
 /area/maintenance/fore)
 "azo" = (
 /obj/effect/decal/warning_stripes{
@@ -12478,9 +12120,7 @@
 	icon_state = "warning";
 	tag = "icon-warning (NORTH)"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},
@@ -12490,9 +12130,6 @@
 	dir = 4;
 	icon_state = "warning_corner";
 	tag = "icon-warning_corner (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
@@ -12504,19 +12141,11 @@
 	icon_state = "warning_corner";
 	tag = "icon-warning_corner (NORTH)"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},
 /area/maintenance/fore)
-"azr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/simulated/wall,
-/area/maintenance/fpmaint)
 "azs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -12590,10 +12219,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/camera{
 	dir = 1;
 	name = "Science - Toxins Maintenance (Outside)"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
@@ -13792,10 +13423,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/nmpi{
 	dir = 4;
 	tag = "icon-maintguide (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
@@ -66210,11 +65843,6 @@
 	icon_state = "dark"
 	},
 /area/security/brig)
-"cvQ" = (
-/turf/space,
-/area/derelictparts/apderelict{
-	name = "Aft Starboard Derelict"
-	})
 "cvR" = (
 /obj/structure/rack,
 /obj/item/weapon/minihoe,
@@ -75890,30 +75518,6 @@
 /area/security/range{
 	name = "\improper Security E.V.A"
 	})
-"cNA" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/simulated/wall/r_wall,
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
-"cNB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/simulated/wall/r_wall,
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
-"cNC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/simulated/wall/r_wall,
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
 "cND" = (
 /turf/simulated/wall/r_wall,
 /area/security/range{
@@ -76817,19 +76421,6 @@
 /obj/machinery/alarm{
 	pixel_y = 23
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
-"cPd" = (
-/obj/machinery/suit_storage_unit/security,
-/obj/item/weapon/tank/jetpack,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
@@ -76883,10 +76474,7 @@
 	icon_state = "warning";
 	tag = "icon-warning (NORTHWEST)"
 	},
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	frequency = 1331;
-	id_tag = "sec_eva_airlock_pump"
-	},
+/obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
 /area/security/range{
 	name = "\improper Security E.V.A"
@@ -76897,45 +76485,11 @@
 	icon_state = "warning";
 	tag = "icon-warning (NORTHEAST)"
 	},
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1331;
-	id_tag = "sec_eva_airlock_control";
-	pixel_x = 5;
-	pixel_y = 24;
-	req_access_txt = "63";
-	tag_airpump = "sec_eva_airlock_pump";
-	tag_chamber_sensor = "sec_eva_airlock_sensor";
-	tag_exterior_door = "sec_eva_ext_airlock";
-	tag_exterior_sensor = "sec_eva_ext_airlock_sensor";
-	tag_interior_door = "sec_eva_int_airlock";
-	tag_interior_sensor = "sec_eva_int_airlock_sensor"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "sec_eva_airlock_sensor";
-	master_tag = "sec_eva_airlock_control";
-	pixel_x = -5;
-	pixel_y = 24;
-	req_access_txt = "63"
-	},
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	frequency = 1331;
-	id_tag = "sec_eva_airlock_pump"
-	},
 /turf/simulated/floor/plating,
 /area/security/range{
 	name = "\improper Security E.V.A"
 	})
 "cPi" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/atmospherics/unary/portables_connector,
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "sec_eva_int_airlock_sensor";
-	master_tag = "sec_eva_airlock_control";
-	pixel_x = 24;
-	req_access_txt = "63"
-	},
 /obj/effect/decal/warning_stripes{
 	icon_state = "warning_corner";
 	tag = "icon-warning_corner"
@@ -76946,26 +76500,9 @@
 /area/security/range{
 	name = "\improper Security E.V.A"
 	})
-"cPj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/simulated/wall/r_wall,
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
 "cPk" = (
 /obj/machinery/camera{
 	name = "Security EVA Exterior"
-	},
-/turf/space,
-/area)
-"cPl" = (
-/obj/structure/catwalk,
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "sec_eva_ext_airlock_sensor";
-	master_tag = "sec_eva_airlock_control";
-	pixel_x = -24;
-	req_access_txt = "63"
 	},
 /turf/space,
 /area)
@@ -77609,9 +77146,6 @@
 	name = "\improper Security E.V.A"
 	})
 "cQp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -77656,7 +77190,6 @@
 	icon_state = "warning";
 	tag = "icon-warning (WEST)"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /turf/simulated/floor/plating,
 /area/security/range{
 	name = "\improper Security E.V.A"
@@ -77667,22 +77200,15 @@
 	icon_state = "warning";
 	tag = "icon-warning (EAST)"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/security/range{
 	name = "\improper Security E.V.A"
 	})
 "cQu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/decal/warning_stripes{
 	dir = 4;
 	icon_state = "warning";
 	tag = "icon-warning (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -77690,31 +77216,8 @@
 /area/security/range{
 	name = "\improper Security E.V.A"
 	})
-"cQv" = (
-/obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "sec_eva_int_airlock";
-	locked = 1;
-	name = "Security External Airlock";
-	req_access_txt = "63"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
 "cQw" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "sec_eva_ext_airlock";
-	locked = 1;
 	name = "Security External Airlock";
 	req_access_txt = "63"
 	},
@@ -78378,9 +77881,6 @@
 /obj/machinery/suit_storage_unit/security,
 /obj/item/weapon/tank/jetpack,
 /obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "vault"
@@ -78391,9 +77891,6 @@
 "cRF" = (
 /obj/machinery/suit_storage_unit/security,
 /obj/item/weapon/tank/jetpack,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "vault"
@@ -78402,7 +77899,6 @@
 	name = "\improper Security E.V.A"
 	})
 "cRG" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/yellow,
 /obj/machinery/power/apc{
 	pixel_y = -24
@@ -78412,6 +77908,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -78419,12 +77918,6 @@
 	name = "\improper Security E.V.A"
 	})
 "cRH" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	icon_state = "intact_on";
-	on = 1;
-	target_pressure = 200
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
@@ -78442,11 +77935,7 @@
 	icon_state = "warning";
 	tag = "icon-warning (SOUTHWEST)"
 	},
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 1;
-	frequency = 1331;
-	id_tag = "sec_eva_airlock_pump"
-	},
+/obj/structure/closet/emcloset/vox,
 /turf/simulated/floor/plating,
 /area/security/range{
 	name = "\improper Security E.V.A"
@@ -78457,23 +77946,16 @@
 	icon_state = "warning";
 	tag = "icon-warning (SOUTHEAST)"
 	},
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 1;
-	frequency = 1331;
-	id_tag = "sec_eva_airlock_pump"
-	},
 /turf/simulated/floor/plating,
 /area/security/range{
 	name = "\improper Security E.V.A"
 	})
 "cRK" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/decal/warning_stripes{
 	dir = 4;
 	icon_state = "warning_corner";
 	tag = "icon-warning_corner (EAST)"
 	},
-/obj/machinery/meter,
 /obj/machinery/camera{
 	dir = 1;
 	name = "Security EVA"
@@ -78481,26 +77963,6 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
-"cRL" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/structure/window/full/reinforced,
-/turf/simulated/floor/plating,
 /area/security/range{
 	name = "\improper Security E.V.A"
 	})
@@ -78945,28 +78407,6 @@
 	tag = "icon-darkred (EAST)"
 	},
 /area/security/brig)
-"cSD" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/simulated/wall/r_wall,
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
-"cSE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/simulated/wall/r_wall,
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
-"cSF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/simulated/wall/r_wall,
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
 "cSG" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -96343,15 +95783,6 @@
 	oxygen = 0
 	},
 /area/vox_trading_post/atmos)
-"dXF" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_solars_ext_airlock_sensor";
-	master_tag = "vox_solars_airlock_control";
-	pixel_y = -24
-	},
-/turf/space,
-/area)
 "dXG" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -96429,22 +95860,6 @@
 "dXN" = (
 /turf/simulated/wall,
 /area/vox_trading_post/solars)
-"dXO" = (
-/obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "vox_solars_airlock_exterior";
-	locked = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/vox,
-/area/vox_trading_post/solars)
 "dXP" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -96516,33 +95931,10 @@
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/solars)
 "dXY" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	frequency = 1331;
-	id_tag = "vox_solars_airlock_pump"
-	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1331;
-	id_tag = "vox_solars_airlock_control";
-	pixel_x = 24;
-	pixel_y = -5;
-	tag_airpump = "vox_solars_airlock_pump";
-	tag_chamber_sensor = "vox_solars_airlock_sensor";
-	tag_exterior_door = "vox_solars_airlock_exterior";
-	tag_exterior_sensor = "vox_solars_ext_airlock_sensor";
-	tag_interior_door = "vox_solars_airlock_interior";
-	tag_interior_sensor = "vox_solars_int_airlock_sensor"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_solars_airlock_sensor";
-	master_tag = "vox_solars_airlock_control";
-	pixel_x = 24;
-	pixel_y = 5
 	},
 /obj/effect/decal/warning_stripes{
 	dir = 9;
@@ -96653,20 +96045,13 @@
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/solars)
 "dYk" = (
-/obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "vox_solars_airlock_interior";
-	locked = 1
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/solars)
 "dYl" = (
@@ -96794,12 +96179,6 @@
 	name = "Vox Outpost Solar Control";
 	track = 2
 	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_solars_int_airlock_sensor";
-	master_tag = "vox_solars_airlock_control";
-	pixel_y = 24
-	},
 /obj/effect/decal/warning_stripes{
 	dir = 1;
 	icon_state = "warning_corner";
@@ -96813,7 +96192,6 @@
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/solars)
 "dYy" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
@@ -96979,7 +96357,6 @@
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/solars)
 "dYO" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
@@ -97156,17 +96533,10 @@
 /area/vox_trading_post/solars)
 "dZe" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/solars)
 "dZf" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 5;
-	tag = "icon-intact (NORTHEAST)"
-	},
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
@@ -98979,9 +98349,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 4
-	},
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/hallway)
 "ecp" = (
@@ -98991,17 +98358,7 @@
 	icon_state = "warning";
 	tag = "icon-warning (NORTHWEST)"
 	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_dock_int_airlock_sensor";
-	master_tag = "vox_dock_airlock_control";
-	pixel_y = 24;
-	req_access_txt = "150"
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 4
-	},
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/hallway)
 "ecq" = (
@@ -99011,27 +98368,6 @@
 	tag = "icon-warning (NORTHEAST)"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/simulated/floor/plating/vox,
-/area/vox_trading_post/hallway)
-"ecr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes{
-	dir = 1;
-	icon_state = "warning";
-	tag = "icon-warning (NORTH)"
-	},
-/obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "vox_dock_airlock_exterior";
-	locked = 1;
-	req_access_txt = "150"
-	},
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/hallway)
 "ecs" = (
@@ -99040,70 +98376,12 @@
 	icon_state = "warning";
 	tag = "icon-warning (NORTH)"
 	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_dock_ext_airlock_sensor";
-	master_tag = "vox_dock_airlock_control";
-	pixel_y = -24;
-	req_access_txt = "150"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	default_scrubbed_gases = list( "carbon_dioxide", "plasma", "oxygen" );
-	frequency = 1331;
-	name = "Outpost Air Scrubber";
-	on = 1
-	},
+/obj/machinery/light/small,
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/hallway)
 "ect" = (
-/obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "vox_dock_airlock_interior";
-	locked = 1;
-	req_access_txt = "150"
-	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/vox,
-/area/vox_trading_post/hallway)
-"ecu" = (
-/obj/machinery/light/small,
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1331;
-	id_tag = "vox_dock_airlock_control";
-	pixel_x = 5;
-	pixel_y = 24;
-	req_access_txt = "150";
-	tag_airpump = "vox_dock_airlock_pump";
-	tag_chamber_sensor = "vox_dock_airlock_sensor";
-	tag_exterior_door = "vox_dock_airlock_exterior";
-	tag_exterior_sensor = "vox_dock_ext_airlock_sensor";
-	tag_interior_door = "vox_dock_airlock_interior";
-	tag_interior_sensor = "vox_dock_int_airlock_sensor"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_dock_airlock_sensor";
-	master_tag = "vox_dock_airlock_control";
-	pixel_x = -5;
-	pixel_y = 24;
-	req_access_txt = "150"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4;
-	frequency = 1331;
-	id_tag = "vox_dock_airlock_pump"
-	},
-/obj/effect/decal/warning_stripes{
-	dir = 9;
-	icon_state = "all";
-	tag = "icon-all (NORTHWEST)"
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/hallway)
 "ecv" = (
@@ -99267,10 +98545,6 @@
 	},
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/hallway)
-"ecP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/simulated/wall,
-/area/vox_trading_post/hallway)
 "ecQ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -99401,9 +98675,8 @@
 	dir = 4;
 	tag = "icon-map (EAST)"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layered{
-	dir = 4;
-	tag = "icon-map (EAST)"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
+	dir = 9
 	},
 /turf/simulated/floor/vox{
 	icon_state = "dark"
@@ -99608,14 +98881,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/hallway)
-"eds" = (
-/obj/machinery/atmospherics/unary/vent/high_volume{
-	dir = 1;
-	icon_state = "intact"
-	},
-/obj/structure/catwalk,
-/turf/space,
-/area)
 "edt" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -99732,20 +98997,12 @@
 	dir = 4;
 	tag = "icon-intact (EAST)"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
-	dir = 10;
-	tag = "icon-intact (SOUTHWEST)"
-	},
 /turf/simulated/floor/vox{
 	icon_state = "dark"
 	},
 /area/vox_trading_post/trading_floor)
 "edD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layered{
-	dir = 5;
-	tag = "icon-intact (NORTHEAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
 	dir = 5;
 	tag = "icon-intact (NORTHEAST)"
 	},
@@ -99809,24 +99066,18 @@
 	},
 /area/vox_trading_post/trading_floor)
 "edJ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/machinery/light/small,
 /obj/machinery/atm{
 	pixel_y = -30
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/simulated/floor/vox{
 	icon_state = "dark"
 	},
 /area/vox_trading_post/trading_floor)
 "edK" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_trading_int_airlock_sensor";
-	master_tag = "vox_trading_airlock_control";
-	pixel_y = -24
-	},
 /obj/machinery/atmospherics/pipe/layer_adapter/supply/hidden{
 	dir = 4;
 	tag = "icon-adapter_2 (EAST)"
@@ -100016,15 +99267,8 @@
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/armory)
 "eed" = (
-/obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "vox_trading_airlock_interior";
-	locked = 1
-	},
-/obj/machinery/atmospherics/pipe/layer_adapter/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/trading_floor)
 "eee" = (
@@ -100080,14 +99324,6 @@
 /obj/machinery/atmospherics/pipe/layer_adapter/supply/hidden,
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/armory)
-"eei" = (
-/obj/machinery/atmospherics/binary/pump{
-	icon_state = "intact_on";
-	on = 1;
-	target_pressure = 900
-	},
-/turf/simulated/wall,
-/area/vox_trading_post/trading_floor)
 "eej" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -100223,12 +99459,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor/vox/wood,
 /area/vox_trading_post/dorms)
-"eew" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/simulated/wall,
-/area/vox_trading_post/armory)
 "eex" = (
 /obj/structure/closet,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -100239,7 +99469,6 @@
 	},
 /area/vox_trading_post/armory)
 "eey" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes{
 	dir = 1;
@@ -100249,11 +99478,6 @@
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/trading_floor)
 "eez" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 4;
-	frequency = 1331;
-	id_tag = "vox_trading_airlock_pump"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes{
 	dir = 9;
@@ -100306,37 +99530,7 @@
 	icon_state = "dark"
 	},
 /area/vox_trading_post/armory)
-"eeD" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/vox_trading_post/trading_floor)
 "eeE" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 8;
-	frequency = 1331;
-	id_tag = "vox_trading_airlock_pump"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_trading_airlock_sensor";
-	master_tag = "vox_trading_airlock_control";
-	pixel_x = -5;
-	pixel_y = 24
-	},
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1331;
-	id_tag = "vox_trading_airlock_control";
-	pixel_x = 5;
-	pixel_y = 24;
-	tag_airpump = "vox_trading_airlock_pump";
-	tag_chamber_sensor = "vox_trading_airlock_sensor";
-	tag_exterior_door = "vox_trading_airlock_exterior";
-	tag_exterior_sensor = "vox_trading_ext_airlock_sensor";
-	tag_interior_door = "vox_trading_airlock_interior";
-	tag_interior_sensor = "vox_trading_int_airlock_sensor"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes{
 	dir = 5;
@@ -100345,15 +99539,6 @@
 	},
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/trading_floor)
-"eeF" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_trading_ext_airlock_sensor";
-	master_tag = "vox_trading_airlock_control";
-	pixel_x = -24
-	},
-/turf/unsimulated/floor/asteroid,
-/area/mine/explored)
 "eeG" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1331;
@@ -100436,12 +99621,6 @@
 	},
 /turf/simulated/floor/vox/wood,
 /area/vox_trading_post/dorms)
-"eeM" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/simulated/wall,
-/area/vox_trading_post/armory)
 "eeN" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -100457,16 +99636,10 @@
 	},
 /area/vox_trading_post/armory)
 "eeO" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/trading_floor)
 "eeP" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 4;
-	frequency = 1331;
-	id_tag = "vox_trading_airlock_pump"
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -100520,26 +99693,12 @@
 	},
 /area/vox_trading_post/armory)
 "eeT" = (
-/obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "vox_trading_airlock_exterior";
-	locked = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/trading_floor)
 "eeU" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 8;
-	frequency = 1331;
-	id_tag = "vox_trading_airlock_pump"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes{
 	dir = 4;
@@ -100604,7 +99763,6 @@
 	},
 /area/vox_trading_post/armory)
 "efb" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes{
 	icon_state = "warning";
@@ -100613,11 +99771,6 @@
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/trading_floor)
 "efc" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 4;
-	frequency = 1331;
-	id_tag = "vox_trading_airlock_pump"
-	},
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes{
@@ -100655,11 +99808,6 @@
 	},
 /area/vox_trading_post/armory)
 "efg" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 8;
-	frequency = 1331;
-	id_tag = "vox_trading_airlock_pump"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes{
 	dir = 6;
@@ -100677,31 +99825,6 @@
 	tag = "icon-freezerfloor"
 	},
 /area/vox_trading_post/dorms)
-"efi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/simulated/wall,
-/area/vox_trading_post/armory)
-"efj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/simulated/wall,
-/area/vox_trading_post/trading_floor)
-"efk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/vox_trading_post/trading_floor)
-"efl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/simulated/wall,
-/area/vox_trading_post/trading_floor)
 "efm" = (
 /obj/structure/hanging_lantern{
 	dir = 8
@@ -101105,9 +100228,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/research_outpost/entry)
-"egf" = (
-/turf/unsimulated/floor/asteroid,
-/area)
 "egg" = (
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating,
@@ -105766,9 +104886,8 @@
 /area/research_outpost/gearstore)
 "enV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layered{
-	dir = 4;
-	tag = "icon-map (EAST)"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
+	dir = 9
 	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
@@ -105877,10 +104996,8 @@
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "eol" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
-	initialize_directions = 11
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
@@ -106012,10 +105129,6 @@
 	},
 /area/research_outpost/anomaly)
 "eoC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
-	dir = 4;
-	tag = "icon-intact (EAST)"
-	},
 /obj/effect/decal/warning_stripes{
 	icon_state = "warning_corner";
 	tag = "icon-warning_corner"
@@ -106023,20 +105136,10 @@
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "eoD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
-	dir = 6;
-	tag = "icon-intact (SOUTHEAST)"
-	},
 /obj/structure/closet/secure_closet/excavation,
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "eoE" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "anom_int_sensor";
-	master_tag = "anom_airlock_control";
-	pixel_y = -24
-	},
 /obj/effect/decal/warning_stripes{
 	dir = 8;
 	icon_state = "warning_corner";
@@ -106046,14 +105149,11 @@
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "eoF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/decal/warning_stripes{
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "eoG" = (
@@ -106112,21 +105212,13 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/research_outpost/gearstore)
-"eoO" = (
-/obj/machinery/atmospherics/pipe/layer_adapter/scrubbers/hidden,
-/turf/simulated/wall,
-/area/research_outpost/gearstore)
 "eoP" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1;
 	name = "Firelock North"
 	},
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "anom_int_door";
-	locked = 1
+	req_access_txt = "47"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor,
@@ -106159,27 +105251,18 @@
 /turf/simulated/wall/r_wall,
 /area/mine/explored)
 "eoU" = (
-/obj/structure/closet/walllocker/emerglocker/west,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 8;
-	frequency = 1331;
-	id_tag = "anom_airlock_pump"
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4;
+	on = 1
 	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
-"eoV" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/simulated/wall,
-/area/research_outpost/gearstore)
 "eoW" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
-	initialize_directions = 11
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
 	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
@@ -106214,46 +105297,17 @@
 /turf/simulated/wall/r_wall,
 /area/mine/explored)
 "epc" = (
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1331;
-	id_tag = "anom_airlock_control";
-	pixel_x = -24;
-	pixel_y = 2;
-	tag_airpump = "anom_airlock_pump";
-	tag_chamber_sensor = "anom_airlock_sensor";
-	tag_exterior_door = "anom_ext_door";
-	tag_exterior_sensor = "anom_ext_sensor";
-	tag_interior_door = "anom_int_door";
-	tag_interior_sensor = "anom_int_sensor"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "anom_airlock_sensor";
-	master_tag = "anom_airlock_control";
-	pixel_x = -24;
-	pixel_y = -8
-	},
 /obj/machinery/camera{
 	dir = 1;
 	name = "Research Outpost Airlock";
 	network = list("SS13","RD")
 	},
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 8;
-	frequency = 1331;
-	id_tag = "anom_airlock_pump"
-	},
 /obj/effect/decal/warning_stripes{
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
+/obj/structure/closet/walllocker/emerglocker/west,
 /turf/simulated/floor,
-/area/research_outpost/gearstore)
-"epd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/simulated/wall/r_wall,
 /area/research_outpost/gearstore)
 "epe" = (
 /obj/structure/grille,
@@ -106267,9 +105321,6 @@
 /turf/simulated/floor/plating,
 /area/research_outpost/gearstore)
 "epf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /obj/effect/decal/warning_stripes{
 	icon_state = "warning";
 	tag = "icon-warning"
@@ -106327,11 +105378,7 @@
 /area/mine/explored)
 "epl" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "anom_ext_door";
-	locked = 1
+	req_access_txt = "47"
 	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
@@ -106383,18 +105430,6 @@
 "epr" = (
 /obj/machinery/camera{
 	name = "Research Outpost Exterior"
-	},
-/turf/simulated/floor/airless{
-	dir = 5;
-	icon_state = "asteroidfloor"
-	},
-/area/mine/explored)
-"eps" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "anom_ext_sensor";
-	master_tag = "anom_airlock_control";
-	pixel_y = 24
 	},
 /turf/simulated/floor/airless{
 	dir = 5;
@@ -207274,9 +206309,9 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
-aaf
+aaa
+aaa
+aaa
 aaa
 aaf
 aaf
@@ -207778,10 +206813,10 @@ aaa
 aaa
 aaa
 aaa
-amM
-amM
-amM
-amM
+aaa
+aaa
+aaa
+aaa
 amM
 axF
 azi
@@ -208280,11 +207315,11 @@ aaa
 aaa
 aaa
 aaf
+aaa
+aaf
+aaf
+aaf
 amM
-arr
-asS
-auv
-avK
 axH
 azj
 aBm
@@ -208784,7 +207819,7 @@ aaf
 aaf
 amM
 amM
-asR
+amM
 amM
 amM
 axG
@@ -209282,11 +208317,11 @@ aaf
 aaa
 aaa
 amM
-anF
-aoK
-apR
+amM
+amM
+amM
 art
-asT
+ars
 auw
 ars
 axI
@@ -209785,7 +208820,7 @@ aaY
 aaY
 amL
 anE
-aoJ
+axI
 apQ
 ars
 ars
@@ -210285,15 +209320,15 @@ aaa
 aaf
 aaa
 alU
-amN
-anG
-aoL
-apS
+amM
+amM
+amM
+amM
 aru
 asU
-auy
-avM
-avM
+axI
+ars
+ars
 azm
 aBo
 aCK
@@ -210796,7 +209831,7 @@ amM
 aux
 avL
 axJ
-azl
+ars
 aBl
 aCJ
 aEt
@@ -211298,7 +210333,7 @@ aei
 aei
 aei
 aei
-azl
+ars
 aBq
 aCL
 amM
@@ -211800,7 +210835,7 @@ asV
 auz
 avN
 aei
-azn
+amM
 aBp
 amM
 amM
@@ -213808,7 +212843,7 @@ aei
 aei
 aei
 aei
-avR
+aei
 aBt
 aLH
 aLH
@@ -214310,7 +213345,7 @@ aei
 auD
 avS
 axN
-azr
+aei
 azw
 aLH
 aEz
@@ -214810,8 +213845,8 @@ aaf
 aaf
 aei
 aei
-avR
-axM
+aei
+aei
 aei
 ate
 aLH
@@ -215309,9 +214344,9 @@ aaf
 aaa
 aaa
 aei
-arA
-ata
-auF
+aei
+aei
+aei
 avU
 awa
 azt
@@ -216311,13 +215346,13 @@ aaa
 aaa
 aaf
 aaa
-aoN
-apV
-arB
-atb
-auG
-avW
-axP
+aaa
+aei
+aei
+aei
+aei
+awa
+awa
 azv
 aBw
 aLK
@@ -251046,7 +250081,7 @@ cAA
 cKB
 cMf
 cNz
-cPd
+cRF
 cQp
 cRF
 cNy
@@ -252049,11 +251084,11 @@ cEG
 cJm
 cKG
 cMl
-cNC
-cPj
-cQv
-cRL
-cSF
+cND
+cND
+cQw
+cRM
+cND
 cTC
 cUD
 cVr
@@ -252551,11 +251586,11 @@ cEG
 cJk
 cKD
 cMi
-cNA
+cND
 cPg
 cQs
 cRI
-cSD
+cND
 cTC
 cUB
 cVp
@@ -253053,11 +252088,11 @@ cHF
 cJl
 cKE
 cMj
-cNB
+cND
 cPh
 cQt
 cRJ
-cSE
+cND
 cTD
 cUC
 cVq
@@ -254058,7 +253093,7 @@ cJq
 cKI
 cMo
 cEI
-cPl
+acf
 acf
 acf
 aaf
@@ -256554,9 +255589,9 @@ bMT
 csw
 bMT
 bMT
-cvQ
-cvQ
-cvQ
+aaa
+aaa
+aaa
 bMT
 bMT
 bMT
@@ -1175063,8 +1174098,8 @@ dZp
 dYe
 ebX
 ecs
-ecP
-eds
+dZQ
+acf
 acf
 aaa
 aaa
@@ -1175564,7 +1174599,7 @@ eaP
 ebj
 dYf
 ebW
-ecr
+ecn
 ecO
 aaa
 aaa
@@ -1176056,7 +1175091,7 @@ aaf
 aaf
 aaa
 aaa
-aaa
+efS
 dYi
 dYf
 dYf
@@ -1176066,7 +1175101,7 @@ dYf
 ebf
 ebH
 dZQ
-ecu
+ecn
 ecR
 aaa
 aaa
@@ -1182076,7 +1181111,7 @@ aaa
 abq
 dXB
 dXG
-dXO
+dYk
 dXY
 dYk
 dYy
@@ -1182577,7 +1181612,7 @@ aaa
 aaa
 aaa
 aaa
-dXF
+aaa
 dXN
 dXN
 dXN
@@ -1185608,10 +1184643,10 @@ dZQ
 ecX
 dZQ
 eeb
-eew
-eeM
-eeM
-efi
+eeb
+eeb
+eeb
+eeb
 ebS
 ebS
 ebS
@@ -1186113,7 +1185148,7 @@ ebc
 eez
 eeP
 efc
-efk
+ebc
 ebS
 ebS
 ebS
@@ -1186615,7 +1185650,7 @@ eed
 eey
 eeO
 efb
-efj
+ebc
 ebS
 ebS
 ebS
@@ -1187117,7 +1186152,7 @@ ebc
 eeE
 eeU
 efg
-efk
+ebc
 ebS
 ebS
 ebS
@@ -1187615,11 +1186650,11 @@ ebc
 ebz
 ebz
 edJ
-eei
-eeD
+ebc
+ebc
 eeT
-eeD
-efl
+ebc
+ebc
 ebS
 ebS
 ebS
@@ -1188118,7 +1187153,7 @@ ebz
 edh
 edL
 eek
-eeF
+ecI
 ecI
 ecI
 eck
@@ -1243391,7 +1242426,7 @@ eiI
 eil
 ecI
 ecI
-egf
+ecI
 efX
 efX
 efX
@@ -1249417,9 +1248452,9 @@ enA
 enU
 eok
 eoD
-eoO
-eoV
-epd
+elQ
+elQ
+enG
 enG
 epr
 epu
@@ -1250927,7 +1249962,7 @@ elQ
 eoa
 epe
 enG
-eps
+epa
 epu
 ecI
 ecI

--- a/maps/defficiency.dmm
+++ b/maps/defficiency.dmm
@@ -6071,7 +6071,7 @@
 "amL" = (
 /obj/machinery/door/airlock/external{
 	name = "Toxins Western External Airlock";
-	req_access_txt = "47"
+	req_one_access_txt = "13;47"
 	},
 /turf/simulated/floor/plating/airless,
 /area/maintenance/fore)
@@ -7548,7 +7548,7 @@
 "apQ" = (
 /obj/machinery/door/airlock/external{
 	name = "Toxins Western External Airlock";
-	req_access_txt = "47"
+	req_one_access_txt = "13;47"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
@@ -7563,7 +7563,7 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Testing Eastern External Airlock";
-	req_access_txt = "47"
+	req_one_access_txt = "13;47"
 	},
 /turf/simulated/floor/plating/airless,
 /area/maintenance/fpmaint)
@@ -9867,7 +9867,7 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Testing Eastern External Airlock";
-	req_access_txt = "47"
+	req_one_access_txt = "13;47"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)

--- a/maps/defficiency.dmm
+++ b/maps/defficiency.dmm
@@ -6071,7 +6071,7 @@
 "amL" = (
 /obj/machinery/door/airlock/external{
 	name = "Toxins Western External Airlock";
-	req_access_txt = "13"
+	req_access_txt = "47"
 	},
 /turf/simulated/floor/plating/airless,
 /area/maintenance/fore)
@@ -7548,7 +7548,7 @@
 "apQ" = (
 /obj/machinery/door/airlock/external{
 	name = "Toxins Western External Airlock";
-	req_access_txt = "13"
+	req_access_txt = "47"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
@@ -7563,7 +7563,7 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Testing Eastern External Airlock";
-	req_access_txt = "13"
+	req_access_txt = "47"
 	},
 /turf/simulated/floor/plating/airless,
 /area/maintenance/fpmaint)
@@ -9867,7 +9867,7 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Testing Eastern External Airlock";
-	req_access_txt = "13"
+	req_access_txt = "47"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -12145,7 +12145,7 @@
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},
-/area/maintenance/fore)
+/area/maintenance/fpmaint)
 "azs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -55054,68 +55054,15 @@
 /obj/effect/landmark/spacepod/random,
 /turf/space,
 /area/mine/unexplored)
-"cDP" = (
-/obj/structure/hanging_lantern{
-	dir = 4
-	},
-/turf/unsimulated/floor/asteroid,
-/area/mine/unexplored)
 "cDQ" = (
 /turf/simulated/wall,
 /area/mine/unexplored)
-"cDR" = (
-/obj/machinery/airlock_sensor{
-	id_tag = "vox_eva_ext_airlock_sensor";
-	master_tag = "vox_eva_airlock_control";
-	pixel_y = -24
-	},
-/turf/unsimulated/floor/asteroid,
-/area/mine/explored)
 "cDS" = (
 /turf/simulated/wall,
-/area/vox_trading_post/eva)
-"cDT" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1449;
-	icon_state = "door_locked";
-	id_tag = "vox_eva_airlock_exterior";
-	locked = 1
-	},
-/turf/simulated/floor/plating/vox,
 /area/vox_trading_post/eva)
 "cDU" = (
 /obj/effect/glowshroom/single,
 /turf/simulated/wall,
-/area/vox_trading_post/eva)
-"cDV" = (
-/obj/structure/closet/emcloset/vox,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/vox_trading_post/eva)
-"cDW" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 4;
-	frequency = 1449;
-	id_tag = "vox_eva_airlock_pump"
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/vox_trading_post/eva)
-"cDX" = (
-/obj/machinery/airlock_sensor{
-	id_tag = "vox_eva_airlock_sensor";
-	master_tag = "vox_eva_airlock_control";
-	pixel_x = 24
-	},
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/machinery/alarm/vox{
-	pixel_y = 24
-	},
-/turf/simulated/floor/engine/vacuum,
 /area/vox_trading_post/eva)
 "cDY" = (
 /obj/effect/glowshroom,
@@ -55140,17 +55087,9 @@
 	},
 /area/mine/explored)
 "cEb" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/vox_trading_post/eva)
-"cEc" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/vox_trading_post/eva)
+/obj/machinery/door/airlock/external,
+/turf/unsimulated/mineral/random,
+/area/mine/unexplored)
 "cEd" = (
 /obj/item/clothing/under/rank/miner,
 /obj/effect/decal/remains/human,
@@ -55164,63 +55103,39 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/explored)
-"cEf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/simulated/wall,
-/area/vox_trading_post/eva)
 "cEg" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1449;
-	icon_state = "door_locked";
-	id_tag = "vox_eva_airlock_interior";
-	locked = 1
-	},
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/eva)
-"cEh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/simulated/wall,
-/area/vox_trading_post/eva)
 "cEi" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/airlock_sensor{
-	id_tag = "vox_eva_int_airlock_sensor";
-	master_tag = "vox_eva_airlock_control";
-	pixel_y = 24
+/obj/machinery/power/apc{
+	dir = 8;
+	locked = 0;
+	name = "Outpost APC";
+	pixel_x = -24;
+	req_access = null
 	},
 /turf/simulated/floor/vox,
 /area/vox_trading_post/eva)
 "cEj" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
-	default_scrubbed_gases = list("plasma", "carbon", "oxygen");
+	default_scrubbed_gases = list( "carbon_dioxide", "plasma", "oxygen" );
 	dir = 4;
+	frequency = 1331;
 	name = "Outpost Air Scrubber";
 	on = 1
 	},
 /turf/simulated/floor/vox,
 /area/vox_trading_post/eva)
 "cEk" = (
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	id_tag = "vox_eva_airlock_control";
-	pixel_y = 24;
-	tag_airpump = "vox_eva_airlock_pump";
-	tag_chamber_sensor = "vox_eva_airlock_sensor";
-	tag_exterior_door = "vox_eva_airlock_exterior";
-	tag_exterior_sensor = "vox_eva_ext_airlock_sensor";
-	tag_interior_door = "vox_eva_airlock_interior";
-	tag_interior_sensor = "vox_eva_int_airlock_sensor"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
+/obj/structure/closet/emcloset/vox,
 /turf/simulated/floor/vox,
 /area/vox_trading_post/eva)
 "cEl" = (
@@ -55229,18 +55144,18 @@
 	},
 /area/mine/unexplored)
 "cEm" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
 	},
 /turf/simulated/floor/vox,
 /area/vox_trading_post/eva)
 "cEn" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -70206,6 +70121,7 @@
 /obj/structure/table/woodentable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layered,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered,
+/obj/item/weapon/reagent_containers/food/drinks/gromitmug,
 /turf/simulated/floor{
 	icon_state = "redyellowfull"
 	},
@@ -1171903,7 +1171819,7 @@ cDv
 cDv
 cDo
 cDo
-cDo
+cEb
 cDo
 cDo
 cDo
@@ -1176922,11 +1176838,11 @@ aaa
 cDx
 cDx
 cDv
-cDo
-cDo
-cDo
-cDo
-cDo
+cDv
+cDv
+cDv
+cDv
+cDv
 cEt
 cER
 cFp
@@ -1177423,9 +1177339,9 @@ aaa
 asx
 cDx
 cDx
-cDS
-cDU
-cDS
+cDx
+cDx
+cDx
 cDS
 cDS
 cDU
@@ -1177924,11 +1177840,11 @@ aaa
 aaa
 aaa
 cDx
-cDR
+cDx
+cDx
+cDx
+cDx
 cDS
-cDV
-cEb
-cEf
 cEi
 cEm
 cEv
@@ -1178427,9 +1178343,9 @@ cDo
 cDo
 cDx
 cDx
-cDT
-cDW
-cDW
+cDx
+cDx
+cDx
 cEg
 cEj
 cEn
@@ -1178929,10 +1178845,10 @@ cDo
 cDo
 cDx
 cDx
+cDx
+cDx
+cDx
 cDS
-cDX
-cEc
-cEh
 cEk
 cEo
 cEx
@@ -1179430,10 +1179346,10 @@ cDo
 cDo
 cDo
 cDx
+cDz
 cDx
-cDS
-cDS
-cDU
+cDx
+cDx
 cDS
 cDU
 cDS
@@ -1179931,14 +1179847,14 @@ cDo
 cDo
 cDo
 cDo
-cDt
 cDx
-cDt
-cDt
-cDt
-cDt
-cDt
-cDt
+cDx
+cDx
+cDx
+cDx
+cDx
+cDx
+cDx
 cEy
 cEW
 cFu
@@ -1180433,14 +1180349,14 @@ cDo
 cDo
 cDo
 cDo
-cDP
-cDt
-cDt
-cDt
-cDt
-cDt
-cDt
-cDt
+cDz
+cDx
+cDx
+cDx
+cDx
+cDx
+cDx
+cDx
 cEy
 cEX
 cFv
@@ -1180937,12 +1180853,12 @@ cDo
 cDo
 cDQ
 cDo
-cDt
-cDt
-cDt
-cDt
-cDt
-cDt
+cDx
+cDx
+cDx
+cDx
+cDx
+cDx
 cEy
 cEY
 cFw
@@ -1181441,10 +1181357,10 @@ cDo
 cDo
 cDo
 cDo
-cDt
-cDt
-cDt
-cDt
+cDx
+cDx
+cDx
+cDx
 cEy
 cEZ
 cEy
@@ -1181943,10 +1181859,10 @@ cDo
 cDo
 cDo
 cDo
-cDt
-cDt
-cDt
-cDt
+cDx
+cDx
+cDx
+cDx
 cEy
 cFa
 cFx
@@ -1182446,9 +1182362,9 @@ cDo
 cDo
 cDo
 cDo
-cDt
-cDt
-cDt
+cDx
+cDx
+cDx
 cEy
 cFb
 cFx
@@ -1182948,9 +1182864,9 @@ cDo
 cDo
 cDo
 cDo
-cDt
-cDt
-cDt
+cDx
+cDx
+cDx
 cEy
 cFc
 cFx
@@ -1183450,9 +1183366,9 @@ cDo
 cDo
 cDo
 cDo
-cDt
-cDt
-cDt
+cDx
+cDx
+cDx
 cEy
 cFd
 cFx
@@ -1183952,9 +1183868,9 @@ cDo
 cDo
 cDo
 cDo
-cDt
-cDt
-cDt
+cDx
+cDx
+cDx
 cEy
 cEy
 cEy
@@ -1184454,13 +1184370,13 @@ cDo
 cDo
 cDo
 cDo
-cDt
-cDt
-cDt
-cDt
-cDt
-cDt
-cDt
+cDx
+cDx
+cDx
+cDx
+cDx
+cDx
+cDx
 cEy
 cHd
 cHC
@@ -1184957,12 +1184873,12 @@ cDo
 cDo
 cDo
 cDo
-cDt
-cDt
-cDt
-cDt
-cDt
-cDt
+cDx
+cDx
+cDx
+cDx
+cDx
+cDx
 cEy
 cHe
 cHD
@@ -1185459,12 +1185375,12 @@ cDo
 cDo
 cDo
 cDo
-cDt
-cDt
-cDt
-cDt
-cDt
-cDt
+cDx
+cDx
+cDx
+cDx
+cDx
+cDx
 cEy
 cHc
 cHE
@@ -1185963,9 +1185879,9 @@ cDo
 cDo
 cDo
 cDo
-cDt
-cDt
-cDt
+cDx
+cDx
+cDx
 cDx
 cGB
 cHf
@@ -1186466,8 +1186382,8 @@ cDo
 cDo
 cDo
 cDo
-cDt
-cDt
+cDx
+cDx
 cDx
 cGC
 cHg
@@ -1186968,8 +1186884,8 @@ cDo
 cDo
 cDo
 cDo
-cDt
-cDt
+cDx
+cDx
 cDx
 cGC
 cHg
@@ -1187470,8 +1187386,8 @@ cDo
 cDo
 cDo
 cDo
-cDt
-cDt
+cDx
+cDx
 cDx
 cGC
 cHh
@@ -1187972,8 +1187888,8 @@ cDo
 cDo
 cDo
 cDo
-cDt
-cDt
+cDx
+cDx
 cDx
 cDx
 cDx
@@ -1188474,8 +1188390,8 @@ cDo
 cDo
 cDo
 cDo
-cDt
-cDt
+cDx
+cDx
 cDx
 cDx
 cDx
@@ -1188976,8 +1188892,8 @@ cDo
 cDo
 cDo
 cDo
-cDt
-cDt
+cDx
+cDx
 cDx
 cDx
 cDx

--- a/maps/lowfatbagel.dmm
+++ b/maps/lowfatbagel.dmm
@@ -17353,6 +17353,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/weapon/reagent_containers/food/drinks/gromitmug,
 /turf/simulated/floor{
 	icon_state = "bar"
 	},
@@ -36625,9 +36626,6 @@
 	icon_state = "dark"
 	},
 /area/centcom/ert)
-"dAZ" = (
-/turf/space,
-/area/research_outpost/hallway)
 "dBd" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor{
@@ -39041,12 +39039,6 @@
 /obj/machinery/camera{
 	name = "Outpost Expedition Preperation";
 	network = list("MINE","RD","SS13")
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "MINE_int_airlock_sensor";
-	master_tag = "MINE_airlock_control";
-	pixel_y = 22
 	},
 /turf/simulated/floor,
 /area/mine/production)
@@ -41725,13 +41717,6 @@
 	name = "plating"
 	},
 /area/centcom/suppy)
-"eUx" = (
-/obj/machinery/conveyor_switch/oneway{
-	id_tag = "mining_internal";
-	name = "mining conveyor"
-	},
-/turf/unsimulated/floor/asteroid,
-/area/research_outpost/hallway)
 "eUy" = (
 /obj/machinery/atmospherics/pipe/simple/filtering/visible,
 /obj/machinery/meter,
@@ -43721,7 +43706,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/simulated/floor/plating,
-/area)
+/area/mine/explored)
 "fzJ" = (
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid/toxin{
@@ -44104,12 +44089,6 @@
 	icon_state = "xenobio";
 	name = "Xenobiology"
 	})
-"fFJ" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "MINE_airlock_exterior"
-	},
-/turf/simulated/floor/plating,
-/area/mine/production)
 "fGs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/pickaxe,
@@ -47193,28 +47172,6 @@
 /area/maintenance/starboard)
 "gwP" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1331;
-	id_tag = "MINE_airlock_control";
-	name = "Mining Airlock Controller";
-	pixel_x = -24;
-	tag_airpump = "MINE_airlock_pump";
-	tag_chamber_sensor = "MINE_airlock_sensor";
-	tag_exterior_door = "MINE_airlock_exterior";
-	tag_exterior_sensor = "MINE_ext_airlock_sensor";
-	tag_interior_door = "MINE_airlock_interior";
-	tag_interior_sensor = "MINE_int_airlock_sensor"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "MINE_airlock_sensor";
-	master_tag = "MINE_airlock_control";
-	pixel_x = -24;
-	pixel_y = -10
-	},
 /turf/simulated/floor/plating,
 /area/mine/production)
 "gwR" = (
@@ -50380,10 +50337,6 @@
 	icon_state = "grimy"
 	},
 /area/security/detectives_office)
-"hqw" = (
-/obj/structure/hanging_lantern,
-/turf/unsimulated/floor/asteroid,
-/area/research_outpost/hallway)
 "hqQ" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/unsimulated/floor{
@@ -50801,8 +50754,11 @@
 	},
 /area/science/hallway)
 "hwP" = (
-/turf/unsimulated/floor/asteroid,
-/area/research_outpost/hallway)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/simulated/floor,
+/area/mine/production)
 "hwS" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -55844,21 +55800,6 @@
 	},
 /turf/space,
 /area/shuttle/transport1/centcom)
-"jah" = (
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/mine/production)
 "jav" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layered,
@@ -56338,10 +56279,6 @@
 	icon_state = "caution"
 	},
 /area/engineering/atmos_control)
-"jfL" = (
-/obj/structure/disposalpipe/segment,
-/turf/unsimulated/mineral/random,
-/area/mine/unexplored)
 "jfT" = (
 /obj/structure/table/glass,
 /obj/item/device/mmi/posibrain,
@@ -64104,10 +64041,6 @@
 	tag = "icon-yellowsiding"
 	},
 /area/hallway/primary/port)
-"lmk" = (
-/obj/structure/ore_box,
-/turf/unsimulated/floor/asteroid,
-/area/research_outpost/hallway)
 "lmG" = (
 /obj/machinery/biogenerator,
 /turf/simulated/floor{
@@ -67837,12 +67770,6 @@
 	dir = 1;
 	name = "Outpost Exit";
 	network = list("MINE","RD","SS13")
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "MINE_ext_airlock_sensor";
-	master_tag = "MINE_airlock_control";
-	pixel_y = -18
 	},
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidplating"
@@ -74130,12 +74057,6 @@
 	icon_state = "toxstorage";
 	name = "Toxins Storage"
 	})
-"ohi" = (
-/obj/structure/hanging_lantern{
-	dir = 1
-	},
-/turf/unsimulated/floor/asteroid,
-/area)
 "ohj" = (
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain)
@@ -79687,10 +79608,6 @@
 	icon_state = "whitepurple"
 	},
 /area/research_outpost/hallway)
-"pNd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/simulated/floor,
-/area/mine/production)
 "pNj" = (
 /obj/structure/painting/random,
 /turf/unsimulated/wall,
@@ -83750,9 +83667,6 @@
 	},
 /turf/simulated/floor/vox/wood,
 /area/vox_trading_post/dorms)
-"qVj" = (
-/turf/unsimulated/floor/asteroid,
-/area)
 "qVr" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -85370,11 +85284,6 @@
 	icon_state = "white"
 	},
 /area/medical/genetics)
-"rtU" = (
-/turf/unsimulated/floor/airless{
-	icon_state = "asteroidplating"
-	},
-/area/research_outpost/hallway)
 "rtW" = (
 /obj/machinery/light{
 	dir = 1
@@ -91869,9 +91778,7 @@
 	},
 /area/vox_trading_post/gardens)
 "tpf" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "MINE_airlock_interior"
-	},
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor/plating,
 /area/mine/production)
 "tpr" = (
@@ -99275,10 +99182,9 @@
 	name = "Toxins"
 	})
 "vBP" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 8;
-	frequency = 1331;
-	id_tag = "MINE_airlock_pump"
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4;
+	on = 1
 	},
 /turf/simulated/floor/plating,
 /area/mine/production)
@@ -99836,9 +99742,6 @@
 /turf/simulated/floor,
 /area/storage/tools)
 "vKs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor,
 /area/mine/production)
@@ -1207577,7 +1207480,7 @@ sDF
 sDF
 vgk
 eiG
-qVj
+bAS
 aaa
 aaa
 aaa
@@ -1208079,8 +1207982,8 @@ sDF
 sDF
 vWk
 eiG
-qVj
-qVj
+bAS
+bAS
 aaa
 aaa
 aaa
@@ -1208096,7 +1207999,7 @@ aoc
 ovd
 ovd
 mqh
-qnj
+mqh
 mqh
 mqh
 mqh
@@ -1208598,7 +1208501,7 @@ ovd
 ovd
 ovd
 mqh
-qnj
+mqh
 mqh
 mqh
 mqh
@@ -1209083,10 +1208986,10 @@ tQJ
 sDF
 sDF
 eiG
-qVj
-qVj
-qVj
-qVj
+bAS
+bAS
+bAS
+bAS
 aaa
 aaa
 aaa
@@ -1209095,7 +1208998,7 @@ aoc
 aaa
 aaa
 aoc
-fPa
+ovd
 wpd
 wpd
 wpd
@@ -1209585,19 +1209488,19 @@ tQJ
 lpE
 lpE
 vrZ
-qVj
-qVj
-qVj
-qVj
-qVj
+bAS
+bAS
+bAS
+bAS
+bAS
 aaa
 aaa
 aaa
 aoc
 aaa
 aaa
-fPa
-fPa
+ovd
+ovd
 wpd
 miH
 hLV
@@ -1210087,19 +1209990,19 @@ tdb
 iRb
 ths
 egh
-qVj
-qVj
-qVj
-qVj
-qVj
-qVj
-qVj
+bAS
+bAS
+bAS
+bAS
+bAS
+bAS
+bAS
 aoc
 aoc
 aoc
 aoc
-fPa
-fPa
+ovd
+ovd
 wpd
 miH
 miH
@@ -1210592,16 +1210495,16 @@ egh
 hPM
 hPM
 dTg
-ohi
-qVj
-qVj
-qVj
-qVj
+wWH
+bAS
+bAS
+bAS
+bAS
 aoc
 aaa
 aaa
-fPa
-fPa
+ovd
+ovd
 wpd
 miH
 iND
@@ -1211094,11 +1210997,11 @@ cQv
 uVG
 cUc
 uVF
-qVj
-qVj
-qVj
-qVj
-qVj
+bAS
+bAS
+bAS
+bAS
+bAS
 wpd
 wpd
 wpd
@@ -1211596,11 +1211499,11 @@ qic
 vEc
 vEc
 qic
-qVj
-qVj
-qVj
-qVj
-qVj
+bAS
+bAS
+bAS
+bAS
+bAS
 wpd
 wTw
 gwB
@@ -1212098,11 +1212001,11 @@ hPM
 qnv
 vzD
 dTg
-qVj
-qVj
-qVj
-qVj
-qVj
+bAS
+bAS
+bAS
+bAS
+bAS
 wpd
 jPQ
 tzi
@@ -1212597,14 +1212500,14 @@ dYD
 dYD
 wTX
 hPM
-qVj
-qVj
-qVj
-qVj
-qVj
-qVj
-qVj
-qVj
+bAS
+bAS
+bAS
+bAS
+bAS
+bAS
+bAS
+bAS
 wpd
 miH
 ras
@@ -1213056,9 +1212959,9 @@ aaa
 aaa
 aaa
 aaa
-dAZ
-dAZ
-dAZ
+aaa
+aaa
+aaa
 kMD
 eDh
 rLp
@@ -1213099,13 +1213002,13 @@ dYD
 dYD
 dYD
 uzo
-qVj
-qVj
-qVj
-qVj
-qVj
-qVj
-qVj
+bAS
+bAS
+bAS
+bAS
+bAS
+bAS
+bAS
 aaa
 wpd
 iSC
@@ -1213557,10 +1213460,10 @@ aaa
 aaa
 aaa
 aaa
-dAZ
-dAZ
-dAZ
-dAZ
+aaa
+aaa
+aaa
+aaa
 kMD
 njU
 rLp
@@ -1213601,12 +1213504,12 @@ dYD
 dYD
 dYD
 vxF
-qVj
-qVj
-qVj
-qVj
-qVj
-qVj
+bAS
+bAS
+bAS
+bAS
+bAS
+bAS
 aaa
 aaa
 wpd
@@ -1214058,11 +1213961,11 @@ aaa
 aaa
 aaa
 aaa
-dAZ
-dAZ
-dAZ
-dAZ
-dAZ
+aaa
+aaa
+aaa
+aaa
+aaa
 kMD
 dQA
 cYk
@@ -1214103,12 +1214006,12 @@ gcR
 dYD
 dYD
 tDf
-qVj
-qVj
-qVj
-qVj
-qVj
-qVj
+bAS
+bAS
+bAS
+bAS
+bAS
+bAS
 aaa
 aaa
 wpd
@@ -1214560,11 +1214463,11 @@ aaa
 aaa
 aaa
 aaa
-dAZ
-dAZ
-dAZ
-dAZ
-dAZ
+aaa
+aaa
+aaa
+aaa
+aaa
 kMD
 bEx
 pBu
@@ -1214605,11 +1214508,11 @@ hPM
 lAx
 lAx
 hPM
-qVj
-qVj
-qVj
-qVj
-ieo
+bAS
+bAS
+bAS
+bAS
+yez
 aoc
 aaa
 aaa
@@ -1215062,11 +1214965,11 @@ aaa
 aaa
 aaa
 aaa
-dAZ
-hwP
-hwP
-hwP
-hwP
+aaa
+bAS
+bAS
+bAS
+bAS
 kMD
 xwS
 kMD
@@ -1215564,10 +1215467,10 @@ aaa
 aaa
 aaa
 aaa
-hwP
-hwP
-hwP
-hqw
+bAS
+bAS
+bAS
+uxR
 hPM
 hPM
 vzO
@@ -1216066,10 +1215969,10 @@ aaa
 aaa
 aaa
 bAS
-rtU
-rtU
-rtU
-rtU
+bvx
+bvx
+bvx
+bvx
 gVj
 oXs
 vzO
@@ -1216568,10 +1216471,10 @@ aaa
 aaa
 bAS
 bAS
-rtU
-rtU
-rtU
-rtU
+bvx
+bvx
+bvx
+bvx
 gVj
 oXs
 vzO
@@ -1217070,10 +1216973,10 @@ bAS
 bAS
 bAS
 bAS
-rtU
-rtU
-eUx
-hqw
+bvx
+bvx
+swe
+uxR
 hPM
 vgb
 vgb
@@ -1217572,11 +1217475,11 @@ bAS
 bAS
 bAS
 bAS
-rtU
-rtU
-hwP
-lmk
-lmk
+bvx
+bvx
+bAS
+ppR
+ppR
 vgb
 tCc
 vZv
@@ -1218074,11 +1217977,11 @@ bAS
 bAS
 bAS
 bAS
-rtU
-rtU
-hwP
-lmk
-lmk
+bvx
+bvx
+bAS
+ppR
+ppR
 vgb
 pcN
 qiJ
@@ -1218577,10 +1218480,10 @@ bAS
 bAS
 bAS
 bvx
-rtU
-hwP
-hwP
-lmk
+bvx
+bAS
+bAS
+ppR
 vgb
 lql
 tTs
@@ -1219080,9 +1218983,9 @@ bAS
 swe
 bvx
 bvx
-hwP
-hwP
-lmk
+bAS
+bAS
+ppR
 vgb
 lql
 vZv
@@ -1221094,7 +1220997,7 @@ vgb
 vgb
 eig
 qiJ
-vDT
+hwP
 ihE
 tEn
 xjo
@@ -1221593,9 +1221496,9 @@ bvx
 oLh
 mFt
 gwP
-jah
-pNd
-pNd
+oLh
+vZv
+vZv
 vKs
 prq
 ahX
@@ -1222092,7 +1221995,7 @@ sMl
 sMl
 bvx
 bvx
-fFJ
+tpf
 ahu
 vBP
 tpf
@@ -1253211,21 +1253114,21 @@ fPa
 fPa
 fPa
 fPa
-jfL
-jfL
-jfL
-jfL
-jfL
-jfL
-jfL
-jfL
-jfL
-jfL
-jfL
-jfL
-jfL
-jfL
-jfL
+fPa
+fPa
+fPa
+fPa
+fPa
+fPa
+fPa
+fPa
+fPa
+fPa
+fPa
+fPa
+fPa
+fPa
+fPa
 fPa
 fPa
 fPa

--- a/maps/metaclub.dmm
+++ b/maps/metaclub.dmm
@@ -1087,9 +1087,6 @@
 	dir = 1;
 	name = "Security E.V.A."
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "red"
@@ -3332,14 +3329,6 @@
 "aiF" = (
 /turf/simulated/wall,
 /area/security/main)
-"aiH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/simulated/wall/r_wall,
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
 "aiJ" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor{
@@ -10750,14 +10739,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/main)
-"ayb" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/simulated/wall/r_wall,
-/area/security/gas_chamber{
-	name = "Firing Range"
-	})
 "ayd" = (
 /obj/structure/table,
 /obj/item/weapon/folder/red,
@@ -108713,12 +108694,6 @@
 	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
-"eqn" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/research_outpost/gearstore)
 "eqo" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4;
@@ -108978,13 +108953,6 @@
 	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
-"eqS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/simulated/floor,
-/area/research_outpost/gearstore)
 "eqT" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -109094,17 +109062,9 @@
 	icon_state = "dark vault full"
 	},
 /area/research_outpost/iso3)
-"eri" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/simulated/floor,
-/area/research_outpost/gearstore)
 "erj" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "erk" = (
@@ -109124,14 +109084,7 @@
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "erm" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "anom_int_airlock_sensor";
-	master_tag = "anom_airlock_control";
-	pixel_y = -24
-	},
 /obj/structure/dispenser/oxygen,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "ern" = (
@@ -109248,13 +109201,8 @@
 /turf/simulated/wall/r_wall,
 /area/research_outpost/maintstore2)
 "erD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "anom_airlock_interior";
-	locked = 1
+	req_access_txt = "47"
 	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
@@ -109298,10 +109246,6 @@
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
 /area/research_outpost/gearstore)
-"erH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/simulated/wall/r_wall,
-/area/research_outpost/gearstore)
 "erI" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/window/reinforced{
@@ -109338,30 +109282,15 @@
 /obj/machinery/recharger{
 	pixel_x = 29
 	},
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	frequency = 1331;
-	id_tag = "anom_airlock_pump"
-	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "erM" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1331;
-	id_tag = "anom_airlock_control";
-	pixel_x = -24;
-	tag_airpump = "anom_airlock_pump";
-	tag_chamber_sensor = "anom_airlock_sensor";
-	tag_exterior_door = "anom_airlock_exterior";
-	tag_exterior_sensor = "anom_ext_airlock_sensor";
-	tag_interior_door = "anom_airlock_interior";
-	tag_interior_sensor = "anom_int_airlock_sensor"
-	},
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	frequency = 1331;
-	id_tag = "anom_airlock_pump"
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 1;
+	on = 1
 	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
@@ -109425,25 +109354,14 @@
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "erU" = (
 /obj/structure/closet/walllocker/emerglocker/west,
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "anom_airlock_sensor";
-	master_tag = "anom_airlock_control";
-	pixel_x = -24;
-	pixel_y = 21
-	},
 /obj/effect/decal/warning_stripes{
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "erV" = (
@@ -109456,11 +109374,7 @@
 /area/mine/explored)
 "erW" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "anom_airlock_exterior";
-	locked = 1
+	req_access_txt = "47"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -109491,20 +109405,6 @@
 "esa" = (
 /obj/structure/hanging_lantern{
 	dir = 1
-	},
-/turf/unsimulated/floor/airless{
-	icon_state = "asteroidfloor"
-	},
-/area/mine/explored)
-"esb" = (
-/obj/structure/hanging_lantern{
-	dir = 1
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "anom_ext_airlock_sensor";
-	master_tag = "anom_airlock_control";
-	pixel_y = 24
 	},
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
@@ -109622,26 +109522,8 @@
 /obj/structure/hanging_lantern,
 /turf/unsimulated/floor/asteroid,
 /area/mine/explored)
-"esy" = (
-/obj/machinery/airlock_sensor{
-	id_tag = "vox_eva_ext_airlock_sensor";
-	master_tag = "vox_eva_airlock_control";
-	pixel_y = -24;
-	req_access_txt = "140"
-	},
-/turf/unsimulated/floor/asteroid,
-/area/mine/explored)
 "esz" = (
 /turf/simulated/wall,
-/area/vox_station/tradepost)
-"esA" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1449;
-	icon_state = "door_locked";
-	id_tag = "vox_eva_airlock_exterior";
-	locked = 1
-	},
-/turf/simulated/floor/plating/vox,
 /area/vox_station/tradepost)
 "esB" = (
 /obj/structure/cable/yellow{
@@ -109696,23 +109578,14 @@
 /turf/simulated/floor/vox,
 /area/vox_station/tradepost)
 "esL" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 4;
-	frequency = 1449;
-	id_tag = "vox_eva_airlock_pump"
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8;
+	on = 1
 	},
 /turf/simulated/floor/plating/vox,
 /area/vox_station/tradepost)
 "esM" = (
-/obj/machinery/airlock_sensor{
-	id_tag = "vox_eva_airlock_sensor";
-	master_tag = "vox_eva_airlock_control";
-	pixel_x = 24
-	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /turf/simulated/floor/plating/vox,
 /area/vox_station/tradepost)
 "esN" = (
@@ -109732,9 +109605,7 @@
 /turf/simulated/floor/vox,
 /area/vox_station/tradepost)
 "esP" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor/plating/vox,
 /area/vox_station/tradepost)
 "esQ" = (
@@ -109768,9 +109639,6 @@
 /turf/simulated/floor/vox,
 /area/vox_station/tradepost)
 "esU" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /turf/simulated/floor/plating/vox,
 /area/vox_station/tradepost)
 "esV" = (
@@ -109781,15 +109649,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
 /turf/simulated/floor/vox,
-/area/vox_station/tradepost)
-"esX" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1449;
-	icon_state = "door_locked";
-	id_tag = "vox_eva_airlock_interior";
-	locked = 1
-	},
-/turf/simulated/floor/plating/vox,
 /area/vox_station/tradepost)
 "esY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -109804,12 +109663,6 @@
 /area/vox_station/tradepost)
 "eta" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/airlock_sensor{
-	id_tag = "vox_eva_int_airlock_sensor";
-	master_tag = "vox_eva_airlock_control";
-	pixel_y = 24;
-	req_access_txt = "140"
-	},
 /turf/simulated/floor/vox,
 /area/vox_station/tradepost)
 "etb" = (
@@ -109836,19 +109689,8 @@
 /turf/simulated/floor/vox,
 /area/vox_station/tradepost)
 "etf" = (
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	id_tag = "vox_eva_airlock_control";
-	pixel_y = 24;
-	req_access_txt = "140";
-	tag_airpump = "vox_eva_airlock_pump";
-	tag_chamber_sensor = "vox_eva_airlock_sensor";
-	tag_exterior_door = "vox_eva_airlock_exterior";
-	tag_exterior_sensor = "vox_eva_ext_airlock_sensor";
-	tag_interior_door = "vox_eva_airlock_interior";
-	tag_interior_sensor = "vox_eva_int_airlock_sensor"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
 	},
 /turf/simulated/floor/vox,
 /area/vox_station/tradepost)
@@ -117995,11 +117837,6 @@
 	icon_state = "warning";
 	tag = "icon-warning (SOUTHWEST)"
 	},
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 1;
-	frequency = 1331;
-	id_tag = "sec_eva_airlock_pump"
-	},
 /turf/simulated/floor/plating,
 /area/security/range{
 	name = "\improper Security E.V.A"
@@ -118503,7 +118340,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
 /turf/simulated/floor,
 /area/security/range{
 	name = "\improper Security E.V.A"
@@ -118566,14 +118405,6 @@
 /area/security/range{
 	name = "\improper Security E.V.A"
 	})
-"hsT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/security/gas_chamber{
-	name = "Firing Range"
-	})
 "htg" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -118586,14 +118417,6 @@
 	icon_state = "red"
 	},
 /area/security/brig)
-"hFy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/simulated/wall,
-/area/security/gas_chamber{
-	name = "Firing Range"
-	})
 "hGq" = (
 /obj/structure/sink{
 	pixel_y = 28
@@ -118751,14 +118574,6 @@
 	icon_state = "redfull"
 	},
 /area/security/brig)
-"iNC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
 "iPo" = (
 /obj/item/device/radio/intercom{
 	pixel_x = 25
@@ -119207,9 +119022,6 @@
 	icon_state = "warning";
 	tag = "icon-warning (WEST)"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
 /turf/simulated/floor/plating,
 /area/security/range{
 	name = "\improper Security E.V.A"
@@ -119268,11 +119080,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/meter,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "red"
@@ -119302,9 +119109,6 @@
 	dir = 1;
 	icon_state = "warning";
 	tag = "icon-warning (NORTH)"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /obj/item/weapon/tank/jetpack,
 /turf/simulated/floor{
@@ -119443,22 +119247,6 @@
 	icon_state = "dark vault stripe"
 	},
 /area/security/main)
-"moj" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
 "moy" = (
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -119513,7 +119301,9 @@
 	tag = "icon-warning (NORTH)"
 	},
 /obj/item/weapon/tank/jetpack,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "red"
@@ -119665,15 +119455,7 @@
 	dir = 4;
 	name = "Firelock East"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "sec_eva_int_airlock";
-	locked = 1;
 	name = "Security External Airlock";
 	req_access_txt = "63"
 	},
@@ -119756,14 +119538,6 @@
 	icon_state = "dark"
 	},
 /area/security/warden)
-"nrq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/simulated/wall/r_wall,
-/area/security/gas_chamber{
-	name = "Firing Range"
-	})
 "nst" = (
 /obj/machinery/washing_machine,
 /obj/machinery/light/small{
@@ -119800,6 +119574,7 @@
 "nyY" = (
 /obj/machinery/recharger,
 /obj/structure/table,
+/obj/item/weapon/reagent_containers/food/drinks/gromitmug,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "red"
@@ -120075,13 +119850,6 @@
 	},
 /area/research_outpost/anomaly)
 "oOF" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "sec_eva_int_airlock_sensor";
-	master_tag = "sec_eva_airlock_control";
-	pixel_x = -24;
-	req_access_txt = "63"
-	},
 /obj/effect/decal/warning_stripes{
 	dir = 8;
 	icon_state = "warning_corner";
@@ -120090,7 +119858,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
@@ -120137,10 +119904,7 @@
 	icon_state = "warning";
 	tag = "icon-warning (NORTHWEST)"
 	},
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	frequency = 1331;
-	id_tag = "sec_eva_airlock_pump"
-	},
+/obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
 /area/security/range{
 	name = "\improper Security E.V.A"
@@ -120200,12 +119964,6 @@
 	icon_state = "red"
 	},
 /area/security/main)
-"pcW" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/simulated/wall/r_wall,
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
 "pfa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -120214,12 +119972,6 @@
 	icon_state = "white"
 	},
 /area/science/hallway)
-"pjR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/simulated/wall/r_wall,
-/area/research_outpost/gearstore)
 "plB" = (
 /obj/structure/cable/orange{
 	d2 = 2;
@@ -121096,11 +120848,6 @@
 	icon_state = "warning";
 	tag = "icon-warning (SOUTHEAST)"
 	},
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 1;
-	frequency = 1331;
-	id_tag = "sec_eva_airlock_pump"
-	},
 /turf/simulated/floor/plating,
 /area/security/range{
 	name = "\improper Security E.V.A"
@@ -121117,13 +120864,6 @@
 /turf/simulated/floor,
 /area/crew_quarters/sleep)
 "sEg" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "sec_eva_ext_airlock_sensor";
-	master_tag = "sec_eva_airlock_control";
-	pixel_x = 24;
-	req_access_txt = "63"
-	},
 /obj/machinery/camera{
 	dir = 8;
 	name = "Security E.V.A. External"
@@ -121590,14 +121330,6 @@
 	icon_state = "dark"
 	},
 /area/engineering/supermatter_room)
-"uSE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/simulated/wall,
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
 "uWs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/glass_security{
@@ -121736,9 +121468,6 @@
 	tag = "icon-warning (NORTH)"
 	},
 /obj/item/weapon/tank/jetpack,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/simulated/floor{
 	icon_state = "red"
 	},
@@ -121844,31 +121573,6 @@
 	icon_state = "warning";
 	tag = "icon-warning (NORTHEAST)"
 	},
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1331;
-	id_tag = "sec_eva_airlock_control";
-	pixel_x = 5;
-	pixel_y = 24;
-	req_access_txt = "63";
-	tag_airpump = "sec_eva_airlock_pump";
-	tag_chamber_sensor = "sec_eva_airlock_sensor";
-	tag_exterior_door = "sec_eva_ext_airlock";
-	tag_exterior_sensor = "sec_eva_ext_airlock_sensor";
-	tag_interior_door = "sec_eva_int_airlock";
-	tag_interior_sensor = "sec_eva_int_airlock_sensor"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "sec_eva_airlock_sensor";
-	master_tag = "sec_eva_airlock_control";
-	pixel_x = -5;
-	pixel_y = 24;
-	req_access_txt = "63"
-	},
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	frequency = 1331;
-	id_tag = "sec_eva_airlock_pump"
-	},
 /turf/simulated/floor/plating,
 /area/security/range{
 	name = "\improper Security E.V.A"
@@ -121902,9 +121606,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
@@ -122094,11 +121795,6 @@
 /area/shuttle/escape_pod3)
 "xDf" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "sec_eva_ext_airlock";
-	locked = 1;
 	name = "Security External Airlock";
 	req_access_txt = "63"
 	},
@@ -122213,7 +121909,6 @@
 	icon_state = "warning";
 	tag = "icon-warning (EAST)"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /turf/simulated/floor/plating,
 /area/security/range{
 	name = "\improper Security E.V.A"
@@ -225911,11 +225606,11 @@ wQe
 swq
 tLH
 tzK
-nrq
+wQe
 oRC
 ljy
 fjY
-aiH
+xfU
 aam
 aam
 aeo
@@ -226413,11 +226108,11 @@ wQe
 swq
 tLH
 tzK
-ayb
+wQe
 wuu
 xTa
 szD
-pcW
+xfU
 adP
 adP
 adP
@@ -226915,11 +226610,11 @@ tNV
 kFz
 xMJ
 iwY
-hsT
+wQe
 xfU
 mWC
 vMd
-iNC
+xfU
 aiJ
 akd
 aoD
@@ -227417,11 +227112,11 @@ tNV
 aeJ
 aeJ
 aeJ
-hFy
+tNV
 oOF
 lmR
 acZ
-uSE
+xfU
 fSH
 akf
 alz
@@ -229426,7 +229121,7 @@ tNV
 rDX
 wXy
 tNV
-moj
+gKg
 qGv
 gKg
 psr
@@ -1203812,14 +1203507,14 @@ eoc
 eoI
 epn
 epm
-eqn
-eqS
+eql
+eqQ
 erm
-erH
-erH
-pjR
 epg
-esb
+epg
+epg
+epg
+esa
 esf
 eeb
 eeb
@@ -1204818,7 +1204513,7 @@ eph
 epm
 eqi
 eqN
-eri
+epm
 erD
 erL
 erT
@@ -1234484,10 +1234179,10 @@ aaa
 aaa
 aaa
 eeb
-esA
+etD
 esL
-esL
-esX
+esU
+etD
 ete
 etl
 etz
@@ -1234985,11 +1234680,11 @@ aaa
 aaa
 aaa
 aaa
-esy
+eeb
 esz
 esM
 esU
-esY
+esz
 etf
 etq
 etA

--- a/maps/packedstation.dmm
+++ b/maps/packedstation.dmm
@@ -879,18 +879,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
-"abK" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fstarboardsolar)
 "abL" = (
 /turf/simulated/wall,
 /area/maintenance/fstarboardsolar)
@@ -39650,10 +39638,6 @@
 "boV" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/aportsolar)
-"boW" = (
-/obj/structure/lattice,
-/turf/space,
-/area/maintenance/aportsolar)
 "boX" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -58449,9 +58433,6 @@
 /area/vox_trading_post/dorms)
 "cwQ" = (
 /obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/simple/filtering/hidden{
-	dir = 10
-	},
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
@@ -59298,22 +59279,6 @@
 	icon_state = "dark"
 	},
 /area/vox_trading_post/gardens)
-"cys" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_solars_ext_airlock_sensor";
-	master_tag = "vox_solars_airlock_control";
-	pixel_x = 24;
-	req_access_txt = "140"
-	},
-/turf/space,
-/area/vox_trading_post/solararray)
 "cyt" = (
 /obj/machinery/power/solar/control{
 	id_tag = "voxsolar";
@@ -59323,13 +59288,6 @@
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_solars_int_airlock_sensor";
-	master_tag = "vox_solars_airlock_control";
-	pixel_x = -24;
-	req_access_txt = "140"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/vox,
@@ -59353,7 +59311,6 @@
 /area/vox_trading_post/solars)
 "cyv" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/atmospherics/unary/portables_connector,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/solars)
@@ -59537,14 +59494,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "vox_solars_airlock_exterior";
-	locked = 1
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/solars)
 "cyT" = (
@@ -59553,57 +59504,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4;
-	frequency = 1331;
-	id_tag = "vox_solars_airlock_pump"
-	},
 /obj/effect/decal/warning_stripes{
 	dir = 9;
 	icon_state = "all";
 	tag = "icon-all (NORTHWEST)"
 	},
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1331;
-	id_tag = "vox_solars_airlock_control";
-	pixel_x = -7;
-	pixel_y = 25;
-	req_access_txt = "140";
-	tag_airpump = "vox_solars_airlock_pump";
-	tag_chamber_sensor = "vox_solars_airlock_sensor";
-	tag_exterior_door = "vox_solars_airlock_exterior";
-	tag_exterior_sensor = "vox_solars_ext_airlock_sensor";
-	tag_interior_door = "vox_solars_airlock_interior";
-	tag_interior_sensor = "vox_solars_int_airlock_sensor"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_solars_airlock_sensor";
-	master_tag = "vox_solars_airlock_control";
-	pixel_x = 5;
-	pixel_y = 21;
-	req_access_txt = "140"
-	},
 /obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/vox,
-/area/vox_trading_post/solars)
-"cyU" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "vox_solars_airlock_interior";
-	locked = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/solars)
@@ -59616,9 +59522,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
 	icon_state = "5-6"
@@ -59626,16 +59529,10 @@
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/solars)
 "cyW" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/solars)
 "cyX" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 9
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
 	icon_state = "9-10"
@@ -60030,23 +59927,11 @@
 	dir = 4;
 	icon_state = "nitrogen"
 	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_goodsfloor_ext_airlock_sensor";
-	master_tag = "vox_goodsfloor_airlock_control";
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/filtering/hidden{
-	dir = 4
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
 /area/vox_trading_post/trading_floor)
 "czY" = (
-/obj/machinery/atmospherics/pipe/simple/filtering/hidden{
-	dir = 4
-	},
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
@@ -60079,16 +59964,11 @@
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/trading_floor)
 "cAe" = (
-/obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "vox_goodsfloor_airlock_interior";
-	locked = 1
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/door/airlock/silver{
+	name = "Trade Floor";
+	normalspeed = 0;
+	req_access_txt = "140"
 	},
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/trading_floor)
@@ -60099,44 +59979,12 @@
 	tag = "icon-all (NORTHWEST)"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1331;
-	id_tag = "vox_goodsfloor_airlock_control";
-	pixel_x = -7;
-	pixel_y = 25;
-	tag_chamber_sensor = "vox_goodsfloor_airlock_sensor";
-	tag_exterior_door = "vox_goodsfloor_airlock_exterior";
-	tag_exterior_sensor = "vox_goodsfloor_ext_airlock_sensor";
-	tag_interior_door = "vox_goodsfloor_airlock_interior";
-	tag_interior_sensor = "vox_goodsfloor_int_airlock_sensor"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_goodsfloor_airlock_sensor";
-	master_tag = "vox_goodsfloor_airlock_control";
-	pixel_x = 5;
-	pixel_y = 21
-	},
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 4;
-	frequency = 1331;
-	id_tag = "vox_goodsfloor_airlock_pump"
-	},
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/trading_floor)
 "cAg" = (
 /obj/effect/decal/warning_stripes{
 	dir = 8;
 	icon_state = "oxygen"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_goodsfloor_int_airlock_sensor";
-	master_tag = "vox_goodsfloor_airlock_control";
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /turf/simulated/floor/vox{
 	icon_state = "asteroidplating"
@@ -60149,10 +59997,6 @@
 	name = "Outpost APC";
 	pixel_y = 24;
 	req_access = null
-	},
-/obj/machinery/atmospherics/pipe/layer_adapter/supply/hidden{
-	dir = 4;
-	tag = "icon-adapter_2 (EAST)"
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -60181,33 +60025,22 @@
 	},
 /area/vox_trading_post/hallway)
 "cAk" = (
-/obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "vox_goodsfloor_airlock_exterior";
-	locked = 1
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/filtering/hidden{
-	dir = 4
+/obj/machinery/door/airlock/silver{
+	name = "Trade Floor";
+	normalspeed = 0;
+	req_access_txt = "140"
 	},
 /turf/simulated/floor/plating,
 /area/vox_trading_post/trading_floor)
 "cAl" = (
 /obj/machinery/vending/groans,
-/obj/machinery/atmospherics/pipe/simple/filtering/hidden{
-	dir = 4
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
 /area/vox_trading_post/trading_floor)
 "cAm" = (
 /obj/machinery/vending/discount,
-/obj/machinery/atmospherics/pipe/simple/filtering/hidden{
-	dir = 4
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -60257,7 +60090,6 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/filtering/hidden,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -60686,7 +60518,6 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/filtering/hidden,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -60725,9 +60556,12 @@
 	dir = 4;
 	tag = "icon-map (EAST)"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layered,
 /obj/structure/cable/green{
 	icon_state = "1-10"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layered{
+	dir = 4;
+	tag = "icon-map (EAST)"
 	},
 /turf/simulated/floor/vox{
 	icon_state = "asteroidplating"
@@ -60845,20 +60679,13 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/filtering/hidden,
+/obj/machinery/atmospherics/pipe/simple/filtering/hidden{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
 /area/vox_trading_post/trading_floor)
-"cBX" = (
-/obj/machinery/atmospherics/pipe/manifold/filtering/hidden{
-	dir = 4
-	},
-/turf/unsimulated/floor/airless{
-	dir = 4;
-	icon_state = "asteroidwarning"
-	},
-/area/mine/explored)
 "cBY" = (
 /obj/machinery/atmospherics/pipe/manifold/filtering/hidden,
 /turf/unsimulated/floor/airless{
@@ -61338,25 +61165,6 @@
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/trading_floor)
-"cCY" = (
-/obj/machinery/atmospherics/pipe/simple/filtering/hidden,
-/turf/unsimulated/floor/airless{
-	dir = 4;
-	icon_state = "asteroidwarning"
-	},
-/area/mine/explored)
-"cCZ" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_tradehall_ext_airlock_sensor";
-	master_tag = "vox_tradehall_airlock_control";
-	pixel_x = -24
-	},
-/turf/unsimulated/floor/airless{
-	dir = 6;
-	icon_state = "asteroidwarning"
-	},
-/area/mine/explored)
 "cDa" = (
 /turf/simulated/wall/r_rock,
 /area/vox_trading_post/docking)
@@ -61503,43 +61311,13 @@
 	},
 /area/vox_trading_post/hallway)
 "cDr" = (
-/obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "vox_tradehall_airlock_interior";
-	locked = 1
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor/plating,
 /area/vox_trading_post/trading_floor)
 "cDs" = (
 /obj/machinery/light/small{
 	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4;
-	frequency = 1331;
-	id_tag = "vox_tradehall_airlock_pump"
-	},
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1331;
-	id_tag = "vox_tradehall_airlock_control";
-	pixel_x = -7;
-	pixel_y = -24;
-	tag_airpump = "vox_tradehall_airlock_pump";
-	tag_chamber_sensor = "vox_tradehall_airlock_sensor";
-	tag_exterior_door = "vox_tradehall_airlock_exterior";
-	tag_exterior_sensor = "vox_tradehall_ext_airlock_sensor";
-	tag_interior_door = "vox_tradehall_airlock_interior";
-	tag_interior_sensor = "vox_tradehall_int_airlock_sensor"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_tradehall_airlock_sensor";
-	master_tag = "vox_tradehall_airlock_control";
-	pixel_x = 5;
-	pixel_y = -22
 	},
 /obj/effect/decal/warning_stripes{
 	dir = 9;
@@ -61601,20 +61379,6 @@
 "cDC" = (
 /turf/simulated/wall/r_rock,
 /area/vox_trading_post/vault)
-"cDD" = (
-/obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "vox_tradehall_airlock_exterior";
-	locked = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/filtering/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/vox_trading_post/trading_floor)
 "cDE" = (
 /obj/machinery/atmospherics/pipe/simple/filtering/hidden{
 	dir = 9
@@ -61626,17 +61390,6 @@
 /area/mine/explored)
 "cDF" = (
 /obj/docking_port/destination/vox/tradepost,
-/turf/space,
-/area)
-"cDG" = (
-/obj/structure/catwalk,
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_dock_ext_airlock_sensor";
-	master_tag = "vox_dock_airlock_control";
-	pixel_x = 24;
-	req_access_txt = "140"
-	},
 /turf/space,
 /area)
 "cDI" = (
@@ -61694,17 +61447,6 @@
 	icon_state = "dark"
 	},
 /area/vox_trading_post/trading_floor)
-"cDT" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_tradehall_int_airlock_sensor";
-	master_tag = "vox_tradehall_airlock_control";
-	pixel_x = 24
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/vox_trading_post/trading_floor)
 "cDU" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/structure/window{
@@ -61724,13 +61466,6 @@
 /obj/item/weapon/tank/nitrogen,
 /obj/item/weapon/tank/nitrogen,
 /obj/item/weapon/tank/nitrogen,
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_dock_int_airlock_sensor";
-	master_tag = "vox_dock_airlock_control";
-	pixel_x = -24;
-	req_access_txt = "140"
-	},
 /obj/machinery/atmospherics/unary/vent_pump{
 	frequency = 1331;
 	name = "Outpost Air Vent";
@@ -61797,53 +61532,24 @@
 /turf/simulated/wall,
 /area/vox_trading_post/trading_floor)
 "cEb" = (
-/obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "vox_dock_airlock_exterior";
-	locked = 1
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/eva)
 "cEc" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 8;
-	frequency = 1331;
-	id_tag = "vox_dock_airlock_pump"
-	},
 /obj/effect/decal/warning_stripes{
 	dir = 9;
 	icon_state = "all";
 	tag = "icon-all (NORTHWEST)"
 	},
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1331;
-	id_tag = "vox_dock_airlock_control";
-	pixel_x = -7;
-	pixel_y = 25;
-	req_access_txt = "140";
-	tag_airpump = "vox_dock_airlock_pump";
-	tag_chamber_sensor = "vox_dock_airlock_sensor";
-	tag_exterior_door = "vox_dock_airlock_exterior";
-	tag_exterior_sensor = "vox_dock_ext_airlock_sensor";
-	tag_interior_door = "vox_dock_airlock_interior";
-	tag_interior_sensor = "vox_dock_int_airlock_sensor"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_dock_airlock_sensor";
-	master_tag = "vox_dock_airlock_control";
-	pixel_x = 5;
-	pixel_y = 21;
-	req_access_txt = "140"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4;
+	frequency = 1331;
+	name = "Outpost Air Vent";
+	on = 1
+	},
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/eva)
 "cEd" = (
@@ -61926,17 +61632,11 @@
 /turf/unsimulated/floor/asteroid,
 /area/mine/explored)
 "cEj" = (
-/obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "vox_dock_airlock_interior";
-	locked = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/eva)
 "cEl" = (
@@ -62299,16 +61999,6 @@
 	},
 /area/vox_trading_post/docking)
 "cEU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_eva_airlock_sensor";
-	master_tag = "vox_eva_airlock_control";
-	pixel_y = 24;
-	req_access_txt = "140"
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/vox{
 	icon_state = "asteroidplating"
@@ -62444,24 +62134,8 @@
 	},
 /area/vox_trading_post/docking)
 "cFg" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 4;
-	frequency = 1331;
-	id_tag = "vox_eva_airlock_pump"
-	},
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1331;
-	id_tag = "vox_eva_airlock_control";
-	pixel_y = 25;
-	req_access_txt = "140";
-	tag_airpump = "vox_eva_airlock_pump";
-	tag_chamber_sensor = "vox_eva_airlock_sensor";
-	tag_exterior_door = "vox_eva_airlock_exterior";
-	tag_exterior_sensor = "vox_eva_ext_airlock_sensor";
-	tag_interior_door = "vox_eva_airlock_interior";
-	tag_interior_sensor = "vox_eva_int_airlock_sensor"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/emcloset/vox,
 /turf/simulated/floor/vox{
 	icon_state = "asteroidplating"
 	},
@@ -62489,9 +62163,6 @@
 	tag = ""
 	},
 /obj/structure/window/full/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/glowshroom/single,
 /turf/simulated/floor/plating/vox,
@@ -62684,14 +62355,11 @@
 	},
 /area/vox_trading_post/docking)
 "cFA" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "vox_eva_airlock_interior";
-	locked = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor/vox{
 	icon_state = "asteroidplating"
 	},
@@ -62876,24 +62544,6 @@
 	},
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/armory)
-"cFT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated/wall/r_rock,
-/area/vox_trading_post/storage_1)
-"cFU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/simulated/wall/r_rock,
-/area/vox_trading_post/storage_1)
-"cFV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/vox_trading_post/storage_1)
 "cFX" = (
 /obj/effect/glowshroom/single,
 /obj/machinery/power/apc{
@@ -62909,19 +62559,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/vox_trading_post/storage_1)
-"cFY" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_eva_ext_airlock_sensor";
-	master_tag = "vox_eva_airlock_control";
-	pixel_x = -24;
-	req_access_txt = "140"
-	},
-/turf/unsimulated/floor/airless{
-	dir = 6;
-	icon_state = "asteroidwarning"
-	},
-/area/mine/explored)
 "cFZ" = (
 /obj/machinery/suit_storage_unit/excavation,
 /turf/simulated/floor{
@@ -63386,7 +63023,6 @@
 	},
 /area/vox_trading_post/docking)
 "cGX" = (
-/obj/structure/closet/emcloset/vox,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
 	dir = 4;
 	tag = "icon-intact (EAST)"
@@ -63395,6 +63031,8 @@
 	dir = 4;
 	tag = "icon-intact (EAST)"
 	},
+/obj/structure/table,
+/obj/item/weapon/reagent_containers/food/drinks/gromitmug,
 /turf/simulated/floor/vox{
 	icon_state = "asteroidplating"
 	},
@@ -69831,13 +69469,8 @@
 	},
 /area/library)
 "dVE" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "vox_eva_airlock_exterior";
-	locked = 1
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor/vox{
 	icon_state = "asteroidplating"
 	},
@@ -69954,17 +69587,7 @@
 /area/hallway/primary/central)
 "eCQ" = (
 /obj/item/weapon/stool,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_eva_int_airlock_sensor";
-	master_tag = "vox_eva_airlock_control";
-	pixel_x = 25;
-	req_access_txt = "140"
-	},
 /turf/simulated/floor/vox{
 	icon_state = "asteroidplating"
 	},
@@ -70138,7 +69761,9 @@
 /area/library)
 "fEz" = (
 /obj/item/weapon/stool,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
 /turf/simulated/floor/vox{
 	icon_state = "asteroidplating"
 	},
@@ -70779,7 +70404,6 @@
 	},
 /area/library)
 "kDY" = (
-/obj/machinery/atmospherics/pipe/simple/filtering/hidden,
 /obj/structure/closet/walllocker/emerglocker{
 	pixel_x = 32
 	},
@@ -71100,12 +70724,13 @@
 /turf/simulated/floor/plating,
 /area/supply/storage)
 "mgC" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
 	frequency = 1331;
-	id_tag = "vox_eva_airlock_pump"
+	name = "Outpost Air Vent";
+	on = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/vox{
 	icon_state = "asteroidplating"
 	},
@@ -71212,9 +70837,6 @@
 /turf/simulated/wall/shuttle,
 /area/shuttle/escape/centcom)
 "mLc" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
 /turf/simulated/floor/vox{
@@ -72126,15 +71748,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/hallway/secondary/exit)
-"uNL" = (
-/obj/effect/glowshroom/single,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/vox{
-	icon_state = "asteroidplating"
-	},
-/area/vox_trading_post/trading_floor)
 "uVs" = (
 /obj/structure/shuttle/diag_wall/smooth,
 /turf/space,
@@ -173212,7 +172825,7 @@ aXf
 bnw
 blc
 boy
-boW
+aai
 aaa
 aaa
 aaa
@@ -203753,7 +203366,7 @@ aai
 aaa
 aaa
 aaa
-abJ
+adW
 acr
 acZ
 adC
@@ -204255,7 +203868,7 @@ aai
 aaa
 aaa
 aaa
-abK
+abL
 abL
 abL
 abL
@@ -1151639,7 +1151252,7 @@ cvy
 cvC
 cvn
 cvy
-cys
+cwr
 cyR
 aaa
 czG
@@ -1153146,7 +1152759,7 @@ aaa
 aaa
 cyk
 cyk
-cyU
+cyS
 czr
 cyk
 aai
@@ -1153665,7 +1153278,7 @@ cAa
 qUA
 biJ
 cDi
-cDG
+agO
 agO
 aai
 aaa
@@ -1158674,7 +1158287,7 @@ czk
 czk
 czk
 cDh
-uNL
+kbC
 cDm
 gjf
 cAw
@@ -1163200,13 +1162813,13 @@ cBW
 cCo
 cDS
 cDS
-cDT
+cDS
 cEm
 cuO
 cGK
 cFi
 cFA
-cFV
+cGY
 cGK
 cGK
 cuO
@@ -1163708,7 +1163321,7 @@ cuO
 cGY
 cFg
 mgC
-cFT
+cGK
 cuO
 cuO
 cuz
@@ -1164210,7 +1163823,7 @@ cuO
 cGY
 cEU
 mLc
-cFU
+cGK
 cuO
 cuz
 cuz
@@ -1164705,7 +1164318,7 @@ cAQ
 cBY
 cBk
 cCX
-cDD
+cDr
 cEa
 cuP
 cuP
@@ -1165204,17 +1164817,17 @@ cuP
 cuP
 cuV
 cAR
-cBX
-cCY
-cCY
 cDE
-cCZ
+cvd
+cvd
+cvd
+cuY
 cuP
 cuP
 cuV
 cvd
 cvd
-cFY
+cuY
 cuP
 cuO
 cuO
@@ -1184680,7 +1184293,7 @@ cuz
 cuz
 cuz
 cuz
-cuO
+cuz
 cuz
 cuz
 cuz
@@ -1185182,7 +1184795,7 @@ cuz
 cuz
 cuz
 cuz
-cuO
+cuz
 cuz
 cuz
 cuz
@@ -1185684,7 +1185297,7 @@ cuz
 cuz
 cuz
 cuz
-cuO
+cuz
 cuz
 cuz
 cuz
@@ -1186186,7 +1185799,7 @@ cuz
 cuz
 cuz
 cuz
-cuO
+cuz
 cuz
 cuz
 cuz
@@ -1205362,7 +1204975,7 @@ cuP
 cuP
 cuP
 cuO
-cuz
+cuO
 cuO
 cuP
 cuP
@@ -1205864,7 +1205477,7 @@ cuP
 cuP
 cuO
 cuO
-cuz
+cuO
 cuS
 cuP
 cuP
@@ -1206366,7 +1205979,7 @@ cuP
 aai
 cuO
 cuO
-cuz
+cuO
 cuS
 cvI
 cuP
@@ -1206868,7 +1206481,7 @@ agO
 aai
 cuO
 cuO
-cuz
+cuO
 cuS
 cuP
 cuP
@@ -1207370,7 +1206983,7 @@ agO
 aai
 cuO
 cuO
-cuz
+cuO
 cuO
 cuP
 cuP

--- a/maps/snaxi.dmm
+++ b/maps/snaxi.dmm
@@ -70909,14 +70909,8 @@
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/solars)
 "dEs" = (
-/obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "vox_solars_airlock_exterior";
-	locked = 1
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/external,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -70935,34 +70929,6 @@
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/solars)
 "dEu" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	frequency = 1331;
-	id_tag = "vox_solars_airlock_pump"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1331;
-	id_tag = "vox_solars_airlock_control";
-	pixel_x = 24;
-	pixel_y = -5;
-	tag_airpump = "vox_solars_airlock_pump";
-	tag_chamber_sensor = "vox_solars_airlock_sensor";
-	tag_exterior_door = "vox_solars_airlock_exterior";
-	tag_exterior_sensor = "vox_solars_ext_airlock_sensor";
-	tag_interior_door = "vox_solars_airlock_interior";
-	tag_interior_sensor = "vox_solars_int_airlock_sensor"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_solars_airlock_sensor";
-	master_tag = "vox_solars_airlock_control";
-	pixel_x = 24;
-	pixel_y = 5
-	},
 /obj/effect/decal/warning_stripes{
 	dir = 9;
 	icon_state = "all";
@@ -70972,6 +70938,11 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/solars)
 "dEv" = (
@@ -70989,23 +70960,6 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/turf/simulated/floor/plating/vox,
-/area/vox_trading_post/solars)
-"dEy" = (
-/obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "vox_solars_airlock_interior";
-	locked = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/solars)
 "dEz" = (
@@ -71098,12 +71052,6 @@
 	name = "Vox Outpost Solar Control";
 	track = 2
 	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_solars_int_airlock_sensor";
-	master_tag = "vox_solars_airlock_control";
-	pixel_y = 24
-	},
 /obj/effect/decal/warning_stripes{
 	dir = 1;
 	icon_state = "warning_corner";
@@ -71142,7 +71090,6 @@
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/solars)
 "dEI" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -71272,7 +71219,6 @@
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/solars)
 "dET" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -71341,9 +71287,6 @@
 /area/vox_trading_post/hallway)
 "dFa" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/solars)
@@ -71363,10 +71306,6 @@
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/solars)
 "dFc" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 5;
-	tag = "icon-intact (NORTHEAST)"
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -73349,15 +73288,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/trade_processing)
-"dIE" = (
-/obj/structure/catwalk,
-/obj/machinery/airlock_sensor{
-	id_tag = "vox_eva_ext_airlock_sensor";
-	master_tag = "vox_eva_airlock_control";
-	pixel_y = -24
-	},
-/turf/space,
-/area)
 "dIF" = (
 /obj/machinery/vending/voxseeds{
 	slogan_delay = 700
@@ -73497,15 +73427,6 @@
 	},
 /turf/simulated/wall,
 /area/vox_trading_post/trading_floor)
-"dIV" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1449;
-	icon_state = "door_locked";
-	id_tag = "vox_eva_airlock_exterior";
-	locked = 1
-	},
-/turf/simulated/floor/plating/vox,
-/area/vox_trading_post/eva)
 "dIW" = (
 /turf/simulated/wall,
 /area/vox_trading_post/eva)
@@ -73654,11 +73575,6 @@
 /turf/simulated/floor,
 /area/vox_trading_post/trading_floor)
 "dJo" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 4;
-	frequency = 1449;
-	id_tag = "vox_eva_airlock_pump"
-	},
 /turf/simulated/floor/engine/vacuum,
 /area/vox_trading_post/eva)
 "dJp" = (
@@ -73668,9 +73584,6 @@
 	pixel_x = 24
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /turf/simulated/floor/engine/vacuum,
 /area/vox_trading_post/eva)
 "dJq" = (
@@ -73900,18 +73813,20 @@
 /turf/simulated/floor,
 /area/vox_trading_post/trading_floor)
 "dJM" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump{
+	canSpawnMice = 0;
+	dir = 8;
+	frequency = 1331;
+	name = "Outpost Air Vent";
+	on = 1
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/vox_trading_post/eva)
 "dJN" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor/engine/vacuum,
 /area/vox_trading_post/eva)
 "dJO" = (
@@ -74024,6 +73939,7 @@
 	pixel_x = 25;
 	pixel_y = -8
 	},
+/obj/item/weapon/reagent_containers/food/drinks/gromitmug,
 /turf/simulated/floor/vox{
 	icon_state = "dark"
 	},
@@ -74032,19 +73948,6 @@
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor,
 /area/vox_trading_post/trading_floor)
-"dKb" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1449;
-	icon_state = "door_locked";
-	id_tag = "vox_eva_airlock_interior";
-	locked = 1
-	},
-/turf/simulated/floor/plating/vox,
-/area/vox_trading_post/eva)
-"dKc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/simulated/wall,
-/area/vox_trading_post/eva)
 "dKd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/wall,
@@ -74129,26 +74032,13 @@
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/eva)
 "dKm" = (
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	id_tag = "vox_eva_airlock_control";
-	pixel_y = 24;
-	tag_airpump = "vox_eva_airlock_pump";
-	tag_chamber_sensor = "vox_eva_airlock_sensor";
-	tag_exterior_door = "vox_eva_airlock_exterior";
-	tag_exterior_sensor = "vox_eva_ext_airlock_sensor";
-	tag_interior_door = "vox_eva_airlock_interior";
-	tag_interior_sensor = "vox_eva_int_airlock_sensor"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/eva)
 "dKn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/airlock_sensor{
-	id_tag = "vox_eva_int_airlock_sensor";
-	master_tag = "vox_eva_airlock_control";
-	pixel_y = 24
-	},
 /obj/machinery/alarm/vox{
 	alarm_frequency = 1331;
 	dir = 4;
@@ -75511,16 +75401,6 @@
 	tag = "icon-darkyellowfull"
 	},
 /area/shuttle/trade/start)
-"dMN" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_solars_airlock_sensor";
-	master_tag = "vox_solars_airlock_control";
-	pixel_x = -5;
-	pixel_y = -24
-	},
-/turf/space,
-/area)
 "dMO" = (
 /obj/structure/shuttle/diag_wall/black,
 /turf/simulated/floor{
@@ -556761,7 +556641,7 @@ ccH
 ccH
 cCl
 dby
-dIE
+dby
 dIW
 dJq
 dJN
@@ -557064,10 +556944,10 @@ ccH
 cCl
 dby
 dby
-dIV
+dMl
+dJM
 dJo
-dJo
-dKb
+dMl
 dKl
 dKB
 dKP
@@ -557368,8 +557248,8 @@ dby
 dby
 dIW
 dJp
-dJM
-dKc
+dJo
+dIW
 dKm
 dKC
 dKQ
@@ -558553,7 +558433,7 @@ dEo
 dEp
 dEs
 dEu
-dEy
+dEs
 dEI
 dET
 dFc
@@ -558852,7 +558732,7 @@ ccH
 ccH
 ccH
 ccH
-dMN
+ccH
 dEq
 dEq
 dEq

--- a/maps/synergy.dmm
+++ b/maps/synergy.dmm
@@ -2135,14 +2135,6 @@
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/escape_pod3)
-"aes" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/simulated/wall/r_wall,
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
 "aet" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -2153,9 +2145,6 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/full/reinforced,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -2166,16 +2155,8 @@
 	})
 "aeu" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "sec_eva_ext_airlock";
-	locked = 1;
 	name = "Security External Airlock";
 	req_access_txt = "63"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/security/range{
@@ -2570,17 +2551,7 @@
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/escape_pod3)
-"afs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/simulated/wall/r_wall,
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
 "aft" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	frequency = 1331;
-	id_tag = "sec_eva_airlock_pump"
-	},
 /obj/machinery/light/small{
 	dir = 8;
 	flickering = 1
@@ -2599,29 +2570,6 @@
 	name = "\improper Security E.V.A"
 	})
 "afu" = (
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1331;
-	id_tag = "sec_eva_airlock_control";
-	pixel_x = 25;
-	req_access_txt = "63";
-	tag_airpump = "sec_eva_airlock_pump";
-	tag_chamber_sensor = "sec_eva_airlock_sensor";
-	tag_exterior_door = "sec_eva_ext_airlock";
-	tag_exterior_sensor = "sec_eva_ext_airlock_sensor";
-	tag_interior_door = "sec_eva_int_airlock";
-	tag_interior_sensor = "sec_eva_int_airlock_sensor"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "sec_eva_airlock_sensor";
-	master_tag = "sec_eva_airlock_control";
-	pixel_y = -26;
-	req_access_txt = "63"
-	},
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	frequency = 1331;
-	id_tag = "sec_eva_airlock_pump"
-	},
 /obj/effect/decal/warning_stripes{
 	icon_state = "all";
 	tag = "icon-all"
@@ -3042,18 +2990,6 @@
 	name = "\improper Security E.V.A"
 	})
 "agn" = (
-/obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "sec_eva_int_airlock";
-	locked = 1;
-	name = "Security External Airlock";
-	req_access_txt = "63"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -3066,19 +3002,15 @@
 	name = "Security Blast Door";
 	opacity = 0
 	},
+/obj/machinery/door/airlock/external{
+	name = "Security External Airlock";
+	req_access_txt = "63"
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault";
 	tag = "icon-vault (NORTHEAST)"
 	},
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
-"ago" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/simulated/wall,
 /area/security/range{
 	name = "\improper Security E.V.A"
 	})
@@ -3473,15 +3405,7 @@
 	name = "\improper Security E.V.A"
 	})
 "ahi" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "sec_eva_int_airlock_sensor";
-	master_tag = "sec_eva_airlock_control";
-	pixel_y = 26;
-	req_access_txt = "63"
-	},
 /obj/item/weapon/stool,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"
@@ -3490,7 +3414,6 @@
 	name = "\improper Security E.V.A"
 	})
 "ahj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -3887,30 +3810,6 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "unloading"
 	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
-	},
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
-"aid" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/item/weapon/stool,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
-	},
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
-"aie" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"
@@ -4401,8 +4300,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -4937,13 +4836,13 @@
 	name = "\improper Security E.V.A"
 	})
 "aki" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -85154,9 +85053,6 @@
 	},
 /turf/simulated/floor/engine/nitrogen,
 /area/vox_trading_post/atmos)
-"dqN" = (
-/turf/unsimulated/mineral/random/high_chance,
-/area)
 "dqO" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/plasma{
@@ -87863,10 +87759,11 @@
 	},
 /area/vox_trading_post/eva)
 "dwg" = (
-/obj/structure/closet/emcloset/vox,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
+/obj/structure/table,
+/obj/item/weapon/reagent_containers/food/drinks/gromitmug,
 /turf/simulated/floor/vox{
 	icon_state = "asteroidplating"
 	},
@@ -87907,35 +87804,7 @@
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/eva)
 "dwk" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 4;
-	frequency = 1449;
-	id_tag = "vox_eva_airlock_pump"
-	},
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	id_tag = "vox_eva_airlock_control";
-	pixel_y = 25;
-	tag_airpump = "vox_eva_airlock_pump";
-	tag_chamber_sensor = "vox_eva_airlock_sensor";
-	tag_exterior_door = "vox_eva_airlock_exterior";
-	tag_exterior_sensor = "vox_eva_ext_airlock_sensor";
-	tag_interior_door = "vox_eva_airlock_interior";
-	tag_interior_sensor = "vox_eva_int_airlock_sensor"
-	},
-/turf/simulated/floor/vox{
-	icon_state = "asteroidplating"
-	},
-/area/vox_trading_post/eva)
-"dwl" = (
-/obj/effect/glowshroom/single,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/machinery/airlock_sensor{
-	id_tag = "vox_eva_airlock_sensor";
-	master_tag = "vox_eva_airlock_control";
-	pixel_y = 24
-	},
+/obj/structure/closet/emcloset/vox,
 /turf/simulated/floor/vox{
 	icon_state = "asteroidplating"
 	},
@@ -88136,43 +88005,23 @@
 	},
 /area/vox_trading_post/eva)
 "dwA" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1449;
-	icon_state = "door_locked";
-	id_tag = "vox_eva_airlock_interior";
-	locked = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor/vox{
 	icon_state = "asteroidplating"
 	},
 /area/vox_trading_post/eva)
 "dwB" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 4;
-	frequency = 1449;
-	id_tag = "vox_eva_airlock_pump"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8;
+	name = "Air Vent (8)"
 	},
-/turf/simulated/floor/vox{
-	icon_state = "asteroidplating"
-	},
-/area/vox_trading_post/eva)
-"dwC" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/glowshroom/single,
 /turf/simulated/floor/vox{
 	icon_state = "asteroidplating"
 	},
 /area/vox_trading_post/eva)
 "dwD" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1449;
-	icon_state = "door_locked";
-	id_tag = "vox_eva_airlock_exterior";
-	locked = 1
-	},
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor/vox{
 	icon_state = "asteroidplating"
 	},
@@ -88285,27 +88134,19 @@
 /area/vox_trading_post/hallway)
 "dwO" = (
 /obj/item/weapon/stool,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor/vox{
 	icon_state = "asteroidplating"
 	},
 /area/vox_trading_post/eva)
 "dwP" = (
 /obj/item/weapon/stool,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/simulated/floor/vox{
 	icon_state = "asteroidplating"
 	},
 /area/vox_trading_post/eva)
 "dwQ" = (
 /obj/item/weapon/stool,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -88313,36 +88154,10 @@
 	icon_state = "1-2";
 	tag = ""
 	},
-/obj/machinery/airlock_sensor{
-	id_tag = "vox_eva_int_airlock_sensor";
-	master_tag = "vox_eva_airlock_control";
-	pixel_x = 25
-	},
 /turf/simulated/floor/vox{
 	icon_state = "asteroidplating"
 	},
 /area/vox_trading_post/eva)
-"dwR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/vox_trading_post/eva)
-"dwS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/simulated/wall,
-/area/vox_trading_post/eva)
-"dwT" = (
-/obj/effect/glowshroom/single,
-/obj/machinery/airlock_sensor{
-	id_tag = "vox_eva_ext_airlock_sensor";
-	master_tag = "vox_eva_airlock_control";
-	pixel_x = -24
-	},
-/turf/unsimulated/floor/asteroid,
-/area/mine/explored)
 "dwU" = (
 /obj/effect/glowshroom/single,
 /obj/structure/table,
@@ -89612,7 +89427,6 @@
 /turf/simulated/floor/plating,
 /area/mine/production)
 "dzO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/alarm{
 	dir = 4;
 	name = "Air Alarm Min (4)";
@@ -89620,6 +89434,7 @@
 	req_one_access = null;
 	req_one_access_txt = "11;24;48"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor,
 /area/mine/production)
 "dzP" = (
@@ -89710,35 +89525,6 @@
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
 /area/mine/production)
-"dzZ" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1333;
-	id_tag = "min_airlock_sensor";
-	master_tag = "min_airlock_control";
-	pixel_x = 26
-	},
-/turf/unsimulated/floor/airless{
-	icon_state = "asteroidfloor"
-	},
-/area/mine/explored)
-"dAa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/simulated/wall,
-/area/mine/production)
-"dAb" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/simulated/wall,
-/area/mine/production)
-"dAc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/mine/production)
 "dAd" = (
 /obj/machinery/recharger{
 	pixel_y = 28
@@ -89748,50 +89534,17 @@
 	name = "Mining Station Exit";
 	network = list("MINE","SS13")
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1333;
-	id_tag = "min_int_airlock_sensor";
-	master_tag = "min_airlock_control";
-	pixel_x = -26
-	},
 /turf/simulated/floor,
 /area/mine/production)
 "dAe" = (
 /obj/machinery/recharger{
 	pixel_y = 28
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/simulated/floor,
 /area/mine/production)
-"dAf" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	tag = ""
-	},
-/obj/structure/window/full/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/mine/production)
 "dAg" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/vending/mining,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor,
 /area/mine/production)
 "dAh" = (
@@ -89887,42 +89640,24 @@
 /area/mine/production)
 "dAr" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1333;
-	icon_state = "door_locked";
-	id_tag = "min_airlock_exterior";
-	locked = 1
-	},
-/turf/simulated/floor,
-/area/mine/production)
-"dAs" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 1;
-	frequency = 1333;
-	id_tag = "min_airlock_pump"
+	name = "Mining External Airlock";
+	req_access_txt = "54"
 	},
 /turf/simulated/floor,
 /area/mine/production)
 "dAt" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 1;
-	frequency = 1333;
-	id_tag = "min_airlock_pump"
-	},
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor,
 /area/mine/production)
 "dAu" = (
-/obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1333;
-	icon_state = "door_locked";
-	id_tag = "min_airlock_interior";
-	locked = 1
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/external{
+	name = "Mining External Airlock";
+	req_access_txt = "54"
+	},
 /turf/simulated/floor,
 /area/mine/production)
 "dAv" = (
@@ -89998,30 +89733,9 @@
 	icon_state = "dark"
 	},
 /area/mine/production)
-"dAF" = (
+"dAG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1333;
-	id_tag = "min_airlock_sensor";
-	master_tag = "min_airlock_control";
-	pixel_y = -24
-	},
-/turf/simulated/floor,
-/area/mine/production)
-"dAG" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1333;
-	id_tag = "min_airlock_control";
-	pixel_y = -24;
-	tag_airpump = "min_airlock_pump";
-	tag_chamber_sensor = "min_airlock_sensor";
-	tag_exterior_door = "min_airlock_exterior";
-	tag_exterior_sensor = "min_ext_airlock_sensor";
-	tag_interior_door = "min_airlock_interior";
-	tag_interior_sensor = "min_int_airlock_sensor"
 	},
 /turf/simulated/floor,
 /area/mine/production)
@@ -92706,12 +92420,6 @@
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "dGh" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "anom_int_airlock_sensor";
-	master_tag = "anom_airlock_control";
-	pixel_x = 24
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -92728,36 +92436,18 @@
 /turf/simulated/wall,
 /area/research_outpost/gearstore)
 "dGj" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
+/obj/structure/closet/emcloset,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "purple"
 	},
 /area/research_outpost/gearstore)
 "dGk" = (
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1331;
-	id_tag = "anom_airlock_control";
-	pixel_x = 4;
-	pixel_y = 24;
-	tag_airpump = "anom_airlock_pump";
-	tag_chamber_sensor = "anom_airlock_sensor";
-	tag_exterior_door = "anom_airlock_exterior";
-	tag_exterior_sensor = "anom_ext_airlock_sensor";
-	tag_interior_door = "anom_airlock_interior";
-	tag_interior_sensor = "anom_int_airlock_sensor"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "anom_airlock_sensor";
-	master_tag = "anom_airlock_control";
-	pixel_x = -6;
-	pixel_y = 21
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -92765,25 +92455,11 @@
 	},
 /area/research_outpost/gearstore)
 "dGl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "purple"
 	},
 /area/research_outpost/gearstore)
-"dGm" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "anom_ext_airlock_sensor";
-	master_tag = "anom_airlock_control";
-	pixel_x = -24
-	},
-/turf/unsimulated/floor/airless{
-	icon_state = "asteroidfloor"
-	},
-/area/mine/explored)
 "dGn" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
@@ -92884,42 +92560,27 @@
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "dGx" = (
-/obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "anom_airlock_interior";
-	locked = 1
-	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
-/area/research_outpost/gearstore)
-"dGy" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	frequency = 1331;
-	id_tag = "anom_airlock_pump"
+/obj/machinery/door/airlock/external{
+	req_access_txt = "47"
 	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "dGz" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	frequency = 1331;
-	id_tag = "anom_airlock_pump"
-	},
 /obj/machinery/camera{
 	dir = 1;
 	name = "Research Outpost Airlock";
 	network = list("SS13","RD")
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	name = "Air Vent (1)"
+	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "dGA" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "anom_airlock_exterior";
-	locked = 1
+	req_access_txt = "47"
 	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
@@ -93045,19 +92706,16 @@
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "dGM" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
 /turf/simulated/floor{
 	icon_state = "purple"
 	},
 /area/research_outpost/gearstore)
 "dGN" = (
 /obj/structure/dispenser/oxygen,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/camera{
 	dir = 8;
 	name = "Research Outpost Expedition Prep";
@@ -93068,27 +92726,8 @@
 	icon_state = "purple"
 	},
 /area/research_outpost/gearstore)
-"dGO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/research_outpost/gearstore)
 "dGP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/wall/r_wall,
-/area/research_outpost/gearstore)
-"dGQ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/simulated/wall/r_wall,
-/area/research_outpost/gearstore)
-"dGR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /turf/simulated/wall/r_wall,
 /area/research_outpost/gearstore)
 "dGS" = (
@@ -236739,12 +236378,12 @@ aai
 aaa
 aaa
 adB
-aes
-afs
-afs
+agm
+agm
+agm
 ahi
-aid
-aid
+ahi
+ahi
 aki
 all
 amu
@@ -237245,7 +236884,7 @@ aet
 aft
 agn
 ahj
-aie
+ahj
 aja
 akj
 alm
@@ -237745,7 +237384,7 @@ aaa
 abM
 aeu
 afu
-ago
+ajc
 ahk
 aif
 ajb
@@ -1154333,7 +1153972,7 @@ dpP
 dvP
 dwj
 dwA
-dwR
+dvP
 dvP
 dvP
 dpP
@@ -1154835,7 +1154474,7 @@ dpP
 dvP
 dwk
 dwB
-dwR
+dvP
 dpP
 dpP
 dpP
@@ -1155335,9 +1154974,9 @@ dpP
 dpP
 dpP
 dvP
-dwl
-dwC
-dwS
+dwi
+dwi
+dvP
 dpP
 dpP
 dpP
@@ -1156341,7 +1155980,7 @@ dpQ
 dvQ
 dpQ
 dpQ
-dwT
+dvQ
 dpQ
 dpQ
 dpT
@@ -1177085,7 +1176724,7 @@ dFr
 dFT
 dGh
 dGw
-dGO
+dGS
 dGS
 dHO
 dIy
@@ -1178088,8 +1177727,8 @@ dFr
 dFE
 dFV
 dGj
-dGy
-dGQ
+dGe
+dGS
 dHl
 dHQ
 dIA
@@ -1178591,7 +1178230,7 @@ dFF
 dFr
 dGk
 dGz
-dGQ
+dGS
 dHl
 dHQ
 dIB
@@ -1179092,8 +1178731,8 @@ dFs
 dFG
 dFV
 dGl
-dGy
-dGR
+dGe
+dGS
 dHm
 dHR
 dIC
@@ -1180095,7 +1179734,7 @@ dvl
 dvl
 dvl
 dFW
-dGm
+dvl
 dvl
 dGT
 dHo
@@ -1182928,7 +1182567,7 @@ aaa
 aaa
 aaa
 aaa
-dqN
+dpY
 aaa
 dpY
 dpY
@@ -1183429,7 +1183068,7 @@ aaa
 aaa
 aaa
 aaa
-dqN
+dpY
 dpY
 aaa
 dpY
@@ -1265892,7 +1265531,7 @@ dyx
 dyx
 dur
 dvl
-dzZ
+dvl
 dvl
 dvl
 dvl
@@ -1266896,9 +1266535,9 @@ dvl
 dvl
 dvl
 dvl
-dAa
-dAs
-dAF
+dyA
+dzt
+dzt
 dyA
 dvl
 dur
@@ -1267398,7 +1267037,7 @@ dvl
 dvl
 dvl
 dyV
-dAb
+dyA
 dAt
 dAG
 dyA
@@ -1267900,7 +1267539,7 @@ dza
 dzq
 dzB
 dyA
-dAc
+dyA
 dAu
 dAH
 dyA
@@ -1269406,7 +1269045,7 @@ dzd
 dzs
 dzE
 dyA
-dAf
+dAR
 dzt
 dAI
 dAR

--- a/maps/tgstation-sec.dmm
+++ b/maps/tgstation-sec.dmm
@@ -22959,7 +22959,7 @@
 /area/bridge)
 "aVl" = (
 /obj/structure/table/holotable/wood,
-/obj/item/weapon/reagent_containers/food/drinks/soda_cans/sportdrink,
+/obj/item/weapon/reagent_containers/food/drinks/gromitmug,
 /turf/simulated/floor/beach/sand,
 /area/hallway/primary/central)
 "aVm" = (
@@ -94659,7 +94659,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/research_outpost/xenobot)
+/area/research_outpost/hallway)
 "dSS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -95199,14 +95199,6 @@
 /area/science/test_area)
 "dTF" = (
 /obj/structure/hanging_lantern,
-/turf/unsimulated/floor/asteroid,
-/area/mine/explored)
-"dTG" = (
-/obj/machinery/airlock_sensor{
-	id_tag = "vox_eva_ext_airlock_sensor";
-	master_tag = "vox_eva_airlock_control";
-	pixel_y = -24
-	},
 /turf/unsimulated/floor/asteroid,
 /area/mine/explored)
 "dTH" = (
@@ -95999,15 +95991,6 @@
 "dUT" = (
 /turf/simulated/wall,
 /area/vox_trading_post/eva)
-"dUU" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1449;
-	icon_state = "door_locked";
-	id_tag = "vox_eva_airlock_exterior";
-	locked = 1
-	},
-/turf/simulated/floor/plating/vox,
-/area/vox_trading_post/eva)
 "dUV" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -96730,33 +96713,6 @@
 /obj/effect/glowshroom/single,
 /turf/simulated/wall,
 /area/vox_trading_post/eva)
-"dWc" = (
-/obj/structure/closet/emcloset/vox,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/vox_trading_post/eva)
-"dWd" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 4;
-	frequency = 1449;
-	id_tag = "vox_eva_airlock_pump"
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/vox_trading_post/eva)
-"dWe" = (
-/obj/machinery/airlock_sensor{
-	id_tag = "vox_eva_airlock_sensor";
-	master_tag = "vox_eva_airlock_control";
-	pixel_x = 24
-	},
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/vox_trading_post/eva)
 "dWf" = (
 /turf/simulated/wall,
 /area/mine/unexplored)
@@ -97305,18 +97261,6 @@
 	},
 /turf/simulated/floor/grass,
 /area/science/test_area)
-"dXd" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/vox_trading_post/eva)
-"dXe" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/vox_trading_post/eva)
 "dXg" = (
 /obj/structure/transit_tube{
 	icon_state = "E-SW"
@@ -98026,22 +97970,9 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/science/test_area)
-"dYq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/simulated/wall,
-/area/vox_trading_post/eva)
 "dYr" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1449;
-	icon_state = "door_locked";
-	id_tag = "vox_eva_airlock_interior";
-	locked = 1
-	},
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor/plating/vox,
-/area/vox_trading_post/eva)
-"dYs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/simulated/wall,
 /area/vox_trading_post/eva)
 "dYt" = (
 /obj/structure/transit_tube{
@@ -98515,14 +98446,7 @@
 "dZi" = (
 /obj/structure/cable/yellow{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/airlock_sensor{
-	id_tag = "vox_eva_int_airlock_sensor";
-	master_tag = "vox_eva_airlock_control";
-	pixel_y = 24
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -98544,19 +98468,10 @@
 /turf/simulated/floor/vox,
 /area/vox_trading_post/eva)
 "dZk" = (
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	id_tag = "vox_eva_airlock_control";
-	pixel_y = 24;
-	tag_airpump = "vox_eva_airlock_pump";
-	tag_chamber_sensor = "vox_eva_airlock_sensor";
-	tag_exterior_door = "vox_eva_airlock_exterior";
-	tag_exterior_sensor = "vox_eva_ext_airlock_sensor";
-	tag_interior_door = "vox_eva_airlock_interior";
-	tag_interior_sensor = "vox_eva_int_airlock_sensor"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
+/obj/structure/closet/emcloset/vox,
 /turf/simulated/floor/vox,
 /area/vox_trading_post/eva)
 "dZl" = (
@@ -98606,12 +98521,6 @@
 	req_access_txt = "47"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/simulated/floor,
-/area/research_outpost/gearstore)
-"dZs" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "dZt" = (
@@ -99017,8 +98926,8 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
 	},
 /turf/simulated/floor/vox,
 /area/vox_trading_post/eva)
@@ -99080,13 +98989,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/research_outpost/gearstore)
-"eao" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/simulated/floor,
 /area/research_outpost/gearstore)
 "eap" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -99401,27 +99303,12 @@
 /turf/simulated/floor/plating,
 /area/research_outpost/gearstore)
 "ebc" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "anom_int_airlock_sensor";
-	master_tag = "anom_airlock_control";
-	pixel_y = -24
-	},
 /obj/structure/dispenser/oxygen,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "ebd" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/simulated/floor,
-/area/research_outpost/gearstore)
-"ebe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "ebf" = (
@@ -99961,12 +99848,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/research_outpost/gearstore)
-"ecm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/simulated/wall/r_wall,
-/area/research_outpost/gearstore)
 "ecn" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -99980,19 +99861,12 @@
 /obj/structure/window/reinforced,
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor/plating,
 /area/research_outpost/gearstore)
 "eco" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "anom_airlock_interior";
-	locked = 1
+	req_access_txt = "47"
 	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
@@ -100318,27 +100192,15 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1331;
-	id_tag = "anom_airlock_control";
-	pixel_x = -24;
-	tag_airpump = "anom_airlock_pump";
-	tag_chamber_sensor = "anom_airlock_sensor";
-	tag_exterior_door = "anom_airlock_exterior";
-	tag_exterior_sensor = "anom_ext_airlock_sensor";
-	tag_interior_door = "anom_airlock_interior";
-	tag_interior_sensor = "anom_int_airlock_sensor"
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 1;
+	on = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "ecZ" = (
 /obj/machinery/recharger{
 	pixel_x = 29
-	},
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	frequency = 1331;
-	id_tag = "anom_airlock_pump"
 	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
@@ -100780,19 +100642,9 @@
 /area/mine/explored)
 "edY" = (
 /obj/structure/closet/walllocker/emerglocker/west,
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "anom_airlock_sensor";
-	master_tag = "anom_airlock_control";
-	pixel_x = -24;
-	pixel_y = 21
-	},
 /obj/effect/decal/warning_stripes{
 	icon_state = "warning";
 	tag = "icon-warning"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
 	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
@@ -100803,9 +100655,6 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "warning";
 	tag = "icon-warning"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
 	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
@@ -101212,11 +101061,7 @@
 /area/research_outpost/gearstore)
 "eeT" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "anom_airlock_exterior";
-	locked = 1
+	req_access_txt = "47"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -101618,20 +101463,6 @@
 /turf/unsimulated/floor/airless{
 	dir = 6;
 	icon_state = "asteroidwarning"
-	},
-/area/mine/explored)
-"efJ" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "anom_ext_airlock_sensor";
-	master_tag = "anom_airlock_control";
-	pixel_y = 24
-	},
-/obj/structure/hanging_lantern{
-	dir = 1
-	},
-/turf/unsimulated/floor/airless{
-	icon_state = "asteroidfloor"
 	},
 /area/mine/explored)
 "efK" = (
@@ -1211748,7 +1211579,7 @@ aaa
 aak
 dNe
 dNe
-dIu
+dJh
 dIu
 dIu
 dIu
@@ -1212250,7 +1212081,7 @@ aaa
 aaa
 dNe
 dNe
-dIu
+dJh
 dIu
 dIu
 dIu
@@ -1212752,12 +1212583,12 @@ aaa
 aaa
 dNe
 dNe
-dIu
-dIu
-dIu
-dIu
-dIu
-dIu
+dJh
+dJh
+dJh
+dJh
+dJh
+dJh
 eaS
 ebV
 ecI
@@ -1213254,9 +1213085,9 @@ aaa
 aak
 dNe
 dNe
-dUT
-dWb
-dUT
+dNe
+dNe
+dNe
 dUT
 dUT
 dWb
@@ -1213755,11 +1213586,11 @@ aaa
 aaa
 aaa
 dNe
-dTG
+dNe
+dNe
+dNe
+dNe
 dUT
-dWc
-dXd
-dYq
 dZi
 eag
 eaU
@@ -1214258,9 +1214089,9 @@ dIv
 dIv
 dNe
 dNe
-dUU
-dWd
-dWd
+dNe
+dNe
+dNe
 dYr
 dZj
 eah
@@ -1214760,10 +1214591,10 @@ dIv
 dIv
 dNe
 dNe
+dNe
+dNe
+dNe
 dUT
-dWe
-dXe
-dYs
 dZk
 eai
 eaW
@@ -1215262,9 +1215093,9 @@ dIv
 dIv
 dNe
 dTH
-dUT
-dUT
-dWb
+dNe
+dNe
+dNe
 dUT
 dWb
 dUT
@@ -1215764,12 +1215595,12 @@ dIv
 dIv
 dIu
 dTI
-dIu
-dIu
-dIu
-dIu
-dIu
-dIu
+dJh
+dJh
+dJh
+dJh
+dJh
+dJh
 eaX
 eca
 ecN
@@ -1226313,7 +1226144,7 @@ dIv
 dIv
 dIv
 dIv
-dML
+dIv
 dML
 dML
 dNe
@@ -1226815,7 +1226646,7 @@ dIv
 dIv
 dIv
 dIv
-dML
+dIv
 dIv
 dML
 dNe
@@ -1227317,7 +1227148,7 @@ dIv
 dIv
 dIv
 dIv
-dML
+dIv
 dIv
 dML
 dNe
@@ -1246892,14 +1246723,14 @@ dVd
 dWl
 dXm
 dXj
-dZs
-eao
+dZq
+eam
 ebc
-ecm
 dXh
 dXh
 dXh
-efJ
+dXh
+efK
 egm
 dNe
 dJh
@@ -1247898,7 +1247729,7 @@ dXo
 dXj
 dZu
 eaq
-ebe
+dXj
 eco
 ecZ
 edZ
@@ -1254925,7 +1254756,7 @@ dWv
 dXC
 dYF
 dZF
-eaw
+eaz
 ebk
 dVo
 dJh
@@ -1256933,7 +1256764,7 @@ dWy
 dXF
 dYG
 dZJ
-eaz
+eaw
 ebn
 dVr
 dJh

--- a/maps/tgstation-snow.dmm
+++ b/maps/tgstation-snow.dmm
@@ -12222,12 +12222,6 @@
 	icon_state = "floorgrime"
 	},
 /area/mine/production)
-"aCz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/simulated/floor,
-/area/research_outpost/gearstore)
 "aCA" = (
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/libertycap,
 /turf/unsimulated/floor/snow/cave/rock,
@@ -12359,15 +12353,11 @@
 /turf/simulated/floor/plating,
 /area/research_outpost/tempstorage)
 "aCV" = (
-/obj/structure/table,
-/obj/item/weapon/storage/box/excavation,
-/obj/item/weapon/pickaxe,
-/obj/item/tool/wrench,
-/obj/item/device/measuring_tape,
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/structure/closet/crate,
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "aCW" = (
@@ -12558,10 +12548,6 @@
 "aDR" = (
 /obj/machinery/recharger{
 	pixel_x = 29
-	},
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	frequency = 1331;
-	id_tag = "anom_airlock_pump"
 	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
@@ -14569,11 +14555,11 @@
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "aIf" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/research_outpost/gearstore)
+/obj/structure/table/woodentable,
+/obj/item/weapon/kitchen/utensil/fork,
+/obj/item/weapon/reagent_containers/food/drinks/gromitmug,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "aIg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -14883,13 +14869,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/research_outpost/gearstore)
-"aIO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/simulated/floor,
-/area/research_outpost/gearstore)
 "aIP" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/simulated/floor,
@@ -15028,14 +15007,13 @@
 	name = "Toxins"
 	})
 "aJe" = (
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13";
-	req_one_access_txt = "13"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/external{
+	req_access_txt = "47"
 	},
 /turf/simulated/floor/plating,
 /area/research_outpost/dorm2{
@@ -15190,21 +15168,12 @@
 /turf/simulated/floor/plating,
 /area/research_outpost/gearstore)
 "aJw" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "anom_int_airlock_sensor";
-	master_tag = "anom_airlock_control";
-	pixel_y = -24
-	},
 /obj/structure/dispenser/oxygen,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "aJx" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "aJy" = (
@@ -15397,10 +15366,7 @@
 /turf/simulated/floor/plating,
 /area/research_outpost/gearstore)
 "aJU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/research_outpost/gearstore)
 "aJV" = (
 /obj/structure/window/reinforced{
@@ -15415,19 +15381,12 @@
 /obj/structure/window/reinforced,
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor/plating,
 /area/research_outpost/gearstore)
 "aJW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "anom_airlock_interior";
-	locked = 1
+	req_access_txt = "47"
 	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
@@ -15545,18 +15504,10 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1331;
-	id_tag = "anom_airlock_control";
-	pixel_x = -24;
-	tag_airpump = "anom_airlock_pump";
-	tag_chamber_sensor = "anom_airlock_sensor";
-	tag_exterior_door = "anom_airlock_exterior";
-	tag_exterior_sensor = "anom_ext_airlock_sensor";
-	tag_interior_door = "anom_airlock_interior";
-	tag_interior_sensor = "anom_int_airlock_sensor"
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 1;
+	on = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "aKo" = (
@@ -15582,14 +15533,13 @@
 	name = "Toxins"
 	})
 "aKq" = (
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13";
-	req_one_access_txt = "13"
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/external{
+	req_access_txt = "47"
 	},
 /turf/simulated/floor/plating,
 /area/research_outpost/dorm2{
@@ -15716,19 +15666,9 @@
 /area/mine/explored)
 "aKG" = (
 /obj/structure/closet/walllocker/emerglocker/west,
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "anom_airlock_sensor";
-	master_tag = "anom_airlock_control";
-	pixel_x = -24;
-	pixel_y = 21
-	},
 /obj/effect/decal/warning_stripes{
 	icon_state = "warning";
 	tag = "icon-warning"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
 	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
@@ -15739,9 +15679,6 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "warning";
 	tag = "icon-warning"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
 	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
@@ -15814,11 +15751,7 @@
 /area/research_outpost/gearstore)
 "aKT" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "anom_airlock_exterior";
-	locked = 1
+	req_access_txt = "47"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -177428,13 +177361,13 @@ aEY
 aFM
 aGt
 aGq
-aIf
-aIO
+aIc
+aIM
 aJw
 aJU
-aDS
-aDS
-aDS
+aJU
+aJU
+aJU
 aLg
 aoX
 aaD
@@ -178034,7 +177967,7 @@ aGv
 aGq
 aIh
 aBM
-aCz
+aGq
 aJW
 aDR
 aKH
@@ -178337,10 +178270,10 @@ aHw
 aAz
 aIQ
 aCV
-aDS
-aDS
-aDS
-aDS
+aJU
+aJU
+aJU
+aJU
 abH
 aoX
 aaD
@@ -253203,7 +253136,7 @@ bGn
 bCC
 bGn
 bAS
-wfm
+aIf
 bGn
 bGj
 bEs

--- a/maps/tgstation.dmm
+++ b/maps/tgstation.dmm
@@ -5008,44 +5008,12 @@
 	},
 /turf/space,
 /area/solar/fport)
-"ahW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/simulated/wall/r_wall,
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
 "ahX" = (
 /turf/simulated/wall/r_wall,
 /area/security/range{
 	name = "\improper Security E.V.A"
 	})
-"ahY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
-"ahZ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/simulated/wall/r_wall,
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
 "aia" = (
-/turf/simulated/wall,
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
-"aib" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /turf/simulated/wall,
 /area/security/range{
 	name = "\improper Security E.V.A"
@@ -5414,13 +5382,6 @@
 /turf/space,
 /area/solar/fport)
 "aiK" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "sec_eva_ext_airlock_sensor";
-	master_tag = "sec_eva_airlock_control";
-	pixel_x = 24;
-	req_access_txt = "63"
-	},
 /obj/machinery/camera{
 	dir = 8;
 	name = "Security E.V.A. External"
@@ -5437,10 +5398,7 @@
 	icon_state = "warning";
 	tag = "icon-warning (NORTHWEST)"
 	},
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	frequency = 1331;
-	id_tag = "sec_eva_airlock_pump"
-	},
+/obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
 /area/security/range{
 	name = "\improper Security E.V.A"
@@ -5451,31 +5409,6 @@
 	icon_state = "warning";
 	tag = "icon-warning (NORTHEAST)"
 	},
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1331;
-	id_tag = "sec_eva_airlock_control";
-	pixel_x = 5;
-	pixel_y = 24;
-	req_access_txt = "63";
-	tag_airpump = "sec_eva_airlock_pump";
-	tag_chamber_sensor = "sec_eva_airlock_sensor";
-	tag_exterior_door = "sec_eva_ext_airlock";
-	tag_exterior_sensor = "sec_eva_ext_airlock_sensor";
-	tag_interior_door = "sec_eva_int_airlock";
-	tag_interior_sensor = "sec_eva_int_airlock_sensor"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "sec_eva_airlock_sensor";
-	master_tag = "sec_eva_airlock_control";
-	pixel_x = -5;
-	pixel_y = 24;
-	req_access_txt = "63"
-	},
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	frequency = 1331;
-	id_tag = "sec_eva_airlock_pump"
-	},
 /turf/simulated/floor/plating,
 /area/security/range{
 	name = "\improper Security E.V.A"
@@ -5483,6 +5416,7 @@
 "aiN" = (
 /obj/machinery/recharger,
 /obj/structure/table,
+/obj/item/weapon/reagent_containers/food/drinks/gromitmug,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "red"
@@ -5491,13 +5425,6 @@
 	name = "\improper Security E.V.A"
 	})
 "aiO" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "sec_eva_int_airlock_sensor";
-	master_tag = "sec_eva_airlock_control";
-	pixel_x = -24;
-	req_access_txt = "63"
-	},
 /obj/effect/decal/warning_stripes{
 	dir = 8;
 	icon_state = "warning_corner";
@@ -5506,7 +5433,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
@@ -6018,20 +5944,12 @@
 	icon_state = "warning";
 	tag = "icon-warning (WEST)"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
 /turf/simulated/floor/plating,
 /area/security/range{
 	name = "\improper Security E.V.A"
 	})
 "ajD" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "sec_eva_ext_airlock";
-	locked = 1;
 	name = "Security External Airlock";
 	req_access_txt = "63"
 	},
@@ -6044,15 +5962,7 @@
 	dir = 4;
 	name = "Firelock East"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "sec_eva_int_airlock";
-	locked = 1;
 	name = "Security External Airlock";
 	req_access_txt = "63"
 	},
@@ -6066,7 +5976,6 @@
 	icon_state = "warning";
 	tag = "icon-warning (EAST)"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /turf/simulated/floor/plating,
 /area/security/range{
 	name = "\improper Security E.V.A"
@@ -6076,9 +5985,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
@@ -6097,11 +6003,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/meter,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "red"
@@ -6134,7 +6035,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
 /turf/simulated/floor,
 /area/security/range{
 	name = "\improper Security E.V.A"
@@ -6637,11 +6540,6 @@
 	icon_state = "warning";
 	tag = "icon-warning (SOUTHWEST)"
 	},
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 1;
-	frequency = 1331;
-	id_tag = "sec_eva_airlock_pump"
-	},
 /turf/simulated/floor/plating,
 /area/security/range{
 	name = "\improper Security E.V.A"
@@ -6669,11 +6567,6 @@
 	icon_state = "warning";
 	tag = "icon-warning (SOUTHEAST)"
 	},
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 1;
-	frequency = 1331;
-	id_tag = "sec_eva_airlock_pump"
-	},
 /turf/simulated/floor/plating,
 /area/security/range{
 	name = "\improper Security E.V.A"
@@ -6688,9 +6581,6 @@
 	dir = 1;
 	icon_state = "warning";
 	tag = "icon-warning (NORTH)"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /obj/item/weapon/tank/jetpack,
 /turf/simulated/floor{
@@ -6709,9 +6599,6 @@
 /obj/machinery/camera{
 	dir = 1;
 	name = "Security E.V.A."
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 10;
@@ -6732,7 +6619,9 @@
 	tag = "icon-warning (NORTH)"
 	},
 /obj/item/weapon/tank/jetpack,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "red"
@@ -6749,9 +6638,6 @@
 	tag = "icon-warning (NORTH)"
 	},
 /obj/item/weapon/tank/jetpack,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/simulated/floor{
 	icon_state = "red"
 	},
@@ -7135,28 +7021,17 @@
 	},
 /turf/space,
 /area/solar/fstarboard)
-"alj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/simulated/wall/r_wall,
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
 "alk" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/simulated/wall/r_wall,
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
-"all" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/simulated/wall/r_wall,
-/area/security/range{
-	name = "\improper Security E.V.A"
-	})
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/vox_trading_post/trade_processing)
 "alm" = (
 /turf/simulated/wall,
 /area/security/medical)
@@ -101076,14 +100951,6 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating/airless,
 /area/science/test_area)
-"efJ" = (
-/obj/machinery/airlock_sensor{
-	id_tag = "vox_eva_ext_airlock_sensor";
-	master_tag = "vox_eva_airlock_control";
-	pixel_y = -24
-	},
-/turf/unsimulated/floor/asteroid,
-/area/mine/explored)
 "efK" = (
 /obj/structure/hanging_lantern,
 /turf/unsimulated/floor/asteroid,
@@ -101878,15 +101745,6 @@
 "egX" = (
 /turf/simulated/wall,
 /area/vox_trading_post/eva)
-"egY" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1449;
-	icon_state = "door_locked";
-	id_tag = "vox_eva_airlock_exterior";
-	locked = 1
-	},
-/turf/simulated/floor/plating/vox,
-/area/vox_trading_post/eva)
 "egZ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -102609,33 +102467,6 @@
 /obj/effect/glowshroom/single,
 /turf/simulated/wall,
 /area/vox_trading_post/eva)
-"eig" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 4;
-	frequency = 1449;
-	id_tag = "vox_eva_airlock_pump"
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/vox_trading_post/eva)
-"eih" = (
-/obj/structure/closet/emcloset/vox,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/vox_trading_post/eva)
-"eii" = (
-/obj/machinery/airlock_sensor{
-	id_tag = "vox_eva_airlock_sensor";
-	master_tag = "vox_eva_airlock_control";
-	pixel_x = 24
-	},
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/vox_trading_post/eva)
 "eik" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'INTERNALS REQUIRED'.";
@@ -103193,18 +103024,6 @@
 	},
 /turf/simulated/floor/grass,
 /area/science/test_area)
-"ejh" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/vox_trading_post/eva)
-"eji" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/vox_trading_post/eva)
 "ejk" = (
 /obj/structure/transit_tube{
 	icon_state = "E-SW"
@@ -103917,21 +103736,8 @@
 /turf/simulated/floor/plating/airless,
 /area/science/test_area)
 "eku" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1449;
-	icon_state = "door_locked";
-	id_tag = "vox_eva_airlock_interior";
-	locked = 1
-	},
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor/plating/vox,
-/area/vox_trading_post/eva)
-"ekv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/simulated/wall,
-/area/vox_trading_post/eva)
-"ekw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/simulated/wall,
 /area/vox_trading_post/eva)
 "ekx" = (
 /obj/structure/transit_tube{
@@ -104417,12 +104223,6 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/airlock_sensor{
-	id_tag = "vox_eva_int_airlock_sensor";
-	master_tag = "vox_eva_airlock_control";
-	pixel_y = 24
-	},
 /obj/machinery/power/apc{
 	dir = 8;
 	locked = 0;
@@ -104433,19 +104233,10 @@
 /turf/simulated/floor/vox,
 /area/vox_trading_post/eva)
 "elo" = (
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	id_tag = "vox_eva_airlock_control";
-	pixel_y = 24;
-	tag_airpump = "vox_eva_airlock_pump";
-	tag_chamber_sensor = "vox_eva_airlock_sensor";
-	tag_exterior_door = "vox_eva_airlock_exterior";
-	tag_exterior_sensor = "vox_eva_ext_airlock_sensor";
-	tag_interior_door = "vox_eva_airlock_interior";
-	tag_interior_sensor = "vox_eva_int_airlock_sensor"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
+/obj/structure/closet/emcloset/vox,
 /turf/simulated/floor/vox,
 /area/vox_trading_post/eva)
 "elp" = (
@@ -104517,12 +104308,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/simulated/floor,
-/area/research_outpost/gearstore)
-"elz" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "elA" = (
@@ -104918,8 +104703,8 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
 	},
 /turf/simulated/floor/vox,
 /area/vox_trading_post/eva)
@@ -104972,13 +104757,6 @@
 /area/research_outpost/tempstorage)
 "ems" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/turf/simulated/floor,
-/area/research_outpost/gearstore)
-"emt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "emu" = (
@@ -105312,20 +105090,11 @@
 /area/research_outpost/tempstorage)
 "enh" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "eni" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "anom_int_airlock_sensor";
-	master_tag = "anom_airlock_control";
-	pixel_y = -24
-	},
 /obj/structure/dispenser/oxygen,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "enj" = (
@@ -105334,12 +105103,6 @@
 	pixel_x = 24
 	},
 /obj/structure/closet/crate,
-/turf/simulated/floor,
-/area/research_outpost/gearstore)
-"enk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "enl" = (
@@ -105884,18 +105647,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor/plating,
 /area/research_outpost/gearstore)
-"eos" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/simulated/wall/r_wall,
-/area/research_outpost/gearstore)
 "eot" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "anom_airlock_interior";
-	locked = 1
+	req_access_txt = "47"
 	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
@@ -106217,30 +105971,15 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1331;
-	id_tag = "anom_airlock_control";
-	pixel_x = -24;
-	tag_airpump = "anom_airlock_pump";
-	tag_chamber_sensor = "anom_airlock_sensor";
-	tag_exterior_door = "anom_airlock_exterior";
-	tag_exterior_sensor = "anom_ext_airlock_sensor";
-	tag_interior_door = "anom_airlock_interior";
-	tag_interior_sensor = "anom_int_airlock_sensor"
-	},
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	frequency = 1331;
-	id_tag = "anom_airlock_pump"
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 1;
+	on = 1
 	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "epf" = (
 /obj/machinery/recharger{
 	pixel_x = 29
-	},
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	frequency = 1331;
-	id_tag = "anom_airlock_pump"
 	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
@@ -106663,18 +106402,10 @@
 /area/mine/explored)
 "eqb" = (
 /obj/structure/closet/walllocker/emerglocker/west,
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "anom_airlock_sensor";
-	master_tag = "anom_airlock_control";
-	pixel_x = -24;
-	pixel_y = 21
-	},
 /obj/effect/decal/warning_stripes{
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "eqc" = (
@@ -106684,9 +106415,6 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "warning";
 	tag = "icon-warning"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
 	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
@@ -107091,11 +106819,7 @@
 /area/research_outpost/gearstore)
 "eqW" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "anom_airlock_exterior";
-	locked = 1
+	req_access_txt = "47"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -107518,20 +107242,6 @@
 /turf/unsimulated/floor/airless{
 	dir = 6;
 	icon_state = "asteroidwarning"
-	},
-/area/mine/explored)
-"erL" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "anom_ext_airlock_sensor";
-	master_tag = "anom_airlock_control";
-	pixel_y = 24
-	},
-/obj/structure/hanging_lantern{
-	dir = 1
-	},
-/turf/unsimulated/floor/airless{
-	icon_state = "asteroidfloor"
 	},
 /area/mine/explored)
 "erM" = (
@@ -108154,15 +107864,7 @@
 	},
 /area/vox_trading_post/trade_processing)
 "esO" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1551;
-	icon_state = "door_locked";
-	id_tag = "vox_trade_airlock_interior";
-	locked = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/filtering/hidden{
-	dir = 4
-	},
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor{
 	icon_state = "asteroidfloor"
 	},
@@ -108174,30 +107876,6 @@
 	},
 /area/vox_trading_post/trade_processing)
 "esQ" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1551;
-	id_tag = "vox_trade_chamber_sensor";
-	master_tag = "vox_trade_airlock_control";
-	pixel_x = 6;
-	pixel_y = -24
-	},
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1551;
-	id_tag = "vox_trade_airlock_control";
-	pixel_x = -6;
-	pixel_y = -25;
-	tag_airpump = "vox_trade_airlock_pump";
-	tag_chamber_sensor = "vox_trade_chamber_sensor";
-	tag_exterior_door = "vox_trade_airlock_exterior";
-	tag_exterior_sensor = "vox_trade_ext_airlock_sensor";
-	tag_interior_door = "vox_trade_airlock_interior";
-	tag_interior_sensor = "vox_trade_int_airlock_sensor"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8;
-	frequency = 1551;
-	id_tag = "vox_trade_airlock_pump"
-	},
 /turf/simulated/floor{
 	icon_state = "asteroidfloor"
 	},
@@ -108651,9 +108329,6 @@
 	tag = "icon-warning (SOUTHEAST)"
 	},
 /obj/structure/closet/emcloset,
-/obj/machinery/atmospherics/pipe/simple/filtering/hidden{
-	dir = 9
-	},
 /obj/machinery/door/window{
 	dir = 1
 	},
@@ -108667,12 +108342,7 @@
 	icon_state = "warning";
 	tag = "icon-warning (EAST)"
 	},
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/air{
-	filled = 0.2
-	},
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -108692,9 +108362,6 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/door/window{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/filtering/hidden{
-	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -114520,24 +114187,6 @@
 	icon_state = "whitegreen"
 	},
 /area/medical/virology)
-"eJw" = (
-/obj/effect/decal/warning_stripes{
-	dir = 4;
-	icon_state = "warning";
-	tag = "icon-warning (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/filtering/hidden,
-/obj/machinery/airlock_sensor{
-	frequency = 1551;
-	id_tag = "vox_trade_int_airlock_sensor";
-	master_tag = "vox_trade_airlock_control";
-	pixel_x = 24;
-	pixel_y = 6
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/vox_trading_post/trade_processing)
 "eNj" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -114649,19 +114298,6 @@
 /obj/structure/catwalk,
 /turf/space,
 /area/medical/virology)
-"fTL" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1551;
-	id_tag = "vox_trade_ext_airlock_sensor";
-	master_tag = "vox_trade_airlock_control";
-	pixel_x = -24;
-	pixel_y = 6
-	},
-/turf/unsimulated/floor/airless{
-	dir = 4;
-	icon_state = "asteroidwarning"
-	},
-/area/mine/explored)
 "gdr" = (
 /obj/structure/sign/biohazard,
 /turf/simulated/wall/r_wall,
@@ -115015,17 +114651,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
-"jwl" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1551;
-	icon_state = "door_locked";
-	id_tag = "vox_trade_airlock_exterior";
-	locked = 1
-	},
-/turf/simulated/floor{
-	icon_state = "asteroidfloor"
-	},
-/area/vox_trading_post/trade_processing)
 "jyd" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor{
@@ -115478,14 +115103,6 @@
 	icon_state = "dark"
 	},
 /area/vox_trading_post/trade_processing)
-"pnS" = (
-/obj/machinery/atmospherics/pipe/simple/filtering/hidden{
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/vox_trading_post/trade_processing)
 "pqh" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -115845,12 +115462,6 @@
 	icon_state = "white"
 	},
 /area/medical/virology_break)
-"sEN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/simulated/wall/r_wall,
-/area/research_outpost/gearstore)
 "tbd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -217192,11 +216803,11 @@ aaa
 aaa
 aaa
 aaa
-ahW
+ahX
 aiL
 ajC
 aky
-alj
+ahX
 aaa
 aaa
 anh
@@ -217694,11 +217305,11 @@ aaa
 aaa
 aaa
 aaa
-ahZ
+ahX
 aiM
 ajF
 akA
-alk
+ahX
 aaa
 aaa
 anj
@@ -218196,11 +217807,11 @@ aaj
 aal
 aaj
 aaa
-ahY
+ahX
 ahX
 ajE
 akz
-ahY
+ahX
 aaa
 aaa
 ani
@@ -218698,11 +218309,11 @@ acG
 afE
 acG
 acG
-aib
+aia
 aiO
 ajH
 akC
-all
+ahX
 alQ
 alQ
 alQ
@@ -1218692,10 +1218303,10 @@ dVB
 dVB
 dVE
 dVE
-dUR
-dUR
-dUR
-dUR
+dVE
+dVE
+dVE
+dVE
 emW
 enV
 eoK
@@ -1219192,9 +1218803,9 @@ aaa
 aaj
 dVB
 dVB
-egX
-eif
-egX
+dVB
+dVB
+dVB
 egX
 egX
 eif
@@ -1219693,11 +1219304,11 @@ aaa
 aaa
 aaa
 dVB
-efJ
+dVB
+dVB
+dVB
+dVB
 egX
-eih
-ejh
-ekv
 eln
 eml
 emY
@@ -1220196,9 +1219807,9 @@ dUS
 dYv
 dVB
 dVB
-egY
-eig
-eig
+dVB
+dVB
+dVB
 eku
 elm
 emk
@@ -1220698,10 +1220309,10 @@ dUS
 dYv
 dVB
 dVB
+dVB
+dVB
+dVB
 egX
-eii
-eji
-ekw
 elo
 emm
 ena
@@ -1221200,9 +1220811,9 @@ dUS
 dYv
 dVB
 efL
-egX
-egX
-eif
+dVB
+dVB
+dVB
 egX
 eif
 egX
@@ -1225733,7 +1225344,7 @@ erA
 esm
 rRp
 etq
-esm
+alk
 emZ
 dVE
 dUR
@@ -1226735,8 +1226346,8 @@ dVE
 emZ
 erB
 esi
-pnS
-eJw
+eoP
+eto
 etI
 emZ
 dVE
@@ -1228241,7 +1227852,7 @@ dVE
 eqO
 hkT
 etn
-jwl
+esO
 emZ
 esp
 dVB
@@ -1228744,7 +1228355,7 @@ eqO
 tse
 epd
 epd
-fTL
+epd
 erK
 dVB
 dVE
@@ -1252830,14 +1252441,14 @@ ehk
 eis
 ejv
 ejl
-elz
-emt
+elv
+emq
 eni
-eos
-eos
-sEN
 ejp
-erL
+ejp
+ejp
+ejp
+erM
 esp
 dVB
 dVE
@@ -1253836,7 +1253447,7 @@ ejx
 ejl
 elB
 emv
-enk
+ejl
 eot
 epf
 eqc

--- a/maps/waystation.dmm
+++ b/maps/waystation.dmm
@@ -8348,9 +8348,6 @@
 	tag = ""
 	},
 /obj/structure/window/full/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/glowshroom/single,
 /turf/simulated/floor/plating/vox,
@@ -14029,7 +14026,9 @@
 	})
 "doB" = (
 /obj/item/weapon/stool,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
 /turf/simulated/floor/vox{
 	icon_state = "asteroidplating"
 	},
@@ -14047,6 +14046,7 @@
 	req_access = null
 	},
 /obj/effect/glowshroom/single,
+/turf/space,
 /turf/simulated/floor/vox{
 	icon_state = "asteroidplating"
 	},
@@ -22535,6 +22535,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/weapon/reagent_containers/food/drinks/gromitmug,
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -25869,6 +25870,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
+/turf/space,
 /turf/simulated/floor/vox{
 	icon_state = "asteroidplating"
 	},
@@ -27870,24 +27872,8 @@
 	},
 /area/shuttle/syndicate_elite/mothership)
 "gHh" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 4;
-	frequency = 1331;
-	id_tag = "vox_eva_airlock_pump"
-	},
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1331;
-	id_tag = "vox_eva_airlock_control";
-	pixel_y = 25;
-	req_access_txt = "140";
-	tag_airpump = "vox_eva_airlock_pump";
-	tag_chamber_sensor = "vox_eva_airlock_sensor";
-	tag_exterior_door = "vox_eva_airlock_exterior";
-	tag_exterior_sensor = "vox_eva_ext_airlock_sensor";
-	tag_interior_door = "vox_eva_airlock_interior";
-	tag_interior_sensor = "vox_eva_int_airlock_sensor"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/emcloset/vox,
 /turf/simulated/floor/vox{
 	icon_state = "asteroidplating"
 	},
@@ -32080,7 +32066,6 @@
 	},
 /area/centcom/suppy)
 "hJl" = (
-/obj/structure/closet/emcloset/vox,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
 	dir = 4;
 	tag = "icon-intact (EAST)"
@@ -32089,6 +32074,8 @@
 	dir = 4;
 	tag = "icon-intact (EAST)"
 	},
+/obj/structure/table,
+/obj/item/weapon/reagent_containers/food/drinks/gromitmug,
 /turf/simulated/floor/vox{
 	icon_state = "asteroidplating"
 	},
@@ -37693,17 +37680,7 @@
 /area/security/detectives_office)
 "jhP" = (
 /obj/item/weapon/stool,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_eva_int_airlock_sensor";
-	master_tag = "vox_eva_airlock_control";
-	pixel_x = 25;
-	req_access_txt = "140"
-	},
 /turf/simulated/floor/vox{
 	icon_state = "asteroidplating"
 	},
@@ -39699,14 +39676,11 @@
 	name = "Upper Terminal"
 	})
 "jGH" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "vox_eva_airlock_interior";
-	locked = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor/vox{
 	icon_state = "asteroidplating"
 	},
@@ -42848,13 +42822,8 @@
 	},
 /area/hallway/primary/aft)
 "kru" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "vox_eva_airlock_exterior";
-	locked = 1
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor/vox{
 	icon_state = "asteroidplating"
 	},
@@ -51111,16 +51080,6 @@
 	},
 /area/security/main)
 "mpj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_eva_airlock_sensor";
-	master_tag = "vox_eva_airlock_control";
-	pixel_y = 24;
-	req_access_txt = "140"
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/vox{
 	icon_state = "asteroidplating"
@@ -67818,12 +67777,6 @@
 	icon_state = "hallA";
 	name = "Xenoarchaeology Hallway"
 	})
-"qVA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated/wall/r_rock,
-/area/vox_trading_post/storage_1)
 "qVK" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/orange{
@@ -69081,9 +69034,6 @@
 	},
 /area/vox_trading_post/hallway)
 "ryi" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
 /turf/simulated/floor/vox{
@@ -74090,18 +74040,9 @@
 	name = "Xenoarchaeology Hallway"
 	})
 "tLg" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "vox_eva_ext_airlock_sensor";
-	master_tag = "vox_eva_airlock_control";
-	pixel_x = -24;
-	req_access_txt = "140"
-	},
-/turf/unsimulated/floor/airless{
-	dir = 6;
-	icon_state = "asteroidwarning"
-	},
-/area/mine/explored)
+/turf/space,
+/turf/simulated/wall/r_rock,
+/area/vox_trading_post/storage_1)
 "tLi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	req_access_txt = 1
@@ -77323,12 +77264,13 @@
 	},
 /area/science/lab)
 "vox" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
 	frequency = 1331;
-	id_tag = "vox_eva_airlock_pump"
+	name = "Outpost Air Vent";
+	on = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/vox{
 	icon_state = "asteroidplating"
 	},
@@ -80034,12 +79976,6 @@
 	},
 /turf/simulated/floor,
 /area/supply/office)
-"wER" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/vox_trading_post/storage_1)
 "wFf" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder{
@@ -82054,12 +81990,6 @@
 	icon_state = "whitegreen"
 	},
 /area/research_outpost/xenobot)
-"xyx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/simulated/wall/r_rock,
-/area/vox_trading_post/storage_1)
 "xzz" = (
 /turf/simulated/floor{
 	icon_state = "white"
@@ -1185209,7 +1185139,7 @@ ohH
 mnB
 jhP
 coz
-fyO
+tLg
 vJN
 ucF
 ucF
@@ -1185709,7 +1185639,7 @@ vJN
 fyO
 bYt
 jGH
-wER
+xak
 fyO
 fyO
 vJN
@@ -1186211,7 +1186141,7 @@ vJN
 xak
 gHh
 vox
-qVA
+fyO
 vJN
 vJN
 ucF
@@ -1186713,7 +1186643,7 @@ vJN
 xak
 mpj
 ryi
-xyx
+fyO
 vJN
 ucF
 ucF
@@ -1187717,7 +1187647,7 @@ rAv
 gYb
 jny
 jny
-tLg
+eil
 rAv
 vJN
 vJN

--- a/maps/wheelstation.dmm
+++ b/maps/wheelstation.dmm
@@ -57820,8 +57820,13 @@
 	},
 /area/security/gas_chamber)
 "cai" = (
-/obj/machinery/atmospherics/unary/tank/air,
-/turf/simulated/floor/plating,
+/obj/structure/table,
+/obj/item/weapon/storage/box/mugs,
+/obj/item/weapon/reagent_containers/food/drinks/gromitmug,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "red"
+	},
 /area/security/eva)
 "caj" = (
 /obj/structure/table,
@@ -57829,7 +57834,10 @@
 /obj/machinery/firealarm{
 	pixel_y = 29
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "red"
+	},
 /area/security/eva)
 "cak" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
@@ -57853,14 +57861,11 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor{
-	dir = 9;
+	dir = 1;
 	icon_state = "red"
 	},
 /area/security/eva)
 "cam" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layered{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layered{
 	dir = 8
 	},
@@ -57868,6 +57873,10 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
+	dir = 5;
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor,
 /area/security/eva)
@@ -58147,18 +58156,18 @@
 	},
 /area/security/gas_chamber)
 "caY" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/machinery/meter,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layered{
+	dir = 4;
+	tag = "icon-intact (EAST)"
+	},
+/turf/simulated/floor{
+	icon_state = "red"
+	},
 /area/security/eva)
 "caZ" = (
-/obj/machinery/atmospherics/binary/pump/on{
-	dir = 8;
-	target_pressure = 4000
-	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -58167,16 +58176,26 @@
 	name = "_South APC";
 	pixel_y = -24
 	},
-/turf/simulated/floor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layered{
+	dir = 4;
+	tag = "icon-intact (EAST)"
+	},
+/turf/simulated/floor{
+	icon_state = "red"
+	},
 /area/security/eva)
 "cba" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layered{
+	dir = 6;
+	tag = ""
+	},
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "red"
+	},
 /area/security/eva)
 "cbb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layered{
@@ -58194,24 +58213,24 @@
 	},
 /area/security/eva)
 "cbc" = (
-/obj/machinery/atmospherics/pipe/layer_adapter/supply/hidden{
-	dir = 8
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layered{
+	dir = 4;
+	tag = "icon-intact (EAST)"
+	},
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "red"
+	icon_state = "redcorner"
 	},
 /area/security/eva)
 "cbd" = (
 /obj/machinery/atmospherics/unary/vent_pump/on/layered{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/layer_adapter/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layered{
 	dir = 9
 	},
@@ -58651,7 +58670,7 @@
 	},
 /area/security/gas_chamber)
 "cbU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layered,
 /turf/simulated/wall/r_wall,
 /area/security/eva)
 "cbV" = (
@@ -58673,7 +58692,6 @@
 	},
 /area/security/eva)
 "cbX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor,
 /area/security/eva)
 "cbY" = (
@@ -58942,9 +58960,6 @@
 	},
 /area/security/gas_chamber)
 "ccA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/machinery/embedded_controller/radio/airlock_controller{
 	frequency = 1331;
 	id_tag = "sec_eva_airlock_control";
@@ -58969,10 +58984,10 @@
 /turf/simulated/floor/plating,
 /area/security/eva)
 "ccB" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on/layered{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -59005,7 +59020,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on/layered{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor,
 /area/security/eva)
 "ccF" = (
@@ -59509,34 +59523,10 @@
 	},
 /area/security/gas_chamber)
 "cdx" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	frequency = 1331;
-	id_tag = "sec_eva_airlock_pump"
-	},
-/turf/simulated/floor/plating,
-/area/security/eva)
+/turf/simulated/floor/engine,
+/area/mine/eva)
 "cdy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "sec_eva_int_airlock";
-	locked = 1;
-	name = "Security External Airlock";
-	req_access_txt = "63"
-	},
-/turf/simulated/floor/plating,
-/area/security/eva)
-"cdz" = (
-/obj/machinery/door/airlock/external{
-	autoclose = 0;
-	frequency = 1331;
-	icon_state = "door_locked";
-	id_tag = "sec_eva_ext_airlock";
-	locked = 1;
 	name = "Security External Airlock";
 	req_access_txt = "63"
 	},
@@ -59551,18 +59541,12 @@
 	},
 /area/security/eva)
 "cdB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "red"
 	},
 /area/security/eva)
 "cdC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /turf/simulated/floor{
 	icon_state = "red"
 	},
@@ -59850,30 +59834,15 @@
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/security/gas_chamber)
-"cef" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "sec_eva_ext_airlock_sensor";
-	master_tag = "sec_eva_airlock_control";
-	pixel_x = 24;
-	req_access_txt = "63"
-	},
-/obj/structure/catwalk,
-/turf/space,
-/area)
 "ceg" = (
 /turf/simulated/floor{
 	icon_state = "white"
 	},
 /area/security/gas_chamber)
 "ceh" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/simulated/floor/plating,
 /area/security/eva)
 "cei" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
@@ -59882,9 +59851,6 @@
 /turf/simulated/wall/r_wall,
 /area/security/eva)
 "cej" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
 /area/security/eva)
@@ -75680,9 +75646,6 @@
 /turf/simulated/floor/shuttle,
 /area/shuttle/supply)
 "cMH" = (
-/obj/machinery/atmospherics/pipe/layer_adapter/scrubbers/hidden{
-	dir = 8
-	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -75695,6 +75658,10 @@
 	},
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layered{
+	dir = 4;
+	tag = "icon-intact (EAST)"
+	},
 /turf/simulated/floor/plating,
 /area/research_outpost/gearstore)
 "cMI" = (
@@ -89517,7 +89484,8 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layered{
-	dir = 9
+	dir = 9;
+	tag = ""
 	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
@@ -89851,29 +89819,11 @@
 	icon_state = "dark"
 	},
 /area/vox_trading_post/trading_floor)
-"dKq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/simulated/wall,
-/area/vox_trading_post/trading_floor)
-"dKr" = (
-/obj/machinery/atmospherics/unary/tank/nitrogen,
-/turf/simulated/floor/vox{
-	icon_state = "dark"
-	},
-/area/vox_trading_post/trading_floor)
 "dKs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/simulated/floor/engine/vacuum,
 /area/vox_trading_post/trading_floor)
 "dKt" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/structure/closet/emcloset/vox,
 /obj/machinery/light/small{
 	dir = 1
@@ -89888,16 +89838,6 @@
 	icon_state = "dark"
 	},
 /area/vox_trading_post/trading_floor)
-"dKv" = (
-/obj/machinery/airlock_sensor{
-	id_tag = "vox_eva_ext_airlock_sensor";
-	master_tag = "vox_eva_airlock_control";
-	pixel_x = -25
-	},
-/turf/unsimulated/floor/airless{
-	icon_state = "asteroidplating"
-	},
-/area/mine/explored)
 "dKw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
 	dir = 4
@@ -89924,18 +89864,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layered{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
-	dir = 4
-	},
 /turf/simulated/floor/vox{
 	icon_state = "dark"
 	},
 /area/vox_trading_post/trading_floor)
 "dKz" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layered{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layered,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
+	dir = 10;
+	tag = "icon-intact (SOUTHWEST)"
+	},
 /turf/simulated/floor/vox{
 	icon_state = "dark"
 	},
@@ -89949,74 +89887,23 @@
 	},
 /area/vox_trading_post/trading_floor)
 "dKB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/machinery/door/airlock/external{
-	frequency = 1449;
-	icon_state = "door_locked";
-	id_tag = "vox_eva_airlock_interior";
-	locked = 1
+/obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layered{
+	dir = 4
 	},
 /turf/simulated/floor/engine/vacuum,
-/area/vox_trading_post/trading_floor)
-"dKC" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
-	dir = 10
-	},
-/turf/simulated/floor/vox{
-	icon_state = "dark"
-	},
 /area/vox_trading_post/trading_floor)
 "dKD" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	frequency = 1449;
-	id_tag = "vox_eva_airlock_pump"
+/turf/simulated/floor/engine/vacuum,
+/area/vox_trading_post/trading_floor)
+"dKG" = (
+/obj/machinery/atmospherics/unary/vent_pump/on/layered{
+	dir = 8
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/vox_trading_post/trading_floor)
-"dKE" = (
-/obj/machinery/atmospherics/pipe/layer_adapter/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
-	dir = 4
-	},
-/turf/simulated/floor/vox{
-	icon_state = "dark"
-	},
-/area/vox_trading_post/trading_floor)
-"dKF" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
-	dir = 4
-	},
-/turf/simulated/floor/vox{
-	icon_state = "dark"
-	},
-/area/vox_trading_post/trading_floor)
-"dKG" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	icon_state = "intact_on";
-	on = 1;
-	target_pressure = 4000
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
-	dir = 4
-	},
-/turf/simulated/floor/vox{
-	icon_state = "dark"
-	},
-/area/vox_trading_post/trading_floor)
 "dKH" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1449;
-	icon_state = "door_locked";
-	id_tag = "vox_eva_airlock_exterior";
-	locked = 1
-	},
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor/engine/vacuum,
 /area/vox_trading_post/trading_floor)
 "dKI" = (
@@ -90026,57 +89913,6 @@
 /turf/simulated/floor/vox{
 	icon_state = "dark"
 	},
-/area/vox_trading_post/trading_floor)
-"dKJ" = (
-/obj/machinery/atmospherics/pipe/layer_adapter/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/vox_trading_post/trading_floor)
-"dKK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
-	dir = 5
-	},
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	id_tag = "vox_eva_airlock_control";
-	pixel_x = 25;
-	pixel_y = -5;
-	tag_airpump = "vox_eva_airlock_pump";
-	tag_chamber_sensor = "vox_eva_airlock_sensor";
-	tag_exterior_door = "vox_eva_airlock_exterior";
-	tag_exterior_sensor = "vox_eva_ext_airlock_sensor";
-	tag_interior_door = "vox_eva_airlock_interior";
-	tag_interior_sensor = "vox_eva_int_airlock_sensor"
-	},
-/obj/machinery/airlock_sensor{
-	id_tag = "vox_eva_int_airlock_sensor";
-	master_tag = "vox_eva_airlock_control";
-	pixel_x = 25;
-	pixel_y = 5
-	},
-/turf/simulated/floor/vox{
-	icon_state = "dark"
-	},
-/area/vox_trading_post/trading_floor)
-"dKL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/obj/machinery/airlock_sensor{
-	id_tag = "vox_eva_airlock_sensor";
-	master_tag = "vox_eva_airlock_control";
-	pixel_x = 25
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/vox_trading_post/trading_floor)
-"dKM" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/airlock_sensor{
-	id_tag = "vox_eva_airlock_sensor";
-	master_tag = "vox_eva_airlock_control";
-	pixel_x = -25
-	},
-/turf/simulated/floor/engine/vacuum,
 /area/vox_trading_post/trading_floor)
 "dKN" = (
 /obj/machinery/light,
@@ -93098,26 +92934,18 @@
 	},
 /area/vox_trading_post/hallway)
 "dRp" = (
-/obj/machinery/atmospherics/pipe/layer_adapter/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
-	dir = 10
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layered{
+	dir = 10;
+	tag = ""
+	},
 /turf/simulated/floor,
 /area/mine/eva)
 "dRq" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	icon_state = "intact_on";
-	on = 1;
-	target_pressure = 4000
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -93149,14 +92977,14 @@
 /area/mine/eva)
 "dRs" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layered,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layered{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
+	dir = 10
 	},
 /turf/simulated/floor,
 /area/mine/eva)
@@ -93183,9 +93011,6 @@
 /area/research_outpost/hallway)
 "dRv" = (
 /obj/structure/rack,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/item/weapon/pickaxe,
 /obj/item/weapon/pickaxe,
 /obj/item/weapon/pickaxe,
@@ -93456,7 +93281,7 @@
 /turf/simulated/floor,
 /area/mine/production)
 "dRW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layered,
 /turf/simulated/floor,
 /area/mine/eva)
 "dRX" = (
@@ -93515,18 +93340,9 @@
 	},
 /turf/simulated/floor,
 /area/research_outpost/hallway)
-"dSf" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/machinery/recharger,
-/turf/simulated/floor,
-/area/mine/eva)
 "dSg" = (
-/obj/machinery/atmospherics/unary/tank/air{
-	dir = 8
-	},
+/obj/structure/table,
+/obj/machinery/recharger,
 /turf/simulated/floor,
 /area/mine/eva)
 "dSh" = (
@@ -93812,31 +93628,8 @@
 /turf/simulated/floor,
 /area/mine/production)
 "dSQ" = (
-/obj/machinery/atmospherics/pipe/layer_adapter/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
-/area/mine/eva)
-"dSR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	id_tag = "mining_eva_airlock_control";
-	pixel_x = 5;
-	pixel_y = -25;
-	tag_airpump = "mining_eva_airlock_pump";
-	tag_chamber_sensor = "mining_eva_airlock_sensor";
-	tag_exterior_door = "mining_eva_airlock_exterior";
-	tag_exterior_sensor = "mining_eva_ext_airlock_sensor";
-	tag_interior_door = "mining_eva_airlock_interior";
-	tag_interior_sensor = "mining_eva_int_airlock_sensor"
-	},
-/obj/machinery/airlock_sensor{
-	id_tag = "mining_eva_int_airlock_sensor";
-	master_tag = "mining_eva_airlock_control";
-	pixel_x = -5;
-	pixel_y = -25
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layered,
 /turf/simulated/floor,
 /area/mine/eva)
 "dSS" = (
@@ -93909,13 +93702,6 @@
 	},
 /turf/simulated/floor,
 /area/research_outpost/hallway)
-"dSX" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/machinery/recharger,
-/obj/machinery/light,
-/turf/simulated/floor,
-/area/mine/eva)
 "dSY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layered{
 	dir = 4
@@ -94433,38 +94219,18 @@
 /turf/simulated/floor,
 /area/mine/production)
 "dTC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layered,
 /obj/machinery/door/airlock/external{
-	frequency = 1449;
-	icon_state = "door_locked";
-	id_tag = "mining_eva_airlock_interior";
-	locked = 1
+	name = "Mining External Airlock";
+	req_access_txt = "54"
 	},
 /turf/simulated/floor/engine,
 /area/mine/eva)
 "dTD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/simulated/wall,
-/area/mine/eva)
-"dTE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
-/turf/simulated/floor/plating,
+/obj/structure/table,
+/obj/machinery/recharger,
+/obj/machinery/light,
+/turf/simulated/floor,
 /area/mine/eva)
 "dTF" = (
 /obj/structure/window/reinforced,
@@ -94758,35 +94524,25 @@
 /turf/simulated/floor,
 /area/mine/production)
 "dUm" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 8;
-	frequency = 1449;
-	id_tag = "mining_eva_airlock_pump"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layered{
+	dir = 9;
+	tag = ""
 	},
 /turf/simulated/floor/engine,
 /area/mine/eva)
 "dUn" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/airlock_sensor{
-	id_tag = "mining_eva_airlock_sensor";
-	master_tag = "mining_eva_airlock_control";
-	pixel_x = -5;
-	pixel_y = 25
-	},
 /turf/simulated/floor/engine,
 /area/mine/eva)
 "dUo" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
 /obj/machinery/recharger{
 	pixel_x = -30
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on/layered{
+	dir = 4
 	},
 /turf/simulated/floor/engine,
 /area/mine/eva)
@@ -94985,21 +94741,10 @@
 /turf/space,
 /area)
 "dUO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/machinery/airlock_sensor{
-	id_tag = "mining_eva_airlock_sensor";
-	master_tag = "mining_eva_airlock_control";
-	pixel_y = -25
-	},
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/engine,
 /area/mine/eva)
 "dUP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /obj/machinery/recharger{
 	pixel_x = -30
 	},
@@ -95181,10 +94926,11 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
-	dir = 4
-	},
 /obj/item/tool/wrench,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layered{
+	dir = 4;
+	tag = "icon-intact (EAST)"
+	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "dVg" = (
@@ -95193,11 +94939,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layered{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layered{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
@@ -95215,18 +94959,16 @@
 	name = "_North APC";
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
-	dir = 4
-	},
 /obj/item/tool/wrench,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layered{
+	dir = 4;
+	tag = "icon-intact (EAST)"
+	},
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
 "dVi" = (
 /obj/machinery/recharger{
 	pixel_y = 30
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
 	},
 /turf/simulated/floor/engine,
 /area/research_outpost/gearstore)
@@ -95234,21 +94976,11 @@
 /obj/machinery/recharger{
 	pixel_y = 30
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+/obj/machinery/atmospherics/unary/vent_pump/on/layered{
+	dir = 4
 	},
 /turf/simulated/floor/engine,
 /area/research_outpost/gearstore)
-"dVk" = (
-/obj/machinery/airlock_sensor{
-	id_tag = "xenoarch_eva_ext_airlock_sensor";
-	master_tag = "xenoarch_eva_airlock_control";
-	pixel_x = 25
-	},
-/turf/unsimulated/floor/airless{
-	icon_state = "asteroidfloor"
-	},
-/area/mine/explored)
 "dVl" = (
 /obj/effect/decal/warning_stripes{
 	dir = 8;
@@ -95270,12 +95002,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/research_outpost/hallway2)
-"dVo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/research_outpost/gearstore)
 "dVp" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal{
@@ -95299,9 +95025,6 @@
 /turf/simulated/floor/plating,
 /area/research_outpost/gearstore)
 "dVq" = (
-/obj/machinery/atmospherics/pipe/layer_adapter/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/light_switch{
 	pixel_y = 28
 	},
@@ -95416,10 +95139,8 @@
 /area/mine/production)
 "dVE" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1449;
-	icon_state = "door_locked";
-	id_tag = "mining_eva_airlock_exterior";
-	locked = 1
+	name = "Mining External Airlock";
+	req_access_txt = "54"
 	},
 /turf/simulated/floor/engine,
 /area/mine/eva)
@@ -95559,29 +95280,12 @@
 "dVT" = (
 /turf/simulated/floor,
 /area/research_outpost/gearstore)
-"dVU" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1449;
-	icon_state = "door_locked";
-	id_tag = "xenoarch_eva_airlock_interior";
-	locked = 1
-	},
-/turf/simulated/floor/engine,
-/area/research_outpost/gearstore)
 "dVV" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 1;
-	frequency = 1449;
-	id_tag = "xenoarch_eva_airlock_pump"
-	},
 /turf/simulated/floor/engine,
 /area/research_outpost/gearstore)
 "dVW" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1449;
-	icon_state = "door_locked";
-	id_tag = "xenoarch_eva_airlock_exterior";
-	locked = 1
+	req_access_txt = "47"
 	},
 /turf/simulated/floor/engine,
 /area/research_outpost/gearstore)
@@ -95607,9 +95311,6 @@
 /turf/simulated/floor/plating,
 /area/research_outpost/hallway2)
 "dWa" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /turf/simulated/floor/plating,
 /area/research_outpost/gearstore)
 "dWb" = (
@@ -95725,16 +95426,6 @@
 	icon_state = "asteroidwarning"
 	},
 /area/mine/explored)
-"dWn" = (
-/obj/machinery/airlock_sensor{
-	id_tag = "mining_eva_ext_airlock_sensor";
-	master_tag = "mining_eva_airlock_control";
-	pixel_y = 25
-	},
-/turf/unsimulated/floor/airless{
-	icon_state = "asteroidfloor"
-	},
-/area/mine/explored)
 "dWo" = (
 /obj/machinery/conveyor_switch{
 	convdir = 1;
@@ -95846,70 +95537,24 @@
 	},
 /area/research_outpost/bathroom)
 "dWz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/chem_dispenser/brewer/mapping,
+/obj/structure/table,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "red"
 	},
-/turf/simulated/floor,
-/area/research_outpost/gearstore)
-"dWA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/research_outpost/gearstore)
-"dWB" = (
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	id_tag = "xenoarch_eva_airlock_control";
-	pixel_x = -25;
-	pixel_y = -5;
-	tag_airpump = "xenoarch_eva_airlock_pump";
-	tag_chamber_sensor = "xenoarch_eva_airlock_sensor";
-	tag_exterior_door = "xenoarch_eva_airlock_exterior";
-	tag_exterior_sensor = "xenoarch_eva_ext_airlock_sensor";
-	tag_interior_door = "xenoarch_eva_airlock_interior";
-	tag_interior_sensor = "xenoarch_eva_int_airlock_sensor"
-	},
-/obj/machinery/airlock_sensor{
-	id_tag = "xenoarch_eva_int_airlock_sensor";
-	master_tag = "xenoarch_eva_airlock_control";
-	pixel_x = -25;
-	pixel_y = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/research_outpost/gearstore)
+/area/security/eva)
 "dWC" = (
-/obj/machinery/airlock_sensor{
-	id_tag = "xenoarch_eva_airlock_sensor";
-	master_tag = "xenoarch_eva_airlock_control";
-	pixel_x = -25
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
 /obj/machinery/light/small,
 /turf/simulated/floor/engine,
 /area/research_outpost/gearstore)
 "dWD" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/machinery/airlock_sensor{
-	id_tag = "xenoarch_eva_airlock_sensor";
-	master_tag = "xenoarch_eva_airlock_control";
-	pixel_x = 25;
-	pixel_y = 5
-	},
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/engine,
 /area/research_outpost/gearstore)
 "dWE" = (
 /turf/simulated/wall/r_wall,
 /area/research_outpost/iso1)
-"dWF" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/simulated/floor/plating,
-/area/research_outpost/gearstore)
 "dWG" = (
 /turf/simulated/wall,
 /area/research_outpost/iso1)
@@ -97374,8 +97019,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/external{
-	req_access_txt = "13";
-	req_one_access_txt = "13"
+	req_access_txt = "47"
 	},
 /turf/simulated/floor/plating,
 /area/research_outpost/toxins)
@@ -97421,18 +97065,6 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/research_outpost/toxins)
-"dZt" = (
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13";
-	req_one_access_txt = "13"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/research_outpost/toxins)
@@ -204965,7 +204597,7 @@ caW
 cbS
 bZo
 aau
-cef
+aau
 aau
 aau
 aau
@@ -205466,7 +205098,7 @@ bZq
 bZq
 bZq
 bZq
-cdz
+cdy
 bZq
 bZq
 aau
@@ -205964,11 +205596,11 @@ bVV
 bXf
 bYs
 bZp
-cai
+dWz
 cba
 cbU
 ccB
-cdx
+ceh
 cej
 bZq
 aau
@@ -206470,7 +206102,7 @@ cai
 caY
 bZq
 ccA
-cdx
+ceh
 ceh
 bZq
 aaf
@@ -1217947,7 +1217579,7 @@ dJV
 dJV
 dKm
 dKk
-dKE
+dKy
 dKk
 dKV
 dKZ
@@ -1218449,7 +1218081,7 @@ dJX
 dJV
 dJV
 dKu
-dKG
+dKy
 dKN
 dJV
 dJV
@@ -1218950,8 +1218582,8 @@ dHK
 dHK
 dKi
 dJV
-dKr
-dKF
+dKk
+dKy
 dKk
 dKU
 dSK
@@ -1219452,9 +1219084,9 @@ dID
 dJW
 dKg
 dJV
-dKr
-dKC
-dKK
+dKk
+dKy
+dKk
 dKT
 dSK
 dSK
@@ -1219954,9 +1219586,9 @@ dHK
 dHK
 dKf
 dJV
-dKq
+dJV
 dKB
-dKJ
+dJV
 dJV
 dSK
 dSK
@@ -1220457,8 +1220089,8 @@ dJX
 dHA
 dJV
 dKt
+dKG
 dKD
-dKM
 dKU
 dSK
 dSK
@@ -1220960,7 +1220592,7 @@ dHA
 dJV
 dKs
 dKD
-dKL
+dKD
 dKT
 dSK
 dSK
@@ -1221962,7 +1221594,7 @@ dHA
 dJY
 dSK
 dKn
-dKv
+dKo
 dKo
 dKo
 dKn
@@ -1252139,7 +1251771,7 @@ dQE
 dRs
 dRY
 dSS
-dTE
+tNd
 dUo
 dUP
 tNd
@@ -1252643,7 +1252275,7 @@ dRW
 dSQ
 dTC
 dUm
-dUm
+cdx
 dVE
 dLy
 dLy
@@ -1253142,12 +1252774,12 @@ dPS
 dQC
 dRq
 dQC
-dSR
-dTD
+dQC
+dPb
 dUn
 dUO
 dPb
-dWn
+dLy
 dLy
 dLo
 dSK
@@ -1253643,8 +1253275,8 @@ dPb
 dPZ
 dQK
 dRv
-dSf
-dSX
+dQC
+dQC
 dPb
 dPb
 dPb
@@ -1254146,7 +1253778,7 @@ dPb
 dPb
 dPb
 dSg
-dSg
+dTD
 dPb
 dSK
 dSK
@@ -1265697,7 +1265329,7 @@ dTL
 dRx
 dLy
 dLy
-dVk
+dLy
 dLy
 dLo
 dSK
@@ -1267704,8 +1267336,8 @@ dTh
 dTN
 dUx
 cMH
-dVU
-dWA
+dVW
+dUx
 dUz
 dXm
 dXI
@@ -1268207,7 +1267839,7 @@ dTO
 dUx
 dVh
 dVT
-dWB
+dVT
 dWS
 dXn
 dVT
@@ -1268709,7 +1268341,7 @@ dTM
 dUx
 dVf
 wcC
-dWz
+dVT
 dVT
 dVT
 dVT
@@ -1269211,7 +1268843,7 @@ dSy
 dUy
 dVg
 dJB
-dWz
+dVT
 dWR
 dXl
 dVT
@@ -1269713,7 +1269345,7 @@ dTT
 dUx
 dVq
 dWc
-dWz
+dVT
 dWV
 dXl
 dVT
@@ -1270215,7 +1269847,7 @@ dTO
 dUx
 dVr
 dUx
-dWA
+dUx
 dUz
 dXm
 dXI
@@ -1270715,9 +1270347,9 @@ dSk
 dTl
 dTS
 dUx
-dVo
 dWa
-dWF
+dWa
+dWa
 dUz
 dLB
 dKo
@@ -1281773,7 +1281405,7 @@ aaa
 aaa
 dYL
 dYL
-dZt
+dZo
 dYL
 dYL
 dZY

--- a/maps/wheelstation.dmm
+++ b/maps/wheelstation.dmm
@@ -95314,9 +95314,7 @@
 /turf/simulated/floor/plating,
 /area/research_outpost/gearstore)
 "dWb" = (
-/obj/machinery/atmospherics/unary/tank/air{
-	dir = 8
-	},
+/obj/structure/closet/crate/flatpack/brewer,
 /turf/simulated/floor/plating,
 /area/research_outpost/gearstore)
 "dWc" = (
@@ -1265828,7 +1265826,7 @@ dRx
 dSq
 dSZ
 dNW
-dUz
+dUx
 nrZ
 dVW
 dUz
@@ -1266330,7 +1266328,7 @@ dRF
 dSo
 dTj
 dSo
-dUz
+dUx
 dVi
 dVV
 dWC
@@ -1270851,7 +1270849,7 @@ dTO
 dUx
 dVp
 dWb
-dWb
+dWa
 dUz
 dXr
 dKo


### PR DESCRIPTION
have you ever tried to leave the brig into space, or leave the research outpost, and been faced with a goddamn cycling airlock, wasting your valuable time, thinking to yourself "well, the miners can just fucking walk out, why must I live like this"?
NO MORE
this removes all of them, transitioning them into normal airlocks. I attempt to keep them consistent with the map where able, and when slightly larger map changes are required (such as removal of some air tanks), I try to at least maintain the philosophy of the map when able.
there are also some smaller edits in here, such as fixing some incorrect areas which were noted.
[roid] [box] [bagel] [horizon] [way] [meta] [deff] [packed] [snaxi] [synergy] [castle] [wheel]
![gromit-gromit-mug](https://github.com/user-attachments/assets/eab5a7d8-24f3-4d13-ab61-7007ced355ca)

This generally includes Trader Airlocks, Security Airlocks, and Research Outpost Airlocks. I give them correct access where able. Small outliers include locations using those big air jugs mapped in, which I fiddled with. The most notable of them all are the toxins exterior airlocks on deff, north of science, which are normal science-access-requiring externals now.
<img width="1051" height="669" alt="Untitled" src="https://github.com/user-attachments/assets/65e9c9a3-fec0-4909-a100-3dc1303ed3ab" />

