### PR TITLE
Fix IJzerkoekje runtimes

### DIFF
--- a/code/game/machinery/bots/draculabot.dm
+++ b/code/game/machinery/bots/draculabot.dm
@@ -19,13 +19,6 @@
 	var/currently_drawing_blood = 0 //One patient at a time.
 	var/quiet = 0
 	var/since_last_reward = 0 //Once every 55u, dispense reward
-	var/list/possible_rewards = list(/obj/item/weapon/reagent_containers/food/snacks/ijzerkoekje,
-								/obj/item/weapon/reagent_containers/food/snacks/ijzerkoekje,
-								/obj/item/weapon/reagent_containers/food/snacks/ijzerkoekje,
-								/obj/item/weapon/reagent_containers/food/snacks/chococoin/wrapped,
-								/obj/item/weapon/reagent_containers/food/snacks/chococoin/wrapped,
-								/obj/item/weapon/reagent_containers/food/snacks/chococoin/wrapped,
-								/obj/item/weapon/reagent_containers/food/snacks/ijzerkoekje_helper_dummy) //3/7 chance for one cookie, 3/7 chance for chococoin, 1/7 for many cookies!
 	var/list/contained_bags = list()
 	var/obj/item/weapon/reagent_containers/blood/last_bag
 
@@ -275,8 +268,14 @@
 
 /obj/machinery/bot/bloodbot/proc/dispense_reward()
 	speak(pick("Enjoy!","Come again!","Donate often!"))
-	var/path = pick(possible_rewards)
-	new path(get_turf(src))
+	var/roll = rand(1,7)
+	if (roll <= 3) // 3/7 chance for single cookie
+		new /obj/item/weapon/reagent_containers/food/snacks/ijzerkoekje(get_turf(src))
+	else if (roll <= 6) // 3/7 chance for chococoin
+		new /obj/item/weapon/reagent_containers/food/snacks/chococoin(get_turf(src))
+	else // 1/7 chance for a stack of ijzerkoekje
+		for (var/i = 1 to 6)
+			new /obj/item/weapon/reagent_containers/food/snacks/ijzerkoekje(get_turf(src))
 
 /obj/machinery/bot/bloodbot/proc/speak(var/message)
 	if(!src.on || !message)

--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -2847,7 +2847,7 @@
 
 /datum/recipe/ijzerkoekje
 	reagents = list(FLOUR = 30, IRON = 30)
-	result = /obj/item/weapon/reagent_containers/food/snacks/ijzerkoekje_helper_dummy
+	result = /obj/item/weapon/reagent_containers/food/snacks/ijzerkoekje
 
 /datum/recipe/ijzerkoekje/make_food(obj/container, mob/user)
 	// fixing a buggy old hack, dont ask any questions

--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -2849,14 +2849,11 @@
 	reagents = list(FLOUR = 30, IRON = 30)
 	result = /obj/item/weapon/reagent_containers/food/snacks/ijzerkoekje_helper_dummy
 
