### PR TITLE
bump spacemandmm to 1.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         #TODO: Cache Dreamchecker install
       - name: Run dreamchecker
         run: |
-          SPACEMAN_DMM_GIT_TAG="suite-1.10" tools/travis/install_spaceman_dmm.sh dreamchecker
+          SPACEMAN_DMM_GIT_TAG="suite-1.11" tools/travis/install_spaceman_dmm.sh dreamchecker
           ~/dreamchecker 2>&1 | bash tools/ci/annotate_dm.sh
 
       - name: Run map checker


### PR DESCRIPTION
## What this does

Bump SpacemanDMM Suite to v 1.11

https://github.com/SpaceManiac/SpacemanDMM/releases/tag/suite-1.11

## Why it's good

Ours is out of date using v 1.10

## How it was tested
The CI ran on github

## Changelog
No user-facing change