### PR TITLE
Sound system minor fixes + cleanup

### DIFF
--- a/code/controllers/subsystem/sounds.dm
+++ b/code/controllers/subsystem/sounds.dm
@@ -20,7 +20,5 @@ var/datum/subsystem/sounds/SSsounds
 		for (var/datum/sound_emitter/E in client.listener_context.current_channels_by_emitter)
 			if (done[E]) // only need to run update_active_sound_param once per emitter
 				continue
-			spawn()
-				// recalc volume and such for when player/emitter isn't raising move events
-				E.update_active_sound_param()
+			E.update_active_sound_param()
 			done[E] = TRUE

--- a/code/controllers/subsystem/sounds.dm
+++ b/code/controllers/subsystem/sounds.dm
@@ -23,4 +23,4 @@ var/datum/subsystem/sounds/SSsounds
 			spawn()
 				// recalc volume and such for when player/emitter isn't raising move events
 				E.update_active_sound_param()
-				done[E] = TRUE
+			done[E] = TRUE

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -408,7 +408,7 @@ var/global/list/air_alarms = list()
 	..()
 
 /obj/machinery/alarm/setup_sound()
-	sound_emitter = new /datum/sound_emitter(src, is_static = TRUE)
+	sound_emitter = new /datum/sound_emitter(src)
 	if (sound_emitter)
 		var/sound/warn_sound = sound()
 		warn_sound.file = 'sound/machines/effects/air_alarm_warning.ogg'

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -108,7 +108,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 	put_mob(L, user)
 
 /obj/machinery/atmospherics/unary/cryo_cell/setup_sound()
-	sound_emitter = new(src, is_static = TRUE)
+	sound_emitter = new(src)
 	if (sound_emitter)
 		var/sound/bubbles = sound()
 		bubbles.file = 'sound/machines/looping/bubbles.ogg'
@@ -161,6 +161,8 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 
 	if(stat & (FORCEDISABLE|NOPOWER))
 		on = 0
+		update_icon()
+		update_sound()
 
 	if(!node1)
 		return

