### PR TITLE
tile dragging improvment - smart type detection!

### DIFF
--- a/code/game/objects/items/stacks/tiles/tiles.dm
+++ b/code/game/objects/items/stacks/tiles/tiles.dm
@@ -6,6 +6,7 @@
 	var/datum/paint_overlay/paint_overlay = null
 	var/list/stacked_paint = list()
 	var/active
+	var/lastdragturftype=null
 
 /obj/item/stack/tile/Destroy()
 	..()
@@ -88,17 +89,21 @@
 		return
 	else //End click drag construction, create grille
 		QDEL_NULL(active)
+		lastdragturftype=null
 
 /obj/item/stack/tile/can_drag_use(mob/user, turf/T)
 	if(user.Adjacent(T)) //can we place here
 		var/canbuild = T.canBuildPlating()
 		if(canbuild == BUILD_SUCCESS || canbuild == BUILD_IGNORE || T.canBuildFloortile(src.type))
-			if(use(1)) //place and use rod
-				return 1
-			else
-				QDEL_NULL(active) //otherwise remove the draggable screen
+			if(lastdragturftype ? (T.type==lastdragturftype || (T.type in typesof(lastdragturftype)) || (lastdragturftype in typesof(T.type))) : TRUE)
+				if(use(1)) //place and use rod
+					return 1
+				else
+					QDEL_NULL(active) //otherwise remove the draggable screen
+					lastdragturftype=null
 
 /obj/item/stack/tile/drag_use(mob/user, turf/T)
+	lastdragturftype=T.type
 	if(T.canBuildFloortile(src.type) && istype(T,/turf/simulated/floor))
 		var/turf/simulated/floor/F = T
 		F.make_tiled_floor(src)
@@ -114,6 +119,7 @@
 
 /obj/item/stack/tile/end_drag_use()
 	QDEL_NULL(active)
+	lastdragturftype=null
 
 /obj/item/stack/tile/metal
 	name = "floor tile"


### PR DESCRIPTION
[qol] [tweak]

## What this does
makes it so that dragging tiles will ONLY EITHER turn a lattice into plating, or add a floor tile to plating. this is determined by what tile you drag click on first (if space turf, you'll make lattices to plating, ect)

https://github.com/user-attachments/assets/bcc016e8-6951-4eea-8c62-f760bca48b28

## Why it's good
reduces annoyance when you just want to make plating and not any floors.

## How it was tested
see attached video

## Changelog
:cl:
 * tweak: drag click quick construction with tiles has been changed, and will now only build on tiles of the same type as the first one you built on. engineers rejoice, no more mistaken floor tile placements!
