### PR TITLE
Fix archive diskset from R&D including un-archivable NT tech

### DIFF
--- a/code/modules/research/designs/data.dm
+++ b/code/modules/research/designs/data.dm
@@ -80,7 +80,7 @@
 
 /datum/design/archive_diskset/after_craft(var/obj/O, var/obj/machinery/r_n_d/fabricator/F)
 	for(var/datum/tech/T in get_list_of_elements(F.linked_console.files.known_tech))
-		if(T.id in list("syndicate", "Nanotrasen", "anomaly"))
+		if(T.id in list("syndicate", "nanotrasen", "anomaly"))
 			continue
 		var/obj/item/weapon/disk/tech_disk/TD = new(O)
 		TD.stored = create_tech(T.id)


### PR DESCRIPTION
## What this does
Corrects an oversight that resulted in Nanotrasen research being included in the archive-ready diskset. The R&D Console that produces the diskset just produces a disk for everything it has except a small blacklist, which was meant to include NT but due to a capitalisation mismatch was letting it through.
This disk can not be archived and the archive computer doesn't know what to do with it (separate issue).

## Why it's good
No more dumb unarchivable disk

## How it was tested
Confirmed archive-ready diskset did not include an NT disk after change

## Changelog
:cl:
 * bugfix: Archive-ready Diskset no longer contains an un-archivable NT disk if it was researched
