### PR TITLE
Revert "Holy water also makes slippery puddles if splashed"

### DIFF
--- a/code/modules/reagents/reagents/reagents_religious.dm
+++ b/code/modules/reagents/reagents/reagents_religious.dm
@@ -77,7 +77,6 @@
 		return 1
 	if(volume >= 5)
 		T.bless()
-		T.wet(800) //needs a bit more than regular water cause it's not as pure
 
 	T.clean_act(CLEANLINESS_WATER)
 


### PR DESCRIPTION
1: this same PR has been shot down a few times in the past because among other things; 
holy water is already strong enough
holy water isn't water (and doesn't (and shouldn't ) act like it)

2: god hates slips

🆑 
 - wip: Holy puddles no longer cause you to slip. Remember, God hates slips.