### PR TITLE
Z-Level Mob Pausing

### DIFF
--- a/code/controllers/subsystem/mob.dm
+++ b/code/controllers/subsystem/mob.dm
@@ -9,16 +9,41 @@ var/datum/subsystem/mob/SSmob
 	display_order = SS_DISPLAY_MOB
 
 	var/list/currentrun
-	var/paused = 0 // Count of mobs skipped due to planet optimization
+	var/list/paused_z = list()
+	var/paused = 0 // Count of mobs skipped due to empty z/planet mob pausing
 
 
 /datum/subsystem/mob/New()
 	NEW_SS_GLOBAL(SSmob)
-
+	for(var/datum/zLevel/Z in map.zLevels)
+		paused_z += list(Z = TRUE)
 
 /datum/subsystem/mob/stat_entry()
-	..("P:[mob_list.len] | Paused:[paused]")
+	..("Processing:[mob_list.len - paused] | Paused:[paused]")
 
+/// Called at roundstart to initialize z-level pause states based on player presence
+/datum/subsystem/mob/proc/initialize_z_pause()
+	for(var/datum/zLevel/level in map.zLevels)
+		if(!level)
+			continue
+		var/list/players = mobs_in_zlevel(level.z, client_needed = TRUE)
+		paused_z[level] = !length(players)
+
+/datum/subsystem/mob/proc/z_pause_check(mob/living/user, to_z, from_z)
+	if(!istype(user) || !user.client)
+		return
+
+	// Mark the new z-level as having players
+	if(to_z)
+		var/datum/zLevel/new_level = map.zLevels[to_z]
+		paused_z[new_level] = FALSE
+
+	// Check if the old z-level still has any players
+	if(from_z)
+		var/list/players = mobs_in_zlevel(from_z, client_needed = TRUE)
+		if(!length(players))
+			var/datum/zLevel/oldlevel = map.zLevels[from_z]
+			paused_z[oldlevel] = TRUE
 
 /datum/subsystem/mob/fire(resumed = FALSE)
 	if (!resumed)
@@ -32,11 +57,19 @@ var/datum/subsystem/mob/SSmob
 		if (!M || M.gcDestroyed || M.timestopped)
 			continue
 
-		// Skip processing non-player mobs on planets without players
-		if (M.planet && !M.client)
-			if (!M.planet.process_mobs)
+		// Skip processing non-player mobs on paused z-levels or planets
+		if (!M.client)
+			if(!M.z)
+				qdel(M) // Hiding in nullspace
+				continue
+			var/datum/zLevel/level = map.zLevels[M.z]
+			if (paused_z[level])
 				paused++
 				continue
+			else if (M.planet)
+				if (!M.planet.process_mobs)
+					paused++
+					continue
 
 		M.Life()
 

--- a/code/controllers/subsystem/mob.dm
+++ b/code/controllers/subsystem/mob.dm
@@ -15,8 +15,6 @@ var/datum/subsystem/mob/SSmob
 
 /datum/subsystem/mob/New()
 	NEW_SS_GLOBAL(SSmob)
-	for(var/datum/zLevel/Z in map.zLevels)
-		paused_z += list(Z = TRUE)
 
 /datum/subsystem/mob/stat_entry()
 	..("Processing:[mob_list.len - paused] | Paused:[paused]")
@@ -50,6 +48,10 @@ var/datum/subsystem/mob/SSmob
 		currentrun = mob_list.Copy()
 		paused = 0
 
+	if(!paused_z.len)
+		for(var/datum/zLevel/Z in map.zLevels)
+			paused_z += list(Z = TRUE)
+
 	while (currentrun.len)
 		var/mob/M = currentrun[currentrun.len]
 		currentrun.len--
@@ -58,16 +60,24 @@ var/datum/subsystem/mob/SSmob
 			continue
 
 		// Skip processing non-player mobs on paused z-levels or planets
-		if (!M.client)
-			if(!M.z)
-				qdel(M) // Hiding in nullspace
-				continue
-			var/datum/zLevel/level = map.zLevels[M.z]
+		if (!M.client && istype(M, /mob/living))
+			var/z_to_check
+			var/mob/living/L = M
+			if(!L.z)
+				var/turf/T = get_turf(L)
+				if(!T || !T.z)
+					qdel(L) // Hiding in nullspace
+					continue
+				else
+					z_to_check = T.z
+			else
+				z_to_check = L.z
+			var/datum/zLevel/level = map.zLevels[z_to_check]
 			if (paused_z[level])
 				paused++
 				continue
