### PR TITLE
[dnm] Year of Transparency: Public Player Notes™*

### DIFF
--- a/code/game/verbs/notes.dm
+++ b/code/game/verbs/notes.dm
@@ -1,0 +1,6 @@
+/client/verb/viewadminnotes()
+	set name = "View Admin Notes"
+	set desc = "View public admin notes and bans for your ckey."
+	set category = "OOC"
+
+	show_player_info(usr)


### PR DESCRIPTION
## What this does
This PR will do the following, when completed:
- [ ] All existing player notes will be set to "hidden". Admins, as they go through a player's notes, may choose to unhide these as they see fit. This should ensure that no private information becomes public, and other such concerns with a public notes system.
- [ ] All notes under the new system will, by default, be public. Admins will have an option to set a note to "hidden" so that a player will not be aware of the note. The purpose of this is metacomms notes, sensitive/serious topics, etc. etc. 
- [ ] A player can view their own notes with a verb that will be found in the OOC tab. They cannot view hidden notes, and they cannot view the notes of other people.
- [ ] Notes created as visible may be set to hidden, and hidden notes may be set to visible with the click of a button.
- [ ] Maybe a "un-hide all legacy notes" button to reveal all notes on a player's account, for ease's sake, with multiple "Are You Sure?" warnings for the wily admin that enjoys clicking before thinking.
- [ ] I don't remember if they already do this or not, so I will also ensure that bans automatically create notes.
- [ ] This will need to work on web panel bans as well, which may or may not suck to implement. I will see!
- [ ] JESTER's PRIVILEGE: Per Luzzgawr's request, players will have the ability to write a brief, one-sentence "note" to their own notes. These player notes do nothing and will be in subscript to emphasize that they do not matter.

## Why it's good
Players and admins, presently, operate on two separate amounts of information. The admin has a lot more information on a player, able to see their ban history, infraction history, etc. at the click of a button, while a player has no access to any such information - even though it concerns them directly.

I feel that a public notes system will help both parties be on the same page, and help players understand why their ban length or severity is what it is - without having to bug admins for their notes or make a ban appeal. In other words, it'll improve transparency and help players understand under what context(s) they are being evaluated. 

## How it was tested
This is a draft PR, but I will test all buttons locally when they're all implemented.
I intend to implement all of this without needing use of SQL, but if it comes down to that, I will setup a DB for my test server and see that it's fine.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Admin notes, going forward, are mostly public. Notes from before this system's implementation remain hidden and can be unhidden at an admin's discretion. You may view your public notes with the verb View-Admin-Notes, found in the OOC tab.
 * rscadd: Players can choose to add one short, one-sentence comments on their own notes, should they so choose. These player comments are useless and do not do anything.