### PR TITLE
thallium metabolises slower

### DIFF
--- a/code/modules/reagents/reagents/reagents_material.dm
+++ b/code/modules/reagents/reagents/reagents_material.dm
@@ -340,7 +340,7 @@
 	reagent_state = REAGENT_STATE_SOLID
 	color = "#CACAD2" //rgb: 202, 202, 210
 	density = 11.87
-	custom_metabolism = 0.1
+	custom_metabolism = 0.005
 	flags = CHEMFLAG_NOTREMOVABLE
 	specheatcap = 0.128
 

--- a/code/modules/reagents/reagents/reagents_material.dm
+++ b/code/modules/reagents/reagents/reagents_material.dm
@@ -340,7 +340,7 @@
 	reagent_state = REAGENT_STATE_SOLID
 	color = "#CACAD2" //rgb: 202, 202, 210
 	density = 11.87
-	custom_metabolism = 0.005
+	custom_metabolism = 0.01
 	flags = CHEMFLAG_NOTREMOVABLE
 	specheatcap = 0.128
 


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
~~thallium compounds have an LD50 of about 20mg/kg bodyweight on rats
assuming spessmen are rats that weigh 80kg, that's an LD50 of 1.6grams for a spessman
using thallium's density of 11.87g/cm^3, that's ~ 0.135 cm^3~~
~~assuming 1u is 10cm^3, we get an LD50 dose of ~ 0.0135u per spessman
assuming there's a 50% chance to survive crit, we need 100 health / (0.5 damage/tick) = 200 ticks for LD50
therefore, metabolism should be 0.0135u/200 = 0.0000675u per tick, and let's round it to 0.00005~~
sets metabolism to 0.01
## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->

## How it was tested
neither the math nor the code were tested<!-- Document what procedures you used to test this PR here, including any images if helpful. -->

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: thallium is 10 times more dangerous