### PR TITLE
keycard authenticator public department access

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -56,6 +56,7 @@
 	penetration_dampening = 10
 	var/image/shuttle_warning_lights
 	var/list/remote_control_access = list(/mob/living/silicon, /mob/living/simple_animal/hostile/pulse_demon) //Mobs with access to directly controlling the airlock
+	var/emergency_access_override = FALSE	//enabled via department heads request consoles
 	explosion_block = 1
 
 	emag_cost = 1 // in MJ
@@ -490,7 +491,10 @@ About the new airlock wires panel:
 		if(locked && lights)
 			icon_state = "door_locked"
 		else
-			icon_state = "door_closed"
+			if(emergency_access_override)
+				icon_state = "waiting_for_sprites_to_materialise" //maybe it'll materialise as an overlay instead so this might need to be reworked
+			else
+				icon_state = "door_closed"
 		if (panel_open || welded)
 			var/L[0]
 			if (panel_open)
@@ -1648,3 +1652,16 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/tackled(mob/living/carbon/human/user)
 	if(ishuman(user))
 		emag_check(user.wear_id,user)
+	
+/obj/machinery/door/airlock/proc/enable_emergency_access_override()
+	emergency_access_override = TRUE
+	update_icon()
+	
+/obj/machinery/door/airlock/proc/disable_emergency_access_override()
+	emergency_access_override = FALSE
+	update_icon()
+	
+/obj/machinery/door/airlock/allowed(mob/M)
+	if(emergency_access_override)
+		return 1
+	return ..(M)

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -101,10 +101,16 @@ var/global/list/obj/machinery/keycard_auth/authenticators = list()
 			dat += "<li><A href='?src=\ref[src];triggerevent=Emergency Response Team'>Emergency Response Team</A></li>"
 		else
 			dat += "<li>Emergency Response Team (Disabled while below Code Red)</li>"
