### PR TITLE
Allows External Cycle Airlocks to have their bolts toggled.

### DIFF
--- a/code/game/machinery/embedded_controller/airlock_controllers.dm
+++ b/code/game/machinery/embedded_controller/airlock_controllers.dm
@@ -245,6 +245,8 @@
 			clean = 1
 		if("force_int")
 			clean = 1
+		if("secure")
+			clean = 1
 		if("abort")
 			clean = 1
 

--- a/maps/RoidStation.dmm
+++ b/maps/RoidStation.dmm
@@ -361,7 +361,6 @@
 /area/vox_trading_post/solars)
 "aaR" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "vox_solars_airlock_exterior";
@@ -520,7 +519,6 @@
 /area/vox_trading_post/solars)
 "abf" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "vox_solars_airlock_interior";
@@ -2685,7 +2683,6 @@
 	tag = "icon-warning (NORTH)"
 	},
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "vox_dock_airlock_exterior";
@@ -2717,7 +2714,6 @@
 /area/vox_trading_post/hallway)
 "aeR" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "vox_dock_airlock_interior";
@@ -3916,7 +3912,6 @@
 /area/vox_trading_post/armory)
 "agT" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "vox_trading_airlock_interior";
@@ -4441,7 +4436,6 @@
 /area/vox_trading_post/trading_floor)
 "ahM" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "vox_trading_airlock_exterior";
@@ -103355,7 +103349,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "sec_eva_int_airlock";
@@ -103369,7 +103362,6 @@
 	})
 "dJG" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "sec_eva_ext_airlock";

--- a/maps/bagelstation.dmm
+++ b/maps/bagelstation.dmm
@@ -94281,7 +94281,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "pris_airlock_interior";
@@ -112549,7 +112548,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "pris_airlock_exterior";

--- a/maps/defficiency.dmm
+++ b/maps/defficiency.dmm
@@ -77692,7 +77692,6 @@
 	})
 "cQv" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "sec_eva_int_airlock";
@@ -77710,7 +77709,6 @@
 	})
 "cQw" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "sec_eva_ext_airlock";
@@ -96431,7 +96429,6 @@
 /area/vox_trading_post/solars)
 "dXO" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "vox_solars_airlock_exterior";
@@ -96654,7 +96651,6 @@
 /area/vox_trading_post/solars)
 "dYk" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "vox_solars_airlock_interior";
@@ -99025,7 +99021,6 @@
 	tag = "icon-warning (NORTH)"
 	},
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "vox_dock_airlock_exterior";
@@ -99057,7 +99052,6 @@
 /area/vox_trading_post/hallway)
 "ect" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "vox_dock_airlock_interior";
@@ -100017,7 +100011,6 @@
 /area/vox_trading_post/armory)
 "eed" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "vox_trading_airlock_interior";
@@ -100521,7 +100514,6 @@
 /area/vox_trading_post/armory)
 "eeT" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "vox_trading_airlock_exterior";
@@ -106122,7 +106114,6 @@
 	name = "Firelock North"
 	},
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "anom_int_door";
@@ -106327,7 +106318,6 @@
 /area/mine/explored)
 "epl" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "anom_ext_door";

--- a/maps/metaclub.dmm
+++ b/maps/metaclub.dmm
@@ -109250,7 +109250,6 @@
 "erD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "anom_airlock_interior";
@@ -109456,7 +109455,6 @@
 /area/mine/explored)
 "erW" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "anom_airlock_exterior";
@@ -118511,6 +118509,15 @@
 "hgL" = (
 /turf/simulated/wall,
 /area/crew_quarters/barber)
+"hhq" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1449;
+	icon_state = "door_locked";
+	id_tag = "vox_eva_airlock_interior";
+	locked = 1
+	},
+/turf/simulated/wall,
+/area/vox_trading_post/hallway)
 "hjx" = (
 /obj/structure/closet/wardrobe/orange,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -119669,7 +119676,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "sec_eva_int_airlock";
@@ -122094,7 +122100,6 @@
 /area/shuttle/escape_pod3)
 "xDf" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "sec_eva_ext_airlock";
@@ -1235994,7 +1235999,7 @@ eaH
 eaH
 eaH
 eaH
-etd
+hhq
 etn
 ety
 etd

--- a/maps/packedstation.dmm
+++ b/maps/packedstation.dmm
@@ -59538,7 +59538,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "vox_solars_airlock_exterior";
@@ -59598,7 +59597,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "vox_solars_airlock_interior";
@@ -60080,7 +60078,6 @@
 /area/vox_trading_post/trading_floor)
 "cAe" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "vox_goodsfloor_airlock_interior";
@@ -60182,7 +60179,6 @@
 /area/vox_trading_post/hallway)
 "cAk" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "vox_goodsfloor_airlock_exterior";
@@ -61504,7 +61500,6 @@
 /area/vox_trading_post/hallway)
 "cDr" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "vox_tradehall_airlock_interior";
@@ -61603,7 +61598,6 @@
 /area/vox_trading_post/vault)
 "cDD" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "vox_tradehall_airlock_exterior";
@@ -61798,7 +61792,6 @@
 /area/vox_trading_post/trading_floor)
 "cEb" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "vox_dock_airlock_exterior";
@@ -61927,7 +61920,6 @@
 /area/mine/explored)
 "cEj" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "vox_dock_airlock_interior";

