### PR TITLE
Removes load bearing wall in Snaxi

### DIFF
--- a/maps/snaxi.dmm
+++ b/maps/snaxi.dmm
@@ -41614,9 +41614,6 @@
 	icon_state = "cult"
 	},
 /area/library)
-"bNc" = (
-/turf/simulated/wall,
-/area/security/main)
 "bNd" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
@@ -137296,7 +137293,7 @@ bHH
 bIw
 bJj
 bKg
-bNc
+bLc
 bLX
 bMK
 bND


### PR DESCRIPTION
[snaxi]

## What this does
Closes #38670.

## Changelog
:cl:
 * tweak: Snaxi no longer has an erroneously built wall in the security locker room.