### PR TITLE
Fix cult runtime

### DIFF
--- a/code/_onclick/mindUI/bloodcult/cultist.dm
+++ b/code/_onclick/mindUI/bloodcult/cultist.dm
@@ -1179,6 +1179,9 @@
 							continue
 					if (istype(O, /mob/living/simple_animal/construct))
 						var/mob/living/simple_animal/construct/cons = O
+						if (!(cons.construct_type in construct_types))
+							// its a harvester or something
+							continue
 						if (!(cons.construct_type in free_construct_slots))
 							free_construct_slots += cons.construct_type
 							var/obj/abstract/mind_ui_element/hoverable/bloodcult_cultist_slot/S


### PR DESCRIPTION
## What this does
Fixes a runtime that looks like this:
```
[23:39:19] Runtime in code/_onclick/mindUI/bloodcult/cultist.dm,1204: Cannot read null.overlays
  proc name: UpdateIcon (/obj/abstract/mind_ui_element/bloodcult_cultist_slot_manager/UpdateIcon)
  src: Cultist Slots (/obj/abstract/mind_ui_element/bloodcult_cultist_slot_manager)
  src.loc: null
  call stack:
  Cultist Slots (/obj/abstract/mind_ui_element/bloodcult_cultist_slot_manager): UpdateIcon()
  Cultist Slots (/obj/abstract/mind_ui_element/bloodcult_cultist_slot_manager): process()
  Objects (/datum/subsystem/obj): fire(0)
  Objects (/datum/subsystem/obj): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
```
The code checks the construct type against a list (Artificer, Wraith, Juggernaut) which are pickable. However after Narnar spawns then you can get Harvesters that are not accounted for in the `switch`. As a result `S` is still null when `S.overlays` is accessed which leads to the above.

Fix is to check if the construct type is in the list of possible construct types you can get in that section and skip if its not an Artificer, Wraith or Juggernaut

## Why it's good
runtime bad

## How it was tested
Prayed to Jesus and Jesus told me to just send it

## Changelog
No user-facing change