### PR TITLE
Check wire connection verb now shows direction for loose cables

### DIFF
--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -419,7 +419,7 @@ var/global/movement_disabled_exception //This is the client that calls the proc,
 			neighbour = locate() in get_step(get_turf(C),direction)
 			if(!neighbour || neighbour.get_powernet() != C.get_powernet())
 				found_directions += list(dir2text(direction))
-		iff(found_directions.len)
+		if(found_directions.len)
 			error_str += "<span class = 'warning'>Disconnected wire at [formatJumpTo(get_turf(C))] (Directions: [english_list(found_directions)])</span><br>"
 	error_str += "<h1>Terminal connections on current Z Level [z]</h1>"
 	for(var/obj/machinery/power/terminal/T in terminals)

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -414,12 +414,10 @@ var/global/movement_disabled_exception //This is the client that calls the proc,
 		if(!C.d1) //It's a stub
 			continue
 		var/obj/structure/cable/neighbour
-		neighbour = locate() in get_step(get_turf(C),C.d1)
-		if(!neighbour || neighbour.get_powernet() != C.get_powernet())
-			error_str += "<span class = 'warning'>Disconnected wire at [formatJumpTo(get_turf(C))]</span><br>"
-		neighbour = locate() in get_step(get_turf(C),C.d2)
-		if(!neighbour || neighbour.get_powernet() != C.get_powernet())
-			error_str += "<span class = 'warning'>Disconnected wire at [formatJumpTo(get_turf(C))]</span><br>"
+		for(var/direction in list(C.d1,C.d2))
+			neighbour = locate() in get_step(get_turf(C),direction)
+			if(!neighbour || neighbour.get_powernet() != C.get_powernet())
+				error_str += "<span class = 'warning'>Disconnected wire at [formatJumpTo(get_turf(C))] (Direction: [capitalize(dir2text(direction))])</span><br>"
 	error_str += "<h1>Terminal connections on current Z Level [z]</h1>"
 	for(var/obj/machinery/power/terminal/T in terminals)
 		var/turf/T2 = get_turf(T)

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -414,10 +414,13 @@ var/global/movement_disabled_exception //This is the client that calls the proc,
 		if(!C.d1) //It's a stub
 			continue
 		var/obj/structure/cable/neighbour
+		var/list/found_directions = list()
 		for(var/direction in list(C.d1,C.d2))
 			neighbour = locate() in get_step(get_turf(C),direction)
 			if(!neighbour || neighbour.get_powernet() != C.get_powernet())
-				error_str += "<span class = 'warning'>Disconnected wire at [formatJumpTo(get_turf(C))] (Direction: [capitalize(dir2text(direction))])</span><br>"
+				found_directions += list(dir2text(direction))
+		iff(found_directions.len)
+			error_str += "<span class = 'warning'>Disconnected wire at [formatJumpTo(get_turf(C))] (Directions: [english_list(found_directions)])</span><br>"
 	error_str += "<h1>Terminal connections on current Z Level [z]</h1>"
 	for(var/obj/machinery/power/terminal/T in terminals)
 		var/turf/T2 = get_turf(T)


### PR DESCRIPTION
[administration]

## What this does
<img width="440" height="205" alt="image" src="https://github.com/user-attachments/assets/fc02f111-c409-41ed-aafd-f1aa41112a74" />

Pulls this useful little thing out of #38554. (which was fairly unatomic in that PR to begin with)

## Why it's good
Helps diagnosing the issue on this admin verb better.

## How it was tested
Using the verb on the smallest test map with a wire placed like in the above image. (east and west disconnected)

## Changelog
:cl:
 * tweak: The "Check wire connections" verb now shows what direction a power cable is missing a connection on, and on only one line per cable instead of per direction.