### PR TITLE
Table door improvements and consistency

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -113,7 +113,7 @@
 /obj/machinery/optable/process()
 	check_victim()
 
-/obj/machinery/optable/proc/TryToThrowOnTable(var/mob/user,var/mob/victim)
+/obj/machinery/optable/TryToThrowOnTable(var/mob/user,var/mob/victim)
 	for (var/atom/A in loc)
 		if (A == src || A == victim || A == user)
 			continue

--- a/code/game/machinery/doors/table.dm
+++ b/code/game/machinery/doors/table.dm
@@ -37,6 +37,7 @@
 		set_up_access()
 		electronics = new /obj/item/weapon/circuitboard/airlock(src)
 		electronics.installed = TRUE
+		machine_flags = SCREWTOGGLE | EMAGGABLE | WIREJACK
 		if(req_access?.len)
 			electronics.conf_access = req_access
 		else if(req_one_access?.len)
@@ -168,6 +169,7 @@
 		electronics = null
 	req_access = list()
 	req_one_access = list()
+	machine_flags = SCREWTOGGLE
 
 /obj/machinery/door/table/proc/dismantle()
 	remove_electronics()
@@ -245,6 +247,7 @@
 					else
 						req_access = electronics.conf_access
 				electronics.installed = TRUE
+				machine_flags = SCREWTOGGLE | EMAGGABLE | WIREJACK
 				playsound(loc, 'sound/items/Deconstruct.ogg', 50, 1)
 				to_chat(user, "<span class='notice'>You add [electronics] to [src].</span>")
 			return

--- a/code/game/machinery/doors/table.dm
+++ b/code/game/machinery/doors/table.dm
@@ -262,10 +262,6 @@
 				remove_electronics()
 			return
 
-	if(!allowed(user))
-		denied()
-		return
-
 	. = ..()
 
 /obj/machinery/door/table/emag_act(var/mob/user)

--- a/code/game/machinery/doors/table.dm
+++ b/code/game/machinery/doors/table.dm
@@ -177,12 +177,25 @@
 
 /obj/machinery/door/table/open()
 	playsound(src, soundeffect, 100, 1)
+	state_animate()
 	return ..()
 
 /obj/machinery/door/table/close()
 	playsound(src, soundeffect, 100, 1)
+	state_animate()
 	. = ..()
 	set_opacity(0) //always seethru
+
+/obj/machinery/door/table/proc/state_animate()
+	if(dir & (EAST|WEST))
+		pixel_x -= 2
+	else
+		pixel_y -= 2
+	spawn(2)
+		if(dir & (EAST|WEST))
+			pixel_x += 2
+		else
+			pixel_y += 2
 
 /obj/machinery/door/table/attackby(obj/item/W, mob/user, params)
 	if (density && istype(W, /obj/item/weapon/grab) && get_dist(src,user)<2)

--- a/code/game/machinery/doors/table.dm
+++ b/code/game/machinery/doors/table.dm
@@ -11,7 +11,7 @@
 	closed_layer = TABLE_LAYER
 	throwpass = 1	//You can throw objects over this, despite its density.
 	use_power = MACHINE_POWER_USE_NONE
-	machine_flags = SCREWTOGGLE
+	machine_flags = SCREWTOGGLE | EMAGGABLE | WIREJACK
 	icon = 'icons/obj/doors/tabledoor.dmi'
 	icon_state = "metaldoor_closed"
 	prefix = "metal" //Corresponds to the mineral type
@@ -37,7 +37,6 @@
 		set_up_access()
 		electronics = new /obj/item/weapon/circuitboard/airlock(src)
 		electronics.installed = TRUE
-		machine_flags = SCREWTOGGLE | EMAGGABLE | WIREJACK
 		if(req_access?.len)
 			electronics.conf_access = req_access
 		else if(req_one_access?.len)
@@ -169,7 +168,6 @@
 		electronics = null
 	req_access = list()
 	req_one_access = list()
-	machine_flags = SCREWTOGGLE
 
 /obj/machinery/door/table/proc/dismantle()
 	remove_electronics()
@@ -247,7 +245,7 @@
 					else
 						req_access = electronics.conf_access
 				electronics.installed = TRUE
-				machine_flags = SCREWTOGGLE | EMAGGABLE | WIREJACK
+				emagged = FALSE
 				playsound(loc, 'sound/items/Deconstruct.ogg', 50, 1)
 				to_chat(user, "<span class='notice'>You add [electronics] to [src].</span>")
 			return
@@ -288,7 +286,7 @@
 	return TRUE
 
 /obj/machinery/door/table/wirejack(var/mob/living/silicon/pai/P)
