### PR TITLE
Fixes beer not making people dizzy on only one type of alcohol.

### DIFF
--- a/code/modules/reagents/reagents/reagents_ethanol.dm
+++ b/code/modules/reagents/reagents/reagents_ethanol.dm
@@ -38,7 +38,7 @@
 			if(isnum(A.tick))
 				common_tick += A.tick
 
-	M.dizziness += dizzy_adj
+	M.AdjustDizzy(M.standard_dizzy_reduce + dizzy_adj)
 	if(common_tick >= slur_start && tick < pass_out)
 		if(!M.slurring)
 			M.slurring = 1


### PR DESCRIPTION
[bugfix][hotfix]

## What this does
Closes #38719.

## How it was tested
Adding 50 units of beer to self.

## Changelog
:cl:
 * bugfix: Beer now makes people dizzy again if only one type is consumed.