-		dat += {"<li><A href='?src=\ref[src];triggerevent=Grant Emergency Maintenance Access'>Grant Emergency Maintenance Access</A></li>
-			<li><A href='?src=\ref[src];triggerevent=Revoke Emergency Maintenance Access'>Revoke Emergency Maintenance Access</A></li>
-			</ul>"}
-		user << browse(HTML_SKELETON(dat), "window=keycard_auth;size=500x300")
+			dat += "<li><A href='?src=\ref[src];triggerevent=Toggle Emergency Maintenance Access'>[(access_maint_tunnels in all_access_list) ? "Revoke" : "Grant"] Emergency Maintenance Access</A></li>"
+			dat += "<li><A href='?src=\ref[src];triggerevent=Toggle Emergency Security Access'>[(access_security in all_access_list) ? "Revoke" : "Grant"] Emergency Security Access</A></li>"
+			dat += "<li><A href='?src=\ref[src];triggerevent=Toggle Emergency Medical Access'>[(access_medical in all_access_list) ? "Revoke" : "Grant"] Emergency Medical Access</A></li>"
+			dat += "<li><A href='?src=\ref[src];triggerevent=Toggle Emergency Science Access'>[(access_science in all_access_list) ? "Revoke" : "Grant"] Emergency Science Access</A></li>"
+			dat += "<li><A href='?src=\ref[src];triggerevent=Toggle Emergency Engineering Access'>[(access_engine_minor in all_access_list) ? "Revoke" : "Grant"] Emergency Engineering Access</A></li>"
+			//no public command, we're not commies
+			dat += "<li><A href='?src=\ref[src];triggerevent=Toggle Emergency Civilian areas Access'>[(access_bar in all_access_list) ? "Revoke" : "Grant"] Emergency Civilian areas Access</A></li>"
+			dat += "<li><A href='?src=\ref[src];triggerevent=Toggle Emergency Supply Access'>[(access_cargo in all_access_list) ? "Revoke" : "Grant"] Emergency Supply Access</A></li>"
+			
+		user << browse(HTML_SKELETON(dat), "window=keycard_auth;size=500x400")
 	if(screen == 2)
 
 		dat += "Please swipe your card to authorize the following event: <b>[event]</b>"
@@ -181,12 +187,56 @@ var/global/list/obj/machinery/keycard_auth/authenticators = list()
 		if("Red alert")
 			set_security_level(SEC_LEVEL_RED)
 			feedback_inc("alert_keycard_auth_red",1)
-		if("Grant Emergency Maintenance Access")
-			make_doors_all_access(list(access_maint_tunnels))
-			feedback_inc("alert_keycard_auth_maintGrant",1)
-		if("Revoke Emergency Maintenance Access")
-			revoke_doors_all_access(list(access_maint_tunnels))
-			feedback_inc("alert_keycard_auth_maintRevoke",1)
+		if("Toggle Emergency Maintenance Access")
+			if(access_maint_tunnels in all_access_list)
+				revoke_doors_all_access(list(access_maint_tunnels))
+				feedback_inc("alert_keycard_auth_maintRevoke",1)
+			else
+				make_doors_all_access(list(access_maint_tunnels))
+				feedback_inc("alert_keycard_auth_maintGrant",1)
+		if("Toggle Emergency Security Access")
+			if(access_security in all_access_list)
+				revoke_doors_all_access(get_region_accesses(1))
+				feedback_inc("alert_keycard_auth_secRevoke",1)
+			else
+				make_doors_all_access(get_region_accesses(1))
+				feedback_inc("alert_keycard_auth_secGrant",1)			
+		if("Toggle Emergency Medical Access")
+			if(access_medical in all_access_list)
+				revoke_doors_all_access(get_region_accesses(2))
+				feedback_inc("alert_keycard_auth_medRevoke",1)
+			else
+				make_doors_all_access(get_region_accesses(2))
+				feedback_inc("alert_keycard_auth_medGrant",1)
+		if("Toggle Emergency Science Access")
+			if(access_science in all_access_list)
+				revoke_doors_all_access(get_region_accesses(3))
+				feedback_inc("alert_keycard_auth_sciRevoke",1)
+			else
+				make_doors_all_access(get_region_accesses(3))
+				feedback_inc("alert_keycard_auth_sciGrant",1)	
+		if("Toggle Emergency Engineering Access")
+			if(access_engine_minor in all_access_list)
+				revoke_doors_all_access(get_region_accesses(4) - list(access_maint_tunnels))
+				feedback_inc("alert_keycard_auth_engRevoke",1)
+			else
+				make_doors_all_access(get_region_accesses(4) - list(access_maint_tunnels))
+				feedback_inc("alert_keycard_auth_engGrant",1)	
+		if("Toggle Emergency Civilian areas Access")
+			if(access_bar in all_access_list)
+				revoke_doors_all_access(get_region_accesses(6))
+				feedback_inc("alert_keycard_auth_civRevoke",1)
+			else
+				make_doors_all_access(get_region_accesses(6))
+				feedback_inc("alert_keycard_auth_civGrant",1)	
+		if("Toggle Emergency Supply Access")
+			if(access_cargo in all_access_list)
+				revoke_doors_all_access(get_region_accesses(7))
+				feedback_inc("alert_keycard_auth_supRevoke",1)
+			else
+				make_doors_all_access(get_region_accesses(7))
+				feedback_inc("alert_keycard_auth_supGrant",1)	
+		
 		if("Emergency Response Team")
 			var/datum/striketeam/ert/response_team = new()
 			response_team.mission = ert_reason

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -254,17 +254,18 @@ var/global/list/all_access_list = list()
 
 /proc/make_doors_all_access(var/list/accesses, var/announce = TRUE)
 	all_access_list.Add(accesses)
+	for(var/obj/machinery/door/airlock/AL in world)
+		if(AL.check_access_list(accesses))
+			AL.enable_emergency_access_override()
 	if(announce)
 		to_chat(world, "<font size=4 color='red'>Attention!</font>")
 		to_chat(world, "<span class='red'>The [get_access_desc_list(accesses)] access requirement has been revoked on all airlocks.</span>")
 
 /proc/revoke_doors_all_access(var/list/accesses, var/announce = TRUE)
 	all_access_list.Remove(accesses)
+	for(var/obj/machinery/door/airlock/AL in world)
+		if(AL.check_access_list(accesses))
+			AL.disable_emergency_access_override()
 	if(announce)
 		to_chat(world, "<font size=4 color='red'>Attention!</font>")
 		to_chat(world, "<span class='red'>The [get_access_desc_list(accesses)] access requirement has been readded on all airlocks.</span>")
-
-/obj/machinery/door/airlock/allowed(mob/M)
-	if(check_access_list(all_access_list))
-		return 1
-	return ..(M)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
lets the keycard swipers make departments public-access
only applies to airlocks for now, but adding windoors, blast shutter buttons, and computers(shuttles, RND, etc) to the list would be trivial
was also thinking about not using the keycard for this at all and letting the department head toggle the access on his own department without a second ID to swipe
what do (You) think? [discussion]

see also: #16760 and #33937

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->

## How it was tested
<img width="1107" height="531" alt="image" src="https://github.com/user-attachments/assets/2dd07641-ddc9-4eb0-b0ec-4c06f4ccb668" />

<img width="286" height="210" alt="image" src="https://github.com/user-attachments/assets/2f8eb523-d8a3-4d69-bde1-d8be4f98ff64" />
<img width="303" height="269" alt="image" src="https://github.com/user-attachments/assets/264ced04-0bfb-48ee-b79a-82b3804f003a" />
<img width="393" height="420" alt="image" src="https://github.com/user-attachments/assets/28e7b205-b3ce-4546-9e38-067ab7700a63" />

https://github.com/user-attachments/assets/73bee1b6-ed64-4cf7-b3f9-f5adea30334c



## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: keycard authenticators in command offices can now make entire departments public