### PR TITLE
Fix tooltip runtime

### DIFF
--- a/code/modules/tooltip/tooltip.dm
+++ b/code/modules/tooltip/tooltip.dm
@@ -204,6 +204,10 @@
 	var/atom/refTarget = target.get()
 	var/pixloc/clientLoc = bound_pixloc(holder.owner.virtual_eye, SOUTHWEST)
 	var/pixloc/targetLoc = bound_pixloc(refTarget, SOUTHWEST)
+	if (!targetLoc || !clientLoc)
+		// eg. if hovering over infowindow targetLoc can be null
+		return
+
 	var/tilesLeft = clientView["x"] + 1 - ((clientLoc.x - targetLoc.x) / iconSize["width"])
 	var/tilesBottom = clientView["y"] + 1 - ((clientLoc.y - targetLoc.y) / iconSize["height"])
 	options.mouse = alist(


### PR DESCRIPTION
## What this does
Fixes a runtime that looks like this:

```
[21:50:17] Runtime in code/modules/tooltip/tooltip.dm,207: Cannot read null.x
  proc name: setMouseWithoutParams (/datum/tooltip/proc/setMouseWithoutParams)
  usr: Schlomo Gaskin (lumbermancer) (/mob/living/carbon/human)
  usr.loc: Carpet (216, 243, 1) (/turf/simulated/floor/carpet)
  src: /datum/tooltip (/datum/tooltip)
  call stack:
  /datum/tooltip (/datum/tooltip): setMouseWithoutParams(/alist (/alist), /alist (/alist))
  /datum/tooltip (/datum/tooltip): build()
  /datum/tooltip (/datum/tooltip): show(Screech (30) (/obj/abstract/screen/spell), "icon-x=43;icon-y=32", "Screech (30)", "<br>Cooldown: 300 seconds<br>R...", "midnight", null, null, null, null, null)
  /datum/tooltips (/datum/tooltips): show(Screech (30) (/obj/abstract/screen/spell), "icon-x=43;icon-y=32", "Screech (30)", "<br>Cooldown: 300 seconds<br>R...", "midnight", null, null, null, null, null)
  ```

This occurs when hovering over spells in the infowindow:

<img width="244" height="184" alt="image" src="https://github.com/user-attachments/assets/cc983da4-fbb3-4ae7-be54-beea40bf51ae" />

It is similar to a previous fix but occurs along a different code path, just accessing a var that is null in this use case

## Why it's good
runtime bad

## How it was tested
On local confirmed runtime scenario, confirmed runtime no longer occurs after change

## Changelog
No user-facing change
