### PR TITLE
Allows DIY shuttle engine pre-igniters to verb and alt-click rotate

### DIFF
--- a/code/game/objects/structures/shuttle_engines.dm
+++ b/code/game/objects/structures/shuttle_engines.dm
@@ -68,6 +68,8 @@
 	name = "shuttle engine pre-igniter"
 	var/obj/structure/shuttle/engine/propulsion/DIY/connected_engine
 	anchored = FALSE
+	verb_rotates = TRUE
+	alt_click_rotates = TRUE
 
 /obj/structure/shuttle/engine/heater/DIY/proc/try_connect()
 	if(!anchored)


### PR DESCRIPTION
[qol]

## What this does
Finally uses the system developed in #38439. and...
Closes #28455.
Closes #23767.
Other item suggestions for adding these settings are welcome.

## Why it's good
Consistency with the other part.

## How it was tested
Rotating it anchored and unanchored, verb and alt-click.

## Changelog
:cl:
 * rscadd: DIY shuttle engine pre-igniters can now be rotated with alt click and their verbs, just like the propulsion system.