### PR TITLE
Unfuck pipeline merging

### DIFF
--- a/code/game/machinery/ATMOSPHERICS/datum_pipeline.dm
+++ b/code/game/machinery/ATMOSPHERICS/datum_pipeline.dm
@@ -105,10 +105,9 @@
 									network.merge(other.network)
 								else
 									network = other.network
-									if (network)
-										network.line_members -= other
-										if (!(src in network.line_members)) // sins against the nesting god
-											network.line_members += src
+									network.line_members -= other
+									if (!(src in network.line_members)) // sins against the nesting god
+										network.line_members += src
 
 							other.members = null
 							other.edges = null

--- a/code/game/machinery/ATMOSPHERICS/datum_pipeline.dm
+++ b/code/game/machinery/ATMOSPHERICS/datum_pipeline.dm
@@ -7,9 +7,9 @@
 	var/datum/pipe_network/network
 
 	var/alert_pressure = 0
-var/last_pressure_check=0
+	var/last_pressure_check=0
 
-var/const/PRESSURE_CHECK_DELAY=5 // 5s delay between pchecks to give pipenets time to recover.
+	var/const/PRESSURE_CHECK_DELAY=5 // 5s delay between pchecks to give pipenets time to recover.
 
 /datum/pipeline/Destroy()
 	if(network) //For the pipenet rebuild

--- a/code/game/machinery/ATMOSPHERICS/datum_pipeline.dm
+++ b/code/game/machinery/ATMOSPHERICS/datum_pipeline.dm
@@ -72,62 +72,65 @@
 			if(result.len>0)
 				for(var/obj/machinery/atmospherics/pipe/item in result)
 					var/merged_other = FALSE
-					if(item.parent != src) // encountered a pipe that is not part of this pipeline
-						if(item.parent) // it is already part of another pipeline
-							// merge other pipeline into this to create one bigger pipeline
-							var/datum/pipeline/other = item.parent
-
-							for (var/obj/machinery/atmospherics/pipe/P in other.members)
-								if (P.parent == src)
-									continue
-								P.parent = src
-
-								if (!(P in members))
-									members += P
-
-								if (!(P in possible_expansions))
-									possible_expansions += P
-
-								volume += P.volume
-								alert_pressure = min(alert_pressure, P.alert_pressure)
-								if (P.air_temporary)
-									air.merge(P.air_temporary)
-
-							for (var/obj/machinery/atmospherics/pipe/edge_pipe in other.edges)
-								if (!(edge_pipe in edges))
-									edges += edge_pipe
-
-							if (other.air && other.air != air)
-								air.merge(other.air)
-
-							if (other.network && other.network != network)
-								if (network)
-									network.merge(other.network)
-								else
-									network = other.network
-									network.line_members -= other
-									if (!(src in network.line_members)) // sins against the nesting god
-										network.line_members += src
-
-							other.members = null
-							other.edges = null
-							other.air = null
-							other.network = null
-
-							merged_other = TRUE
-
-						members |= item
-						possible_expansions |= item
-
-						if (!merged_other)
-							volume += item.volume
-							if(item.air_temporary)
-								air.merge(item.air_temporary)
-							item.parent = src
-							alert_pressure = min(alert_pressure, item.alert_pressure)
-
-
 					edge_check--
