### PR TITLE
Makes ruins actually spawn on planets (hotfix)

### DIFF
--- a/code/game/machinery/planet_scanner.dm
+++ b/code/game/machinery/planet_scanner.dm
@@ -398,7 +398,7 @@
 /// Returns: A ruin type path, or null if no ruins are available
 /obj/machinery/planet_scanner/proc/select_random_ruin_type()
 	var/list/available_ruins = list()
-	for(var/ruin_path in subtypesof(/datum/map_element/mining_surprise))
+	for(var/ruin_path in subtypesof(/datum/map_element/ruin))
 		available_ruins += ruin_path
 
 	if(available_ruins.len)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Fixes an incorrect typepath which resulted in planets spawning mining surprises instead of the custom-made ruins

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Stops vaults that belong in a vacuum from spawning on planets

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
0%/hotfix/doesn't need to be

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed mining surprises from spawning on planets instead of ruins.
