### PR TITLE
Fix some grenade runtimes

### DIFF
--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -282,6 +282,10 @@
 
 	reservoir.reagents.trans_to(src, reservoir.reagents.total_volume)
 
+	if (QDELETED(src) || !reagents || !reagents.total_volume)
+		// incase the grenade was explosive and the explosion already qdel'd the grenade
+		return
+
 	if(reagents.total_volume) //The possible reactions didnt use up all reagents.
 		reagents.splashplosion(affected_area)
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -448,7 +448,7 @@ var/global/list/reagents_to_always_log = list(AMUTATIONTOXIN, CYANIDE, CHEFSPECI
 /obj/item/updateUsrDialog()
 	if(in_use)
 		var/is_in_use = 0
-		if(usr)
+		if(_using && usr)
 			_using |= usr
 		if(_using && _using.len)
 			for(var/mob/M in _using) // Only check things actually messing with us.

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -237,6 +237,9 @@
 
 
 /obj/item/device/assembly_holder/process_activation(var/obj/D, var/normal = 1, var/special = 1)
+	if (QDELETED(src))
+		// if this assembly was in a grenade that exploded and was thus qdel'd by the time we get here
+		return
 	if(!D)
 		return 0
 	if(!secured)

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -81,6 +81,9 @@
 			timesoundloop(decrement,freq)
 
 /obj/item/device/assembly/timer/proc/countdown()
+	if (QDELETED(src) || QDELETED(holder))
+		// if the timer was destroyed by an explosion while counting down and we came here from a spawn()
+		return
 	if(timing)
 		if(time > 0)
 			spawn(10)
@@ -94,7 +97,8 @@
 			if(repeat && time > 0)
 				spawn()
 					countdown()
-		updateUsrDialog()
+		if (!QDELETED(src))
+			updateUsrDialog()
 
 /obj/item/device/assembly/timer/update_icon()
 	overlays.len = 0


### PR DESCRIPTION
## What this does
When a grenade is explosive, the explosion usually qdel's the grenade, which results in runtimes as `spawn()` calls come back to qdel'd places:

```
[21:19:32] Runtime in code/game/objects/items/weapons/grenades/chem_grenade.dm,285: Cannot read null.total_volume
  proc name: prime (/obj/item/weapon/grenade/chem_grenade/prime)
  usr: Oswald Wile (inorien) (/mob/living/carbon/human)
  usr.loc: The floor (102, 108, 1) (/turf/simulated/floor)
  src: the grenade (/obj/item/weapon/grenade/chem_grenade)
  src.loc: null
  call stack:
  the grenade (/obj/item/weapon/grenade/chem_grenade): prime()
  the igniter (/obj/item/device/assembly/igniter): activate()
  the igniter (/obj/item/device/assembly/igniter): pulsed(0)
  the timer-igniter assembly (/obj/item/device/assembly_holder): process activation(the timer (/obj/item/device/assembly/timer), 1, 0)
  the timer (/obj/item/device/assembly/timer): pulse(0)
  the timer (/obj/item/device/assembly/timer): timer end()
  the timer (/obj/item/device/assembly/timer): countdown()
  the timer (/obj/item/device/assembly/timer): countdown()
[21:19:32] Runtime in code/modules/assembly/holder.dm,251: Cannot execute null.pulsed(). 
  proc name: process activation (/obj/item/device/assembly_holder/process_activation)
  usr: Oswald Wile (inorien) (/mob/living/carbon/human)
  usr.loc: The floor (102, 108, 1) (/turf/simulated/floor)
  src: the timer-igniter assembly (/obj/item/device/assembly_holder)
  src.loc: null
  call stack:
  the timer-igniter assembly (/obj/item/device/assembly_holder): process activation(the timer (/obj/item/device/assembly/timer), 1, 0)
  the timer (/obj/item/device/assembly/timer): pulse(0)
  the timer (/obj/item/device/assembly/timer): timer end()
  the timer (/obj/item/device/assembly/timer): countdown()
  the timer (/obj/item/device/assembly/timer): countdown()
[21:19:32] Runtime in code/game/objects/objs.dm,452: type mismatch: 0 |= Oswald Wile (/mob/living/carbon/human) //<-- because _using is null (0)
  proc name: updateUsrDialog (/obj/item/updateUsrDialog)
  usr: Oswald Wile (inorien) (/mob/living/carbon/human)
  usr.loc: The floor (102, 108, 1) (/turf/simulated/floor)
  src: the timer (/obj/item/device/assembly/timer)
  src.loc: null
  call stack:
  the timer (/obj/item/device/assembly/timer): updateUsrDialog()
  the timer (/obj/item/device/assembly/timer): countdown()
  the timer (/obj/item/device/assembly/timer): countdown()
```

- in `chem_grenade.dm` checks if the grenade is qdel'd before accessing `reagents`
- in `objs` adds a check for `_using` not being null before accessing it
- `holder.dm` and `timer.dm` check for qdel before proceeding, these calls are behind `spawn()`s and can still be in flight when the grenade gets qdel'd

Found while checking #34195 , I couldn't reproduce that exact bug but there were runtimes


## Why it's good
runtimes

## How it was tested
made explosive grenades with timer+igniter assembly and PrimeD them

## Changelog
:cl:
 * bugfix: Fixed some grenade runtimes
