### PR TITLE
Fixed a 2 year old bug I caused where fireball dealt far less damage than it should have

### DIFF
--- a/code/modules/spells/targeted/projectile/fireball.dm
+++ b/code/modules/spells/targeted/projectile/fireball.dm
@@ -33,8 +33,16 @@
 	hud_state = "wiz_fireball"
 
 /spell/targeted/projectile/dumbfire/fireball/prox_cast(var/list/targets, spell_holder)
-	for(var/mob/living/M in targets)
-		apply_spell_damage(M)
+	var/mob/living/wizard = holder
+	for(var/mob/living/target in range(spell_holder, 1)) //Because cast_prox_range is 0 we have to override this because the targets list is empty.
+		//Copypasted some of the code from choose_prox_targets(), defined in code/modules/spells/targeted/projectile/projectile.dm
+		if(target == wizard)
+			continue
+		if(wizard in target.get_arcane_golems())
+			continue
+		if(wizard.shares_arcane_golem_spell(target))
+			continue
+		apply_spell_damage(target)
 	explosion(get_turf(spell_holder), ex_severe, ex_heavy, ex_light, ex_flash, whodunnit = holder)
 	return targets
 


### PR DESCRIPTION
Thanks to @braplord for reporting it!
Setting cast_prox_range to 0 in [this PR](https://github.com/vgstation-coders/vgstation13/pull/35071) broke target acquisition, which meant that the spell's own 45 brute damage and 40 burn damage weren't also applied, only the explosion's damage was applied. This made fireballs far weaker than normal, with damages as low as 24 per fireball.
This PR fixes it.

:cl:
 * bugfix: Fixed a 2 year old bug I accidentally caused where fireballs dealt far less damage than they should. They are now powerful again.