### PR TITLE
Slime extract fixes

### DIFF
--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -505,13 +505,16 @@
 
 	//slime res
 	if(istype(O, /obj/item/weapon/slimeres))
-		if(uses == 0)
+		if(uses <= 0)
 			to_chat(user, "<span class='warning'>The solution doesn't work on used extracts!</span>")
+			qdel(src)
 			return ..()
 		to_chat(user, "You splash the [O] onto \the [src], causing it to quiver and come to life!")
 		new came_from_slime_type(get_turf(src))
 		uses--
 		qdel(O)
+		if(uses <= 0)
+			qdel(src)
 
 //perform individual slime_act() stuff on children overriding the method here
 /obj/item/slime_extract/afterattack(var/atom/target, mob/user, proximity)
@@ -521,7 +524,7 @@
 		if (uses > 0)
 			uses -= 1
 			update_icon()
-		if (uses == 0)
+		if (uses <= 0)
 			qdel(src)
 
 /obj/item/slime_extract/New()
@@ -534,16 +537,18 @@
 
 /obj/item/slime_extract/update_icon()
 	..()
-	if (uses == 1||uses<0) //return if 1 or less uses
+	if(uses <= 0) //delete if no uses
+		qdel(src)
+	if (uses <= 1) //return if 1 use
 		icon_state = icon_state_backup
-	else if (uses == 3||uses>2) //if 3 or more uses use the triple icon
+	else if (uses >= 3) //if 3 or more uses use the triple icon
 		icon_state = "[icon_state_backup]_3"
 	else 		//only option left is two uses
 		icon_state = "[icon_state_backup]_2"
 
 /obj/item/slime_extract/examine(mob/user)
 	..()
-	to_chat(user, "<span class='notice'>\The [name] has [uses] left.</span>")
+	to_chat(user, "<span class='notice'>\The [name] has [uses] use\s left.</span>")
 
 /obj/item/slime_extract/grey
 	name = "grey slime extract"

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -512,6 +512,7 @@
 		to_chat(user, "You splash the [O] onto \the [src], causing it to quiver and come to life!")
 		new came_from_slime_type(get_turf(src))
 		uses--
+		update_icon()
 		qdel(O)
 		if(uses <= 0)
 			qdel(src)

--- a/code/modules/paperwork/envelope.dm
+++ b/code/modules/paperwork/envelope.dm
@@ -53,6 +53,9 @@
 		overlay.pixel_y = -2 * PIXEL_MULTIPLIER
 		overlays += overlay;
 
+/obj/item/weapon/paper/envelope/slime_act(primarytype, mob/user)
+	return open ? FALSE : ..() //hotfixes slimes being messy with this
+
 /obj/item/weapon/paper/envelope/attackby(obj/item/weapon/P, mob/user)
 	. = ..()
 	if(.)


### PR DESCRIPTION
[bugfix][sanity][grammar]

## What this does
Closes #38647.
Closes #38667.

## How it was tested
Using a black slime extract on an envelope, open and closed, taking the black extract out of the envelope.
Using slime enhancer to triple the extract, applying 3 slime resurrections to the extract.

## Changelog
:cl:
 * bugfix: Slime extracts no longer delete when trying to be put into and pulled out of open envelopes.
 * bugfix: Slime extracts now properly delete and update their icon when slime resurrection serum is used on them.
 * spellcheck: Examining slime extracts now says "The extract has [number] use(s) left", adding the missing "uses" word.