### PR TITLE
Fixes bundle emags being the shitty bugged emags instead of the regular ones.

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -93,7 +93,7 @@
 	var/nticks=0
 	var/disable_config_sync = FALSE
 
-/obj/item/weapon/card/emag/New(var/loc, var/disable_tuning=0)
+/obj/item/weapon/card/emag/New(var/loc, var/disable_tuning=1)
 	..(loc)
 
 	// For standardized subtypes, once they're established.


### PR DESCRIPTION
## What this does
See title.
## Why it's good
Bug bad. Closes #38664
## How it was tested
It wasn't, but the one instance where emags spawn without that shitass behaviour is on the uplink, which sets this value to 1. 
In the event that we DO get an emag subtype one day, they can just set it to 0 on the subtype's new call.
:cl:
 * bugfix: bundle emags shouldn't be the shitty bugged ones no more