--- a/maps/snaxi.dmm
+++ b/maps/snaxi.dmm
@@ -70910,7 +70910,6 @@
 /area/vox_trading_post/solars)
 "dEs" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "vox_solars_airlock_exterior";
@@ -70993,7 +70992,6 @@
 /area/vox_trading_post/solars)
 "dEy" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "vox_solars_airlock_interior";

--- a/maps/synergy.dmm
+++ b/maps/synergy.dmm
@@ -2166,7 +2166,6 @@
 	})
 "aeu" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "sec_eva_ext_airlock";
@@ -3043,7 +3042,6 @@
 	})
 "agn" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "sec_eva_int_airlock";
@@ -89887,7 +89885,6 @@
 /area/mine/production)
 "dAr" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1333;
 	icon_state = "door_locked";
 	id_tag = "min_airlock_exterior";
@@ -89916,7 +89913,6 @@
 /area/mine/production)
 "dAu" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1333;
 	icon_state = "door_locked";
 	id_tag = "min_airlock_interior";
@@ -92885,7 +92881,6 @@
 /area/research_outpost/gearstore)
 "dGx" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "anom_airlock_interior";
@@ -92915,7 +92910,6 @@
 /area/research_outpost/gearstore)
 "dGA" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "anom_airlock_exterior";

--- a/maps/tgstation-sec.dmm
+++ b/maps/tgstation-sec.dmm
@@ -99988,7 +99988,6 @@
 "eco" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "anom_airlock_interior";
@@ -101212,7 +101211,6 @@
 /area/research_outpost/gearstore)
 "eeT" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "anom_airlock_exterior";

--- a/maps/tgstation-snow.dmm
+++ b/maps/tgstation-snow.dmm
@@ -15423,7 +15423,6 @@
 "aJW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "anom_airlock_interior";
@@ -15814,7 +15813,6 @@
 /area/research_outpost/gearstore)
 "aKT" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "anom_airlock_exterior";

--- a/maps/tgstation.dmm
+++ b/maps/tgstation.dmm
@@ -6027,7 +6027,6 @@
 	})
 "ajD" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "sec_eva_ext_airlock";
@@ -6048,7 +6047,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "sec_eva_int_airlock";
@@ -105891,7 +105889,6 @@
 "eot" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "anom_airlock_interior";
@@ -107091,7 +107088,6 @@
 /area/research_outpost/gearstore)
 "eqW" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "anom_airlock_exterior";

--- a/maps/waystation.dmm
+++ b/maps/waystation.dmm
@@ -37879,7 +37879,6 @@
 	})
 "jkj" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "vox_dock_airlock_exterior";
@@ -45019,7 +45018,6 @@
 /area/centcom/control)
 "kTS" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "vox_dock_airlock_interior";
@@ -45863,7 +45861,6 @@
 /area/centcom/ert)
 "ldB" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "vox_goodsfloor_airlock_interior";
@@ -48397,7 +48394,6 @@
 /area/centcom/test)
 "lJb" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "vox_tradehall_airlock_exterior";
@@ -49737,7 +49733,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "vox_solars_airlock_interior";
@@ -56182,7 +56177,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "vox_solars_airlock_exterior";
@@ -69859,7 +69853,6 @@
 	})
 "rPv" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "vox_tradehall_airlock_interior";
@@ -80267,7 +80260,6 @@
 /area/turret_protected/tcomms_control_room)
 "wKT" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "vox_goodsfloor_airlock_exterior";

--- a/maps/wheelstation.dmm
+++ b/maps/wheelstation.dmm
@@ -59520,7 +59520,6 @@
 	dir = 6
 	},
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "sec_eva_int_airlock";
@@ -59532,7 +59531,6 @@
 /area/security/eva)
 "cdz" = (
 /obj/machinery/door/airlock/external{
-	autoclose = 0;
 	frequency = 1331;
 	icon_state = "door_locked";
 	id_tag = "sec_eva_ext_airlock";

--- a/nano/templates/simple_airlock_console.tmpl
+++ b/nano/templates/simple_airlock_console.tmpl
@@ -29,6 +29,9 @@
 			{{:helper.link('Force interior door', 'alert', {'command' : 'force_int'}, null, data.processing ? 'yellowBackground' : null)}}
 		{{/if}}
 		</div>
+		<div class="itemContent" style="width: auto">
+				{{:helper.link('Secure', data.secure ? 'locked' : 'unlocked', {'command' : 'secure'}, data.processing ? 'disabled' : null, data.secure ? 'linkOn' : null)}}
+		</div>
 	</div>
 	<div class="item" style="padding-top: 10px; width: 100%">
 			{{:helper.link('Abort', 'cancel', {'command' : 'abort'}, data.processing ? null : 'disabled', data.processing ? 'redBackground' : null)}}


### PR DESCRIPTION
**This should be merged with the other mapping pr.**
Basically, what this does is just add a button to airlock controllers, which toggles the bolts.
It has an animation which I can't quite get working which I'll hopefully get help with at some point (I asked in da discord), but it's directly taken from the advanced airlock console nanoui.
This will not affect xenobio or virology, as they use different consoles.
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
You should be able to have them function like normal airlocks, if you desire.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
<img width="474" height="311" alt="Untitled" src="https://github.com/user-attachments/assets/45ca9b98-218d-4276-8e5c-58abb70e68af" />

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:

 * tweak: Airlock Consoles can now be used to toggle the bolts.

