### PR TITLE
dragging pinpointers no longer points at movement direction

### DIFF
--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -96,6 +96,11 @@ var/list/pinpointerpinpointer_list = list()
 			to_chat(user,"<span class='danger'>Extreme danger. Arming signal detected. Time remaining: [bomb_timeleft]</span>")
 		else
 			to_chat(user,"<span class='info'>No active nuclear devices detected.</span>")
+		
+/obj/item/weapon/pinpointer/Move(var/newloc, var/direction, var/step_x, var/step_y, var/glide_size_override)
+	var/temp = dir
+	..(newloc, direction, step_x, step_y, glide_size_override)
+	dir = temp	//do not update dir when dragged around
 
 /obj/item/weapon/pinpointer/advpinpointer
 	name = "Advanced Pinpointer"


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does

closes #34983

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->

## How it was tested
https://github.com/user-attachments/assets/17a2eea7-5607-419b-b99c-27b4e05466c5
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 
 * tweak: nuclear pinpointers retain direction when pulled
 