-	if(..())
+	if(electronics && !emagged && ..())
 		SwitchState()
 
 /obj/machinery/door/table/bullet_act(var/obj/item/projectile/Proj)

--- a/code/game/machinery/doors/table.dm
+++ b/code/game/machinery/doors/table.dm
@@ -21,6 +21,15 @@
 	sheet_type = /obj/item/stack/sheet/metal
 	sheet_amt = 2
 
+	hack_abilities = list(
+		/datum/malfhack_ability/toggle/disable,
+		/datum/malfhack_ability/oneuse/overload_quiet,
+		/datum/malfhack_ability/oneuse/emag
+	)
+
+/obj/machinery/door/table/hack_interact(mob/living/silicon/malf)
+	return electronics ? ..() : null
+
 /obj/machinery/door/table/New()
 	. = ..()
 	update_adjacent()
@@ -176,6 +185,33 @@
 	set_opacity(0) //always seethru
 
 /obj/machinery/door/table/attackby(obj/item/W, mob/user, params)
+	if (density && istype(W, /obj/item/weapon/grab) && get_dist(src,user)<2)
+		var/obj/item/weapon/grab/G = W
+		if (istype(G.affecting, /mob/living))
+			var/mob/living/M = G.affecting
+			if (G.state < GRAB_AGGRESSIVE)
+				if(user.a_intent == I_HURT)
+					if (!TryToThrowOnTable(user,M))
+						return
+					if (prob(15))
+						M.Knockdown(5)
+						M.Stun(5)
+					M.apply_damage(8,def_zone = LIMB_HEAD)
+					visible_message("<span class='warning'>[user] slams [M]'s face against \the [src]!</span>")
+					playsound(src, 'sound/weapons/tablehit1.ogg', 50, 1)
+					add_attacklogs(user, M, "harmfully tabled", admin_warn = FALSE)
+				else
+					to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
+					return
+			else
+				if (!TryToThrowOnTable(user,M))
+					return
+				M.Knockdown(5)
+				M.Stun(5)
+				visible_message("<span class='warning'>[user] puts [M] on \the [src].</span>")
+				add_attacklogs(user, M, "harmlessly tabled", admin_warn = FALSE)
+			qdel(W)
+			return
 
 	if (!electronics)
 		if(W.is_wrench(user))
@@ -222,13 +258,26 @@
 /obj/machinery/door/table/emag_act(var/mob/user)
 	if (!electronics || emagged)
 		return FALSE
-	electronics.icon_state = "door_electronics_smoked"
 	emagged = TRUE
 	req_access = list()
 	req_one_access = list()
-	spark(loc,2)
-	open()
+	hackOpen(user)
 	return TRUE
+
+/obj/machinery/door/table/npc_tamper_act(mob/living/L)
+	hackOpen(L)
+
+/obj/machinery/door/table/proc/hackOpen(mob/user)
+	if(electronics)
+		electronics.icon_state = "door_electronics_smoked"
+		spark(loc,2)
+	open()
+	add_fingerprint(user)
+	return TRUE
+
+/obj/machinery/door/table/wirejack(var/mob/living/silicon/pai/P)
+	if(..())
+		SwitchState()
 
 /obj/machinery/door/table/bullet_act(var/obj/item/projectile/Proj)
 	if(Proj.destroy)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -374,7 +374,7 @@
 		return
 	return ..()
 
-/obj/structure/table/proc/TryToThrowOnTable(var/mob/user,var/mob/victim)
+/obj/proc/TryToThrowOnTable(var/mob/user,var/mob/victim)
 	var/turf/oldloc = get_turf(victim)
 	for (var/atom/A in loc)
 		if (A == src || A == victim || A == user)


### PR DESCRIPTION
[consistency]

## What this does
Allows table doors to be malf hacked, if they have electronics in them.
Allows table doors to be NPC tampered.
Allows tabling people on closed table doors.
Allows wirejacking table doors.
Gives table doors a small "nudging" animation in their direction when opened or closed.
Closes #38713.

## Why it's good
Consistency, more visual for opening and closing.

## How it was tested
Opening and closing table doors, putting punpun on it via tabling, AI hacking the captain's table door, spawning a pAI mob and possessing it then purchasing wirejack and calling wirejack() on the table door with the pAI mob as the argument, emagging the table doors then taking out their electronics and emagging them again.

## Changelog
:cl:
 * tweak: Table doors can now be NPC tampered, wirejacked and AI hacked when electronics are installed.
 * tweak: People can now be tabled on table doors when closed.
 * tweak: Table doors are now a little more animated when opening and closing.
 * bugfix: Table doors can now be emagged without access.
 * bugfix: Installing working electronics to a table door now removes the emagged state of it.