+					if (item.parent == src) // encountered a pipe already in this pipeline
+						continue
+					// encountered a pipe that is not part of this pipeline
+					if(item.parent) // it is already part of another pipeline
+						// merge other pipeline into this to create one bigger pipeline
+						var/datum/pipeline/other = item.parent
+
+						for (var/obj/machinery/atmospherics/pipe/P in other.members)
+							if (P.parent == src)
+								continue
+							P.parent = src
+
+							if (!(P in members))
+								members += P
+
+							if (!(P in possible_expansions))
+								possible_expansions += P
+
+							volume += P.volume
+							alert_pressure = min(alert_pressure, P.alert_pressure)
+							if (P.air_temporary)
+								air.merge(P.air_temporary)
+
+						for (var/obj/machinery/atmospherics/pipe/edge_pipe in other.edges)
+							if (!(edge_pipe in edges))
+								edges += edge_pipe
+
+						if (other.air && other.air != air)
+							air.merge(other.air)
+
+						if (other.network && other.network != network)
+							if (network)
+								network.merge(other.network)
+							else
+								network = other.network
+								network.line_members -= other
+								if (!(src in network.line_members)) // sins against the nesting god
+									network.line_members += src
+
+						other.members = null
+						other.edges = null
+						other.air = null
+						other.network = null
+
+						merged_other = TRUE
+
+					members |= item
+					possible_expansions |= item
+
+					if (!merged_other)
+						volume += item.volume
+						if(item.air_temporary)
+							air.merge(item.air_temporary)
+						item.parent = src
+						alert_pressure = min(alert_pressure, item.alert_pressure)
+
+
+
 
 			if(edge_check>0)
 				edges += borderline

--- a/code/game/machinery/ATMOSPHERICS/datum_pipeline.dm
+++ b/code/game/machinery/ATMOSPHERICS/datum_pipeline.dm
@@ -7,9 +7,9 @@
 	var/datum/pipe_network/network
 
 	var/alert_pressure = 0
-	var/last_pressure_check=0
+var/last_pressure_check=0
 
-	var/const/PRESSURE_CHECK_DELAY=5 // 5s delay between pchecks to give pipenets time to recover.
+var/const/PRESSURE_CHECK_DELAY=5 // 5s delay between pchecks to give pipenets time to recover.
 
 /datum/pipeline/Destroy()
 	if(network) //For the pipenet rebuild
@@ -71,21 +71,62 @@
 
 			if(result.len>0)
 				for(var/obj/machinery/atmospherics/pipe/item in result)
-					if(item.parent != src)
-						if(item.parent)
-							//Destroy the old pipeline so that the air is stored in the pipes
-							//This could be optimized significantly by making it merge item.parent into this pipeline instead (or vice versa) but I'm just fixing a bug here
-							qdel(item.parent)
-						members += item
-						possible_expansions += item
+					var/merged_other = FALSE
+					if(item.parent != src) // encountered a pipe that is not part of this pipeline
+						if(item.parent) // it is already part of another pipeline
+							// merge other pipeline into this to create one bigger pipeline
+							var/datum/pipeline/other = item.parent
 
-						volume += item.volume
-						item.parent = src
+							for (var/obj/machinery/atmospherics/pipe/P in other.members)
+								if (P.parent == src)
+									continue
+								P.parent = src
 
-						alert_pressure = min(alert_pressure, item.alert_pressure)
+								if (!(P in members))
+									members += P
 
-						if(item.air_temporary)
-							air.merge(item.air_temporary)
+								if (!(P in possible_expansions))
+									possible_expansions += P
+
+								volume += P.volume
+								alert_pressure = min(alert_pressure, P.alert_pressure)
+								if (P.air_temporary)
+									air.merge(P.air_temporary)
+
+							for (var/obj/machinery/atmospherics/pipe/edge_pipe in other.edges)
+								if (!(edge_pipe in edges))
+									edges += edge_pipe
+
+							if (other.air && other.air != air)
+								air.merge(other.air)
+
+							if (other.network && other.network != network)
+								if (network)
+									network.merge(other.network)
+								else
+									network = other.network
+									if (network)
+										network.line_members -= other
+										if (!(src in network.line_members)) // sins against the nesting god
+											network.line_members += src
+
+							other.members = null
+							other.edges = null
+							other.air = null
+							other.network = null
+
+							merged_other = TRUE
+
+						members |= item
+						possible_expansions |= item
+
+						if (!merged_other)
+							volume += item.volume
+							if(item.air_temporary)
+								air.merge(item.air_temporary)
+							item.parent = src
+							alert_pressure = min(alert_pressure, item.alert_pressure)
+
 
 					edge_check--
 

