### PR TITLE
Reduces explosion shrapnel damage from 100x throw damage to 3x throw damage

### DIFF
--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -203,7 +203,7 @@ var/explosion_shake_message_cooldown = 0
 					continue
 				if(ismob(A))
 					to_chat(A, "<span class='warning'>You are blown away by the explosion!</span>")
-				A.throw_at(throwT,pushback+2,500,TRUE,0,shrapnel_whitelist)
+				A.throw_at(throwT,pushback+2,pushback*3,TRUE,0,shrapnel_whitelist)
 			A.ex_act(dist,null,whodunnit)
 			atomtime = world.time - atomtime
 			if(atomtime > 0)

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -203,7 +203,7 @@ var/explosion_shake_message_cooldown = 0
 					continue
 				if(ismob(A))
 					to_chat(A, "<span class='warning'>You are blown away by the explosion!</span>")
-				A.throw_at(throwT,pushback+2,pushback*3,TRUE,0,shrapnel_whitelist)
+				A.throw_at(throwT,pushback+2,15,TRUE,0,shrapnel_whitelist)
 			A.ex_act(dist,null,whodunnit)
 			atomtime = world.time - atomtime
 			if(atomtime > 0)


### PR DESCRIPTION
A revival of two previous PRs, items thrown by explosions have had the unintended effect of instantly killing spessmen for YEARS

:cl:
 * tweak: Items thrown by explosions no longer deal 100x their throwing damage, but rather 3x more throw force damage.