### PR TITLE
Fix borg name substitution bug

### DIFF
--- a/code/game/machinery/autoborger.dm
+++ b/code/game/machinery/autoborger.dm
@@ -104,12 +104,6 @@
 		// /vg/: Select from various name lists.
 		if(name_type == NAMETYPE_SILLY)
 			R.custom_name = pick(autoborg_silly_names)
-			R.custom_name = replacetext(R.custom_name, "{AINAME}", (!isnull(R.connected_ai) ? R.connected_ai.name : "AI"))
-			if(findtext(R.custom_name, "{###}"))
-				R.custom_name = replacetext(R.custom_name, "{###}", num2text(R.ident))
-			else
-				R.custom_name += "-[num2text(R.ident)]"
-
 
 		// /vg/: Allow AI to disable namepick.
 		R.namepick_uses=enable_namepick
@@ -222,6 +216,6 @@
 /obj/machinery/autoborger/mommi
 	name = "Autimatic Crab Factory 5000"
 	desc = "A large metallic machine with an entrance and an exit. A sign on the side reads 'human goes in, silent crab comes out'. Human must be lying down and alive. Has to cooldown between each use."
-	
+
 /obj/machinery/autoborger/mommi/do_transform(var/mob/living/carbon/human/H, var/deleteItems=FALSE, var/skipnaming=FALSE, var/malfAI=null)
 	return H.MoMMIfy(deleteItems,skipnaming,malfAI)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -305,6 +305,8 @@
 
 	var/changed_name = ""
 	if(custom_name)
+		custom_name = replacetext(custom_name, "{AINAME}", (connected_ai ? connected_ai.name : "AI"))
+		custom_name = replacetext(custom_name, "{###}", num2text(ident))
 		changed_name = custom_name
 	else
 		changed_name = "[modtype] [braintype]-[num2text(ident)]"


### PR DESCRIPTION
## What this does

Fixes #34483 . 
When getting borged in an autoborger or via a malfhacked recharging station, one of the names you can be assigned is `{AINAME} Minion {###}` (from `config/names/autoborg_silly.txt`).
While the autoborger contains code that replaces these markers with correct values, the malfhacked recharge station does not. This PR moves the substitution code into `update_name` so any borg can use the tokens `{AINAME}` for whatever their controlling AI is called and `{###}` for their assigned 3-digit `ident` value.
As a side effect of this change the autoborger no longer forces the 3-digit `ident` to the end of names.

## Why it's good
Fixes bugge and allows borgs to use substitution markers in their chosen names

## How it was tested
Put myself through an autoborger and verified name
Set my name to stuff like `{AINAME} fuck {###}` via `Namepick` and verified tokens were correctly substituted

## Changelog
:cl:
 * rscadd: Borgs may use the markers {AINAME} and {###} in their names for substitution to their controlling AI name (or "AI" if one doesnt exist) and 3-digit ident code respectively.
 * bugfix: People who got borged by machines like autoborger and malf recharge station will no longer be called literal {AINAME} Minion {###} 