-			else if (M.planet)
-				if (!M.planet.process_mobs)
+			else if (L.planet)
+				if (!L.planet.process_mobs)
 					paused++
 					continue
 

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -669,6 +669,10 @@ var/datum/controller/gameticker/ticker
 
 /datum/controller/gameticker/proc/post_roundstart()
 	usr = null
+
+	// Initialize z-level pause states based on player presence
+	SSmob.initialize_z_pause()
+
 	//Handle all the cyborg syncing
 	var/list/active_ais = active_ais()
 	if(active_ais.len)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -88,6 +88,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/artifacts_panel,
 	/client/proc/body_archive_panel,
 	/client/proc/climate_panel,
+	/client/proc/mobs_panel,
 	/datum/admins/proc/ashInvokedEmotions,	/*Ashes all paper from the invoke emotion spell. An emergency purge.*/
 	/client/proc/toggle_admin_examine,
 	/client/proc/beasts_panel,	/* Lists all forgotten beasts generated, along with their characteristics */

--- a/code/modules/admin/mobs_panel.dm
+++ b/code/modules/admin/mobs_panel.dm
@@ -1,0 +1,69 @@
+/datum/admins/proc/mobs_panel()
+	var/dat = {"<html>
+		<head>
+		<style>
+		table, h2 {
+			font-family: Arial, Helvetica, sans-serif;
+			border-collapse: collapse;
+			width: 100%;
+		}
+		td, th {
+			border: 1px solid #dddddd;
+			padding: 8px;
+			text-align: left;
+		}
+		tr:nth-child(even) {
+			background-color: #dddddd;
+		}
+		.header-row {
+			background-color: #4a90d9;
+			color: white;
+			font-weight: bold;
+		}
+		.paused {
+			background-color: #ffcccc;
+		}
+		.active {
+			background-color: #ccffcc;
+		}
+		</style>
+		</head>
+		<body>
+		<h2 style="text-align:center">Mobs Panel</h2>
+		<p style="text-align:center">Total Mobs: [mob_list.len] | Processing: [mob_list.len - SSmob.paused] | Paused: [SSmob.paused]</p>
+		<table>
+		<tr class="header-row">
+			<th>Z-Level</th>
+			<th>Name</th>
+			<th>Status</th>
+			<th>Actions</th>
+		</tr>
+		"}
+
+	for(var/i = 1; i <= map.zLevels.len; i++)
+		var/datum/zLevel/Z = map.zLevels[i]
+		var/is_paused = SSmob.paused_z[Z]
+		var/status_class = is_paused ? "paused" : "active"
+		var/status_text = is_paused ? "PAUSED" : "ACTIVE"
+
+		dat += {"<tr class="[status_class]">
+			<td>Z-[i]</td>
+			<td>[Z.name ? Z.name : Z.type] <a href='?_src_=vars;Vars=\ref[Z]'>\[VV\]</a></td>
+			<td>[status_text]</td>
+			<td>
+				<a href='?src=\ref[src];mobs_panel_clients=1;mobs_z=[i]'>Players</a> |
+				<a href='?src=\ref[src];mobs_panel_paused=1;mobs_z=[i]'>Paused Mobs</a> |
+				<a href='?src=\ref[src];mobs_panel_all=1;mobs_z=[i]'>All Mobs</a> |
+				<a href='?src=\ref[src];mobs_panel_toggle=1;mobs_z=[i]'>Toggle</a>
+			</td>
+		</tr>"}
+
+	dat += {"
+		</table>
+		<br>
+		<p style="text-align:center"><a href='?src=\ref[src];mobs_panel_refresh=1'>Refresh</a></p>
+		</body>
+		</html>
+		"}
+
+	usr << browse(HTML_SKELETON(dat), "window=mobspanel;size=800x500")

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -705,6 +705,76 @@
 		message_admins("<span class='notice'>[key_name(usr)] restarted the climate controller for Z-[C.z].</span>", 1)
 		climate_panel()
 
+	else if(href_list["mobs_panel_refresh"])
+		if(!check_rights(R_DEBUG))
+			return
+		mobs_panel()
+
+	else if(href_list["mobs_panel_clients"])
+		if(!check_rights(R_DEBUG))
+			return
+		var/z = text2num(href_list["mobs_z"])
+		if(!z)
+			return
+		var/list/players = mobs_in_zlevel(z, client_needed = TRUE)
+		if(!length(players))
+			to_chat(usr, "<span class='notice'>No players on Z-[z].</span>")
+			return
+		to_chat(usr, "<span class='notice'><b>Players on Z-[z] ([length(players)]):</b></span>")
+		for(var/mob/M in players)
+			to_chat(usr, "<span class='notice'>- [M] ([M.key]) <a href='?_src_=vars;Vars=\ref[M]'>\[VV\]</a> <a href='?_src_=holder;adminplayeropts=\ref[M]'>\[PP\]</a></span>")
+
+	else if(href_list["mobs_panel_paused"])
+		if(!check_rights(R_DEBUG))
+			return
+		var/z = text2num(href_list["mobs_z"])
+		if(!z)
+			return
+		var/datum/zLevel/level = map.zLevels[z]
+		if(!level || !SSmob.paused_z[level])
+			to_chat(usr, "<span class='notice'>Z-[z] is not paused.</span>")
+			return
+		var/list/paused_mobs = list()
+		for(var/mob/M in mob_list)
+			if(!M.client && M.z == z)
+				paused_mobs += M
+		if(!length(paused_mobs))
+			to_chat(usr, "<span class='notice'>No non-player mobs on Z-[z].</span>")
+			return
+		to_chat(usr, "<span class='notice'><b>Paused mobs on Z-[z] ([length(paused_mobs)]):</b></span>")
+		for(var/mob/M in paused_mobs)
+			to_chat(usr, "<span class='notice'>- [M] ([M.type]) <a href='?_src_=vars;Vars=\ref[M]'>\[VV\]</a></span>")
+
+	else if(href_list["mobs_panel_all"])
+		if(!check_rights(R_DEBUG))
+			return
+		var/z = text2num(href_list["mobs_z"])
+		if(!z)
+			return
+		var/list/all_mobs = mobs_in_zlevel(z, client_needed = FALSE)
+		if(!length(all_mobs))
+			to_chat(usr, "<span class='notice'>No mobs on Z-[z].</span>")
+			return
+		to_chat(usr, "<span class='notice'><b>All mobs on Z-[z] ([length(all_mobs)]):</b></span>")
+		for(var/mob/M in all_mobs)
+			var/client_status = M.client ? "(PLAYER: [M.key])" : ""
+			to_chat(usr, "<span class='notice'>- [M] [client_status] ([M.type]) <a href='?_src_=vars;Vars=\ref[M]'>\[VV\]</a></span>")
+
+	else if(href_list["mobs_panel_toggle"])
+		if(!check_rights(R_DEBUG))
+			return
+		var/z = text2num(href_list["mobs_z"])
+		if(!z)
+			return
+		var/datum/zLevel/level = map.zLevels[z]
+		if(!level)
+			return
+		SSmob.paused_z[level] = !SSmob.paused_z[level]
+		var/new_state = SSmob.paused_z[level] ? "PAUSED" : "ACTIVE"
+		log_admin("[key_name(usr)] toggled Z-[z] mob processing to [new_state].")
+		message_admins("<span class='notice'>[key_name(usr)] toggled Z-[z] mob processing to [new_state].</span>", 1)
+		mobs_panel()
+
 	else if(href_list["delay_round_end"])
 		if(!check_rights(R_SERVER))
 			return

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -1422,6 +1422,14 @@ var/global/blood_virus_spreading_disabled = 0
 		log_admin("[key_name(usr)] checked the Climate Panel.")
 	feedback_add_details("admin_verb","CLI")
 
+/client/proc/mobs_panel()
+	set name = "Mobs Panel"
+	set category = "Debug"
+	if(holder)
+		holder.mobs_panel()
+		log_admin("[key_name(usr)] checked the Mobs Panel.")
+	feedback_add_details("admin_verb","MOBP")
+
 
 /client/proc/start_line_profiling()
 	set category = "Profile"

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -31,6 +31,8 @@
 	if (istype(dyn_mode))
 		dyn_mode.living_players -= src
 
+	unregister_event(/event/z_transition, src, nameof(src::OnMobZChanged()))
+
 	. = ..()
 
 /mob/living/examine(var/mob/user, var/size = "", var/show_name = TRUE, var/show_icon = TRUE) //Show the mob's size and whether it's been butchered

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1779,3 +1779,8 @@ Thanks.
 			for(var/role in mind.antag_roles)
 				var/datum/role/R = mind.antag_roles[role]
 				stat(R.StatPanel())
+
+/// Event handler for z_transition events. Updates SSmob's paused_z tracking.
+/mob/living/proc/OnMobZChanged(mob/living/user, to_z, from_z)
+	if(SSmob)
+		SSmob.z_pause_check(src, to_z, from_z)

--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -27,7 +27,7 @@
 
 		if (hasFactionIcons(src))
 			update_faction_icons()
-	
+
 	if(virus2.len)
 		for(var/ID in virus2)
 			var/datum/disease2/disease/V = virus2[ID]
@@ -35,3 +35,8 @@
 				if(e.count > 0 && e.type == /datum/disease2/effect/loneliness)
 					e.side_effect(src)
 					return
+
+	register_event(/event/z_transition, src, nameof(src::OnMobZChanged()))
+
+	// Notify SSmob that a player has entered this z-level
+	SSmob.z_pause_check(src, z, null)

--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -39,4 +39,5 @@
 	register_event(/event/z_transition, src, nameof(src::OnMobZChanged()))
 
 	// Notify SSmob that a player has entered this z-level
-	SSmob.z_pause_check(src, z, null)
+	if(SSmob)
+		SSmob.z_pause_check(src, z, null)

--- a/code/modules/mob/living/logout.dm
+++ b/code/modules/mob/living/logout.dm
@@ -6,4 +6,5 @@
 
 	unregister_event(/event/z_transition, src, nameof(src::OnMobZChanged()))
 	// Notify SSmob to check if this z-level still has players
-	SSmob.z_pause_check(src,null,z)
+	if(SSmob)
+		SSmob.z_pause_check(src,null,z)

--- a/code/modules/mob/living/logout.dm
+++ b/code/modules/mob/living/logout.dm
@@ -3,3 +3,7 @@
 	if (mind)
 		if(!key)	//key and mind have become seperated.
 			mind.active = 0	//This is to stop say, a mind.transfer_to call on a corpse causing a ghost to re-enter its body.
+
+	unregister_event(/event/z_transition, src, nameof(src::OnMobZChanged()))
+	// Notify SSmob to check if this z-level still has players
+	SSmob.z_pause_check(src,null,z)

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -1389,6 +1389,7 @@
 #include "code\modules\admin\emergency_shuttle_panel.dm"
 #include "code\modules\admin\holder2.dm"
 #include "code\modules\admin\IsBanned.dm"
+#include "code\modules\admin\mobs_panel.dm"
 #include "code\modules\admin\NewBan.dm"
 #include "code\modules\admin\newbanjob.dm"
 #include "code\modules\admin\player_notes.dm"


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Extends the system which pauses mobs on planets without any players to entire z-levels. All mobs present on a z-level without any players present will not process via SSmob until a player returns to that z-level.
Additionally, adds a Mobs Panel in the Debug tab for admins to have better control over the mobs present on each z-level.

<img width="799" height="548" alt="ui" src="https://github.com/user-attachments/assets/032e4a90-a965-4f12-b1ac-288996cb321d" />

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
SSmob is one of our most demanding subsystems. A typical round can see around 600 mobs processing at once, resulting in the subsystem constantly running overtime and lagging the game. Pausing mobs on empty z-levels greatly cuts back on the processing cost while opening the door for more dynamic z-level creation.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Traveled between z-levels as a player and confirmed mobs paused and unpaused accordingly. Verified ghosts did not modify pausing status.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Added the Mobs Panel for admins in the Debug tab.
 * tweak: Mobs present on z-levels without any players will now be paused.