--- a/code/game/machinery/ATMOSPHERICS/datum_pipeline.dm
+++ b/code/game/machinery/ATMOSPHERICS/datum_pipeline.dm
@@ -85,11 +85,8 @@
 								continue
 							P.parent = src
 
-							if (!(P in members))
-								members += P
-
-							if (!(P in possible_expansions))
-								possible_expansions += P
+							members |= P
+							possible_expansions |= P
 
 							volume += P.volume
 							alert_pressure = min(alert_pressure, P.alert_pressure)
@@ -97,8 +94,7 @@
 								air.merge(P.air_temporary)
 
 						for (var/obj/machinery/atmospherics/pipe/edge_pipe in other.edges)
-							if (!(edge_pipe in edges))
-								edges += edge_pipe
+							edges |= edge_pipe
 
 						if (other.air && other.air != air)
 							air.merge(other.air)

--- a/code/game/machinery/ATMOSPHERICS/datum_pipeline.dm
+++ b/code/game/machinery/ATMOSPHERICS/datum_pipeline.dm
@@ -90,8 +90,6 @@
 
 							volume += P.volume
 							alert_pressure = min(alert_pressure, P.alert_pressure)
-							if (P.air_temporary)
-								air.merge(P.air_temporary)
 
 						for (var/obj/machinery/atmospherics/pipe/edge_pipe in other.edges)
 							edges |= edge_pipe
@@ -112,6 +110,7 @@
 						other.edges = null
 						other.air = null
 						other.network = null
+						qdel(other)
 
 						merged_other = TRUE
 
@@ -124,9 +123,6 @@
 							air.merge(item.air_temporary)
 						item.parent = src
 						alert_pressure = min(alert_pressure, item.alert_pressure)
-
-
-
 
 			if(edge_check>0)
 				edges += borderline


### PR DESCRIPTION
## What this does
Fixes an evil bug that arose when merging complex pipenets together

For centuries, atmos techs have known not to merge waste and distro as this led to them both breaking. During the Jungle playtest this mroing there were reports of busted atmos so I connected and tried to VV inspect the pipes but couldn't because `parent` (a `/datum/pipeline`) kept moving around in memory and VV couldn't grabe it.
In local I put some debug lines in and observed that when merging distro and waste in Box like this:

<img width="626" height="570" alt="image" src="https://github.com/user-attachments/assets/96d1d4a0-8da3-44cf-9290-6dcde92a318a" />

some pipeline was getting repeatedly created over and over again, which explains the address constantly changing. More fucking about led to the most likely cause:
>`qdel(item.parent)` completely destroys the parent pipeline of the pipe we are trying to merge into the currently-building pipeline
>the manifold disconnects at some point so returns nothing for its neighbouring nodes when trying to rebuild
>other manifold pipe_network then tries to rebuild its qdel'd pipeline
>encounters the manifold that is now part of a different pipeline and qdel's its pipeline
>repeat

