### PR TITLE
Fix April Fool's day crit runtimes

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -430,7 +430,7 @@
 			spell_master.update_spells(0, src)
 
 	for (var/time in crit_rampup)
-		if (world.time > num2text(time) + 20 SECONDS) // clear out the items older than 20 seconds
+		if (world.time > text2num(time) + 20 SECONDS) // clear out the items older than 20 seconds
 			crit_rampup -= time
 
 	if(base_luck ? base_luck.temporary_luckiness : FALSE)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -292,7 +292,7 @@
 	var/original_density = 1
 	var/old_assigned_role // If they ghosted, what role did they have?
 
-	var/list/crit_rampup = list() // Of the form timestamp/damage
+	var/list/crit_rampup = list() // damage values keyed by text timestamps
 
 	var/list/huds = list() // List of active huds on a mob
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -131,7 +131,7 @@ var/list/impact_master = list()
 /obj/item/projectile/proc/hit_apply(var/mob/living/X, var/blocked) // this is relevant because of projectile/energy/electrode
 	// Random crits
 	if ((Holiday == APRIL_FOOLS_DAY) && firer && X.client)
-		firer.crit_rampup[text2num(world.time)] = damage
+		firer.crit_rampup[num2text(world.time)] = damage
 	X.apply_effects(stun, weaken, paralyze, irradiate, stutter, eyeblur, drowsy, agony, blocked)
 
 /obj/item/projectile/proc/on_hit(var/atom/atarget, var/blocked = 0)


### PR DESCRIPTION
## What this does
Fixes a runtime that looks like this:
```
[18:06:31] Runtime in code/modules/mob/mob.dm,420: type mismatch: "0" + 200
  proc name: Life (/mob/proc/Life)
  src: Rich Butt (/mob/living/carbon/human)
  src.loc: the floor (294,241,1) (/turf/simulated/floor)
  call stack:
  Rich Butt (/mob/living/carbon/human): Life()
  Rich Butt (/mob/living/carbon/human): Life()
  Rich Butt (/mob/living/carbon/human): Life()
  Mob (/datum/subsystem/mob): fire(0)
  Mob (/datum/subsystem/mob): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
```

This happens on April Fool's Day only. There is a critical hit feature that builds a list on `mob` (`crit_rampup`) as a list keyed by world.time (as text so it doesnt make a giant list) however a couple of num2text and text2num calls are the wrong way around which leads to the above.

Found while investigating old issues, possibly the cause of some of them because these runtimes don't stop once anything is added to `crit_rampup` as `Life()` is unable to ever prune them due to the runtime. This is a lot of runtimes

## Why it's good
runtime bad

## How it was tested
Adding values to `crit_rampup` through VV, confirming runtimes disappeared after fix

## Changelog

:cl:
 * bugfix: Fixed some lag that could only occur on April Fool's Day

