### PR TITLE
Revert: Floor tile dragging over plating and reinforced flooring #34053

### DIFF
--- a/code/game/objects/items/stacks/tiles/tiles.dm
+++ b/code/game/objects/items/stacks/tiles/tiles.dm
@@ -99,11 +99,6 @@
 				QDEL_NULL(active) //otherwise remove the draggable screen
 
 /obj/item/stack/tile/drag_use(mob/user, turf/T)
-	if(T.canBuildFloortile(src.type) && istype(T,/turf/simulated/floor))
-		var/turf/simulated/floor/F = T
-		F.make_tiled_floor(src)
-		playsound(T, 'sound/weapons/Genhit.ogg', 25, 1)
-		return
 	if(T.canBuildPlating() == BUILD_SUCCESS) //This deletes lattices, only necessary for BUILD_SUCCESS
 		var/L = locate(/obj/structure/lattice) in T
 		if(!L)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->
I made this midround because it pissed me off so much

## What this does
This reverts the ability to drag-place floor tiles over platings.
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## Why it's good
This ability conflicts with placing down plating over lattices, which makes it a pain when you want to just put down platings.
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
It wasn't.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscdel: Removed drag-placing floor tiles over platings.
 