```
SSpipenet/fire nets=135
new pipe_network /datum/pipe_network (ref=[0x2103ec05])
in build_pipeline base=the Scrubbers pipe net= members=1 edges=0
new pipe_network /datum/pipe_network (ref=[0x2103e1f7])
in build_pipeline base=Air supply pipe net= members=1 edges=0
SSpipenet/fire nets=135
new pipe_network /datum/pipe_network (ref=[0x2103ec27])
in build_pipeline base=the Scrubbers pipe net= members=1 edges=0
new pipe_network /datum/pipe_network (ref=[0x2103ec0c])
in build_pipeline base=Air supply pipe net= members=1 edges=0
SSpipenet/fire nets=135
new pipe_network /datum/pipe_network (ref=[0x2103ec6d])
in build_pipeline base=the Scrubbers pipe net= members=1 edges=0
new pipe_network /datum/pipe_network (ref=[0x2103ec33])
in build_pipeline base=Air supply pipe net= members=1 edges=0
SSpipenet/fire nets=135
new pipe_network /datum/pipe_network (ref=[0x2103ebf6])
in build_pipeline base=the Scrubbers pipe net= members=1 edges=0
new pipe_network /datum/pipe_network (ref=[0x2103ec5b])
in build_pipeline base=Air supply pipe net= members=1 edges=0
SSpipenet/fire nets=135
new pipe_network /datum/pipe_network (ref=[0x2103ec21])
in build_pipeline base=the Scrubbers pipe net= members=1 edges=0
new pipe_network /datum/pipe_network (ref=[0x2103e8ee])
in build_pipeline base=Air supply pipe net= members=1 edges=0
SSpipenet/fire nets=135
new pipe_network /datum/pipe_network (ref=[0x2103e72b])
in build_pipeline base=the Scrubbers pipe net= members=1 edges=0
new pipe_network /datum/pipe_network (ref=[0x2103ec32])
in build_pipeline base=Air supply pipe net= members=1 edges=0
```

There is ALSO a runtime because `SSpipenet` copies the global list of pipe_networks to `process` them, but because a `pipe_network` got qdel'd it tries to process it and encounters null (here's what it looks like with the above):

```
SSpipenet/fire nets=135
new pipe_network /datum/pipe_network (ref=[0x21029618])
in build_pipeline base=the Scrubbers pipe net= members=1 edges=0
new pipe_network /datum/pipe_network (ref=[0x2103e8ee])
in build_pipeline base=Air supply pipe net= members=1 edges=0
[13:05:43] Runtime in code/game/machinery/ATMOSPHERICS/datum_pipe_network.dm,117: Cannot execute null.multiply().
  proc name: reconcile air (/datum/pipe_network/proc/reconcile_air)
SSpipenet/fire nets=135
new pipe_network /datum/pipe_network (ref=[0x21029614])
in build_pipeline base=the Scrubbers pipe net= members=1 edges=0
new pipe_network /datum/pipe_network (ref=[0x2103e6f3])
in build_pipeline base=Air supply pipe net= members=1 edges=0
[13:05:45] Runtime in code/game/machinery/ATMOSPHERICS/datum_pipe_network.dm,117: Cannot execute null.multiply().
  proc name: reconcile air (/datum/pipe_network/proc/reconcile_air)
SSpipenet/fire nets=135
new pipe_network /datum/pipe_network (ref=[0x2103e3b2])
in build_pipeline base=the Scrubbers pipe net= members=1 edges=0
new pipe_network /datum/pipe_network (ref=[0x2103e1cd])
in build_pipeline base=Air supply pipe net= members=1 edges=0
[13:05:47] Runtime in code/game/machinery/ATMOSPHERICS/datum_pipe_network.dm,117: Cannot execute null.multiply().
```

This PR replaces the `qdel(item.parent)` (essentially "resetting" the other pipeline's pipes parent state so they can be picked up by the new pipeline) with merging logic to consume the other pipes directly from the other pipeline.
This has been observed in local to fix the bricking pipenet issue but I want an adult who knows atmos code better than I to look it over.

As a result of waste and distro no longer getting stuck in limbo, this should also fix cases where rooms failed to refill from those frozen pipelines, as well as for pumps to add or remove gases from those pipelines.

## Why it's good
before atmos not work when grug mess pipe but now atmos good for grug pipe experiment

## How it was tested
- checking for flapping New/Destroy behaviour pre- and post- fix
- confirmed the merged waste+distro does not lock up and can be pumped in to/out from as expected
- built a few common atmos setups confirming gas flow while also monitoring length of global pipe_networks list, confirming decrement/increment as expected

## Changelog
:cl:
 * bugfix: Fixed a bug that caused complex pipenets to lock up when being merged
