### PR TITLE
Holy water also makes slippery puddles if splashed

### DIFF
--- a/code/modules/reagents/reagents/reagents_religious.dm
+++ b/code/modules/reagents/reagents/reagents_religious.dm
@@ -77,6 +77,7 @@
 		return 1
 	if(volume >= 5)
 		T.bless()
+		T.wet(800) //needs a bit more than regular water cause it's not as pure
 
 	T.clean_act(CLEANLINESS_WATER)
 


### PR DESCRIPTION
## What this does
Splashing holy water now makes regular puddles as well.
This means that splashing holy water makes a tile slippery for exactly as long as regular water; it does not change the blessing mechanics, they still last as long as it should.
## Why it's good
immulsions why is the holy water puddle not slippery
:cl:
 * rscadd: Holy water puddles are slippery now