### PR TITLE
Fix another timer runtime + accidental bug

### DIFF
--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -68,8 +68,13 @@
 	return
 
 /obj/item/device/assembly/timer/proc/timesoundloop(decrement = clamp(SPEEDSUP_SECONDS-time,0,SPEEDSUP_SECONDS)*SPEEDSUP_SECONDS,freq = 1)
+	if (QDELETED(src))
+		// if the timer was destroyed by an explosion while counting down and we came here from a spawn()
+		return
 	if(!silent && timing && time > 0)
-		playsound(src,decrement >= 7 && speedsup == TICK_SPEEDUP ? 'sound/items/assemblytick1.ogg' : 'sound/items/assemblytick2.ogg',100,1,frequency = freq)
+		if (get_turf(src))
+			// in case timer is in nullspace when the spawn comes back
+			playsound(src,decrement >= 7 && speedsup == TICK_SPEEDUP ? 'sound/items/assemblytick1.ogg' : 'sound/items/assemblytick2.ogg',100,1,frequency = freq)
 		spawn(max(1,10 - decrement))
 			if(speedsup && time <= SPEEDSUP_SECONDS)
 				decrement++
@@ -81,7 +86,7 @@
 			timesoundloop(decrement,freq)
 
 /obj/item/device/assembly/timer/proc/countdown()
-	if (QDELETED(src) || QDELETED(holder))
+	if (QDELETED(src))
 		// if the timer was destroyed by an explosion while counting down and we came here from a spawn()
 		return
 	if(timing)


### PR DESCRIPTION
## What this does

1. Fixes a runtime that looks like this:

[21:27:07] Runtime in code/game/sound.dm,52: code/game/sound.dm:52:Assertion Failed: !isnull(turf_source)
  proc name: playsound (/proc/playsound)
  usr: Unknown () (/mob/living/carbon/human)
  usr.loc: (nullspace)
  src: null
  call stack:
  playsound(the timer (/obj/item/device/assembly/timer), 'sound/items/assemblytick2.ogg', 100, 1, null, null, 1, 0, 0, 1)
  the timer (/obj/item/device/assembly/timer): timesoundloop(0, 1)
  the timer (/obj/item/device/assembly/timer): timesoundloop(0, 1)

This happened because the proc that makes the timer beep has a `spawn` in it and if the timer is destroyed then the spawn comes back to something that isn't in a turf so playsound gets upset
Additionally adds a general QDELETED check similar to that on `countdown` to quit spawning if the timer is deleted
 
2. Fixes a bug introduced in #38708 - I neglected that timers could be run on their own separated from an assembly, the holder qdel check is unnecessary anyway and was preventing timers from ever counting down when not in an assembly (at least it stopped the runtimes tho)

## Why it's good
runtime bad

## How it was tested
Starting a timer and then deleting it

## Changelog
:cl:
 * bugfix: Timers running on their own (no assembly) can count down once again, after a week of holiday

