### PR TITLE
Stops Research Loss Admin Spam

### DIFF
--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -70,7 +70,10 @@
 		for(var/ID in files.known_tech)
 			var/datum/tech/T = files.known_tech[ID]
 			if(prob(1))
-				T.level = 0 // This never happens, so make it dramatic. T.level--
+				if(T.level <= 1) //He's dead, Jim!
+					continue
+				T.level = 1 // This never happens, so make it dramatic. T.level--
+				//Except it does happen and floods the logs!! Minimum level is 1, not 0
 				message_admins("[src] lost [T.id] tech levels due to heat damage.")
 				for(var/obj/machinery/computer/rdservercontrol/SC in machines)
 					SC.screen = -1 //Display an alert

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -73,7 +73,7 @@
 				if(T.level <= 1) //He's dead, Jim!
 					continue
 				T.level = 1 // This never happens, so make it dramatic. T.level--
-				//Except it does happen and floods the logs!! Minimum level is 1, not 0
+				//Except it does happen and floods the admins!! Minimum level is 1, not 0
 				message_admins("[src] lost [T.id] tech levels due to heat damage.")
 				for(var/obj/machinery/computer/rdservercontrol/SC in machines)
 					SC.screen = -1 //Display an alert


### PR DESCRIPTION


## What this does
This PR makes it so that heat damage will not reset tech levels on research that is already at the minimum level. This avoids flooding the admins with heat damage messages if the cooling gives out (usually due to power loss during deadpop).

## Why it's good
Less spam during deadpop when trying to do other things.

## How it was tested
<img width="950" height="954" alt="image" src="https://github.com/user-attachments/assets/515fa4d6-d2dc-4690-8206-9dc1efcdc40b" />

Lighting a plasma fire and seeing what tech levels got reset and how.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Admins will not get as spammed when research servers lose tech levels due to heat damage.
