### PR TITLE
Heavier smithing hammers (Uranium, Iron, Plasma, etc) hit harder when blacksmithing.

### DIFF
--- a/code/modules/blacksmithing/blacksmithing.dm
+++ b/code/modules/blacksmithing/blacksmithing.dm
@@ -146,8 +146,7 @@
 			qdel(src)
 			return
 	if(istype(A,/obj/item/weapon/hammer))
-		var/strikesmod = round((max(1, round(A.quality/2, 1)) * A.material_type.brunt_damage_mod)
-		strikes += strikesmod
+		strikes += round(max(1, round(A.quality/2, 1)) * A.material_type.brunt_damage_mod)
 	else if(istype(A,/obj/item/weapon/storage/toolbox))
 		strikes+=0.25
 	if(!readytoquench && strikes >= strikes_required)

--- a/code/modules/blacksmithing/blacksmithing.dm
+++ b/code/modules/blacksmithing/blacksmithing.dm
@@ -146,7 +146,7 @@
 			qdel(src)
 			return
 	if(istype(A,/obj/item/weapon/hammer))
-		var/strikesmod = (max(1, round(A.quality/2, 1)) * A.material_type.brunt_damage_mod
+		var/strikesmod = round((max(1, round(A.quality/2, 1)) * A.material_type.brunt_damage_mod)
 		strikes += strikesmod
 	else if(istype(A,/obj/item/weapon/storage/toolbox))
 		strikes+=0.25

--- a/code/modules/blacksmithing/blacksmithing.dm
+++ b/code/modules/blacksmithing/blacksmithing.dm
@@ -146,7 +146,8 @@
 			qdel(src)
 			return
 	if(istype(A,/obj/item/weapon/hammer))
-		strikes+=max(1, round(A.quality/2, 1))
+		var/strikesmod = (max(1, round(A.quality/2, 1)) * A.material_type.brunt_damage_mod
+		strikes += strikesmod
 	else if(istype(A,/obj/item/weapon/storage/toolbox))
 		strikes+=0.25
 	if(!readytoquench && strikes >= strikes_required)


### PR DESCRIPTION
## What this does
The amount of "strikes" a smithing hammer does is now affected by the material's brunt mod, meaning that hammers made with heavier materials, like uranium, plasma, phazon, iron, etc, will perform better than those made with less dense materials (like silver/gold). 
Does not affect the damage the hammer does when swung at someone.
## Why it's good
You no longer need to aim for the perfect quality gold hammer, when a good enough uranium hammer can do the same.
## How it was tested
I genuinely tried to open a localhost to test 4 times but it didn't accept any mouse input, so I couldn't test it. If someone can test it I'd appreciate it.
:cl:
 * rscadd: The material a hammer is made of will now affect its smithing performance, with tougher materials (like uranium or plasma) performing better than their counterparts (like gold or silver). Does not affect its performance as a weapon.