### PR TITLE
Makes supply shuttle ordering atom checks consistent with sending

### DIFF
--- a/code/controllers/subsystem/supply_shuttle.dm
+++ b/code/controllers/subsystem/supply_shuttle.dm
@@ -317,8 +317,8 @@ var/datum/subsystem/supply_shuttle/SSsupply_shuttle
 		if(T.density)
 			continue
 		var/contcount
-		for(var/atom/A in T.contents)
-			if(islightingoverlay(A) || istype(A, /obj/machinery/conveyor))
+		for(var/atom/movable/MA in T.contents)
+			if(MA.anchored && !ismecha(MA))
 				continue
 			contcount++
 		if(contcount)


### PR DESCRIPTION
[bugfix][consistency]

## What this does
changes the atom checks in buy() to the ones in sell()
Closes #38748.
Closes #37352.

## How it was tested
putting a conveyor and snow on the shuttle, sending it back, ordering a toner crate, calling it in again.

## Changelog
:cl:
 * bugfix: Snow on cargo shuttles no longer blocks space for crates to be ordered.
