### PR TITLE
Fix simplemobs not being able to destroy girders

### DIFF
--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -10,7 +10,7 @@
 /obj/structure/girder/attack_animal(var/mob/living/M)
 	M.delayNextAttack(8)
 	if(istype(M,/mob/living/simple_animal))
-		var/mob/living/simple_animal/SA
+		var/mob/living/simple_animal/SA = M
 		if(SA.environment_smash_flags & SMASH_WALLS)
 			if(prob(25)) // Not the best solution, but this should allow for better feedback so the player realizes the mob is trying to break through and has time to retreat
 				playsound(src, 'sound/weapons/heavysmash.ogg', 75, 1)
@@ -31,7 +31,7 @@
 		else
 			M.visible_message("<span class='danger'>[M] smashes against \the [src].</span>", \
 			"<span class='attack'>You smash against \the [src].</span>")
-	
+
 /obj/structure/girder/wood
 	icon_state = "girder_wood"
 	name = "wooden girder"


### PR DESCRIPTION
## What this does
Fixes a runtime that looks like this:
```
[10:19:31] Runtime in code/game/objects/structures/girders.dm,14: Cannot read null.environment_smash_flags
  proc name: attack animal (/obj/structure/girder/attack_animal)
  src: the girder (/obj/structure/girder)
  src.loc: the plating (72,204,1) (/turf/simulated/floor/plating)
  call stack:
  the girder (/obj/structure/girder): attack animal(the giant spider (/mob/living/simple_animal/hostile/giant_spider/nurse))
  the giant spider (/mob/living/simple_animal/hostile/giant_spider/nurse): UnarmedAttack(the girder (/obj/structure/girder), 1, null)
  the giant spider (/mob/living/simple_animal/hostile/giant_spider/nurse): UnarmedAttack(the girder (/obj/structure/girder), 1, null)
  the giant spider (/mob/living/simple_animal/hostile/giant_spider/nurse): UnarmedAttack(the girder (/obj/structure/girder), 1, null)
  the giant spider (/mob/living/simple_animal/hostile/giant_spider/nurse): DestroySurroundings()
  the giant spider (/mob/living/simple_animal/hostile/giant_spider/nurse): Life()
  the giant spider (/mob/living/simple_animal/hostile/giant_spider/nurse): Life()
  the giant spider (/mob/living/simple_animal/hostile/giant_spider/nurse): Life()
  Mob (/datum/subsystem/mob): fire(0)
  Mob (/datum/subsystem/mob): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
```

When simple_animals attack girders the girder checks if the simple_animal has `SMASH_WALLS` in its `environment_smash_flags`, however the code was just declaring a `simple_animal` without assigning it before attempting to access it. This check occurs any time any simple animal attacks a girder, even if they can't actually destroy it, so things like spiders which sort of attack everything were spewing lots of runtimes.
Further, because of the runtime, the girder could never actually be destroyed

## Why it's good
runtime bad

## How it was tested
put my ghost in an alien and confirmed I could destroy girders without runtimes

## Changelog
:cl:
 * bugfix: Simplemobs can once again destroy girders