--- a/code/modules/power/battery.dm
+++ b/code/modules/power/battery.dm
@@ -132,7 +132,7 @@ var/global/list/battery_online =	list(
 	//update_sound()
 
 /obj/machinery/power/battery/setup_sound()
-	sound_emitter = new /datum/sound_emitter(src, is_static = TRUE)
+	sound_emitter = new /datum/sound_emitter(src)
 	if(sound_emitter)
 		//var/sound/smes_hum = sound()
 		//smes_hum.file = 'sound/machines/looping/smes_hum.ogg'

--- a/code/modules/sound/sound_emitter.dm
+++ b/code/modules/sound/sound_emitter.dm
@@ -78,12 +78,7 @@
 
 	var/datum/sound_zone_manager/szm // not strictly necessary but its here for easy debugging in this early stage
 
-// for static things (e.g. machines that must be bolted to work) pass is_static = TRUE
-//  this causes the reserved channel to be taken from a shared pool, as static objects won't move close
-//  to eachother and won't contend. There is no overlap between the shared and unique pools, so no contention
-//  for example if someone carrying something noisy (mobile -> unique pool) walks close to something in the shared pool.
-// Dimensional Push is the exception to this (probably), the sound messing up is part of the !!! fun !!!
-/datum/sound_emitter/New(atom/A, var/is_static = FALSE)
+/datum/sound_emitter/New(atom/A)
 	..()
 	source = A
 	range = world.view

--- a/code/modules/sound/sound_emitter.dm
+++ b/code/modules/sound/sound_emitter.dm
@@ -96,6 +96,7 @@
 		sounds.Cut()
 		sounds = null
 	source.unregister_event(/event/moved, src, nameof(src::on_source_moved()))
+	INVOKE_EVENT(src, /event/destroyed, "emitter" = src)
 	. = ..()
 
 /*

--- a/code/modules/sound/sound_emitter.dm
+++ b/code/modules/sound/sound_emitter.dm
@@ -147,8 +147,6 @@
 
 	update_env_effect()
 
-	var/sound/S = active_sound.get()
-	S.status |= SOUND_UPDATE
 	INVOKE_EVENT(src, /event/sound_updated, "emitter" = src)
 
 /datum/sound_emitter/proc/stop()

--- a/code/modules/sound/sound_emitter.dm
+++ b/code/modules/sound/sound_emitter.dm
@@ -86,6 +86,7 @@
 	if (sound_zone_manager)
 		szm = sound_zone_manager
 	sound_zone_manager.register_emitter(src)
+	source.register_event(/event/moved, src, nameof(src::on_source_moved()))
 
 /datum/sound_emitter/Destroy()
 	sound_emitter_collection.remove(src)
@@ -94,6 +95,7 @@
 	if (sounds)
 		sounds.Cut()
 		sounds = null
+	source.unregister_event(/event/moved, src, nameof(src::on_source_moved()))
 	. = ..()
 
 /*

--- a/code/modules/sound/sound_listener_context/sound_listener_context.dm
+++ b/code/modules/sound/sound_listener_context/sound_listener_context.dm
@@ -130,12 +130,14 @@
 	E.register_event(/event/sound_started, src, nameof(src::start_hearing()))
 	E.register_event(/event/sound_stopped, src, nameof(src::stop_hearing()))
 	E.register_event(/event/sound_pushed, src, nameof(src::hear_once()))
+	E.register_event(/event/destroyed, src, nameof(src::on_emitter_destroyed()))
 
 /datum/sound_listener_context/proc/unsubscribe_from(datum/sound_emitter/E)
 	E.unregister_event(/event/sound_updated, src, nameof(src::on_sound_update()))
 	E.unregister_event(/event/sound_started, src, nameof(src::start_hearing()))
 	E.unregister_event(/event/sound_stopped, src, nameof(src::stop_hearing()))
 	E.unregister_event(/event/sound_pushed, src, nameof(src::hear_once()))
+	E.unregister_event(/event/destroyed, src, nameof(src::on_emitter_destroyed()))
 
 /datum/sound_listener_context/proc/start_hearing(datum/sound_emitter/emitter)
 	if (!emitter.is_currently_playing())
@@ -173,6 +175,10 @@
 	S.channel = chan
 	apply_proxymob_effects(S)
 	client << S
+
+/datum/sound_listener_context/proc/on_emitter_destroyed(datum/sound_emitter/emitter)
+	// /event/sound_stopped is invoked by sound_emitter/Destroy, here just cleans up the local reference
+	audible_emitters -= emitter
 
 /datum/sound_listener_context/proc/on_enter_range(datum/sound_emitter/E)
 	start_hearing(E) // this can throw if channel reservation fails, subscribe after its safe


### PR DESCRIPTION
## What this does

Among other things, another attempt at #38074 
After the last attempt at fixing this bug #38480 , I didn't get any more reports about the sound getting stuck until today.
I still haven't been successful in reproducing it on local. It seems to be the case that somehow the sound gets stuck on the client and plays everywhere constantly - this shouldn't be possible given how Byond *should* only play if the `sound.atom` var is set to a visible atom, but here we are. I wasn't able to find a smoking gun and ideally would see it happen in a live round for immediate investigation

I went over the whole system and found a few minor issues:
- Removed some unused code vestiges from V1 and stuff I never ended up using in V2
- Removed the `spawn` in the subsystem call to update emitters environment vars for emitters at least one person can hear. This was originally spawned because the update was heavier when it forced some atmos calcs, but those are now passive and the operation is just light reads. There was a "bug" in here in that `done[E]` was set to TRUE inside the spawn, meaning the same emitter could have its sound params updated multiple times in one go unnecessarily if there were many clients in its vicinity. Now the spawn is gone there are significantly fewer unnecessary updates.
- A stale reference would be orphaned inside `sound_listener_context.audible_emitters` when a `sound_emitter` was destroyed in vicinity of a client. Now the `sound_emitter` invokes `/event/destroyed` which is handled by the `sound_listener_context` and removes its ref from `audible_emitters`. `/event/sound_stopped` is raised separately by the destructor already.
  - This is the change most likely to clear the stuck sound. The ref being held by `sound_listener_context` kept the `sound_emitter` datum alive despite the atom it was on being destroyed, so it stayed in `current_channels_by_emitter` and the subsystem drove updates to it
- Newly created emitters would never register `/event/moved` for updating the `sound_zone_manager`'s table, so any newly created `sound_emitter` that could move would sound-wise be stranded in the cell it was created in. Now it registers the event in `New` and deregisters it in `Destroy` 

Plus a drive-by bugfix free of charge:
- When a cryo tube lost equipment power it wouldn't update its sprite nor change sound state. It now correctly updates its appearance when this happens

## Why it's good
Tightens up the code a bit, reducing places for bugs to hide, maybe it handles that above linked issue if we're lucky. I really need to catch it live in a round though

## How it was tested
Verified `audible_emitters` no longer contains stale ref after qdeling something with a `sound_emitter` on it

## Changelog
:cl:
 * bugfix: Cryo tubes now update their appearance correctly when equipment power drops