### PR TITLE
Brings back rotate chair verb for macros

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -137,6 +137,13 @@
 	else
 		plane = OBJ_PLANE
 
+/obj/structure/bed/chair/verb/rotate_chair()
+	set name = "Rotate Chair"
+	set hidden = TRUE
+	set src in oview(1)
+
+	rotate_ccw()
+
 /obj/structure/bed/chair/relayface(var/mob/living/user, direction) //ALSO for vehicles!
 	if(!rotates_anchored || user.incapacitated())
 		return


### PR DESCRIPTION
## What this does
Brings this back as a hidden verb for macro usage and backwards compatiability.
Closes #38471.

## Why it's good
The people demand their macros.

## How it was tested
Typing the verb in the verb box, confirming it working and being a hidden verb.

## Changelog
:cl:
 * tweak: The "rotate chair" verb now works again, but is hidden from the regular verb list, while still being able to be typed and called in macros.