-/obj/item/weapon/reagent_containers/food/snacks/ijzerkoekje_helper_dummy
-	name = "Helper Dummy"
-	desc = "You should never see this text."
-
-/obj/item/weapon/reagent_containers/food/snacks/ijzerkoekje_helper_dummy/New()
-	for(var/i = 1 to 6)
-		new /obj/item/weapon/reagent_containers/food/snacks/ijzerkoekje(get_turf(src))
-	qdel(src)
+/datum/recipe/ijzerkoekje/make_food(obj/container, mob/user)
+	// fixing a buggy old hack, dont ask any questions
+	for (var/i = 1 to 5)
+		new result(get_turf(container))
+	return ..()
 
 /datum/recipe/pimiento
 	items = list(

--- a/code/modules/unit_tests/icons.dm
+++ b/code/modules/unit_tests/icons.dm
@@ -11,7 +11,6 @@
     types -= typesof(/obj/item/weapon/reagent_containers/food/snacks/customizable)
     types -= /obj/item/weapon/reagent_containers/food/snacks/sliceable
     types -= /obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza
-    types -= /obj/item/weapon/reagent_containers/food/snacks/ijzerkoekje_helper_dummy // idk what the fuck is this, but it's not broken
     types -= /obj/item/weapon/reagent_containers/food/snacks/snackbar/nutriment
     types -= /obj/item/weapon/reagent_containers/food/snacks/sushi
     types -= /obj/item/weapon/reagent_containers/food/snacks/meat/animal/grue //because of meat recoloring


### PR DESCRIPTION
## What this does

Fixes THREE runtimes:

[21:22:25] Runtime in code/modules/ZAS/Fire.dm,212: Cannot read null.heating_value
  proc name: burnSolidFuel (/atom/proc/burnSolidFuel)
  src: Helper Dummy (/obj/item/weapon/reagent_containers/food/snacks/ijzerkoekje_helper_dummy)
  src.loc: the floor (264,257,1) (/turf/simulated/floor)
  call stack:
  Helper Dummy (/obj/item/weapon/reagent_containers/food/snacks/ijzerkoekje_helper_dummy): burnSolidFuel()
  /datum/gas_mixture (/datum/gas_mixture): zburn(the floor (264,257,1) (/turf/simulated/floor), 1)
  the effect (/obj/effect/fire): process()
  Air (/datum/subsystem/air): process part(4)
  Air (/datum/subsystem/air): fire(1)
  Air (/datum/subsystem/air): ignite(1)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()

[21:22:27] Runtime in code/modules/reagents/reagent_containers.dm,435: Cannot execute null.heating().
  proc name: fire act (/obj/item/weapon/reagent_containers/fire_act)
  src: Helper Dummy (/obj/item/weapon/reagent_containers/food/snacks/ijzerkoekje_helper_dummy)
  src.loc: the floor (264,257,1) (/turf/simulated/floor)
  call stack:
  Helper Dummy (/obj/item/weapon/reagent_containers/food/snacks/ijzerkoekje_helper_dummy): fire act(/datum/gas_mixture (/datum/gas_mixture), 1209.79, 507500)
  the effect (/obj/effect/fire): process()
  Air (/datum/subsystem/air): process part(4)
  Air (/datum/subsystem/air): fire(1)
  Air (/datum/subsystem/air): ignite(1)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()

[21:23:26] Runtime in code/__HELPERS/maths.dm,116: Division by zero
  proc name: lerp generic (/proc/lerp_generic)
  src: null
  call stack:
  lerp generic(389.087, 0, null, 0.1, 1)
  Helper Dummy (/obj/item/weapon/reagent_containers/food/snacks/ijzerkoekje_helper_dummy): checksmoke()
  Helper Dummy (/obj/item/weapon/reagent_containers/food/snacks/ijzerkoekje_helper_dummy): checkburn()
  Zone 5038 (/zone): checkzoneburn()
  Burnable (/datum/subsystem/burnable): fire(0)

(All of these were picked up by checking for those muted for 10 minutes due to volume)

These happen because when an IJzerkoekje is made by either the microwave or a Doctor Acula, it uses something called `/obj/item/weapon/reagent_container/food/snacks/ijzerkoekje_helper_dummy` that... spawns 6 IJzerkoekje before `qdel`ing itself.
That helper dummy doesn't call `..()` in `New` so it never sets some vars that the fire system expects to be set, notably `thermal_material` and `reagents`. If the microwave or Doctor Acula produce one of these in the middle of a raging fire, the dummy `/obj/item` can catch fire. However, because the vars aren't set, the fire is unable to destroy it because of the runtimes... so the dummy keeps trying to burn forever, never able to die

This PR removes the helper dummy, replacing the two places where its used with end-result-equivalent logic (bonus: ONE of the IJzerkoekje coming out of the microwave is hot now! Not the others though but this is still one more hot IJzerkoekje than before)

I debated two alternate fixes:
- Just adding `..()` to `New`
- Changing the helper dummy to an `/obj/effect`
but decided that the helper dummy existing at all was haram

Also apparently IJzerkoekje is the correct way to capitalise this word, fun fact at no extra cost

## Why it's good
runtimes bad

## How it was tested
Verified Ijzerkoekje are produced in the correct amounts in expected scenarios post-fix

## Changelog
No user-facing change