### PR TITLE
Fix radstorm and other area overlays not updating properly

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -17,6 +17,7 @@ var/area/space_area
 	var/base_turf_type = null
 	var/shuttle_can_crush = TRUE
 	var/project_shadows = FALSE
+	var/obj/effect/area_alert_holder/alert_holder = null
 	var/obj/effect/narration/narrator = null
 	var/holomap_draw_override = HOLOMAP_DRAW_NORMAL
 
@@ -48,6 +49,8 @@ var/area/space_area
 		power_equip = 1
 		power_environ = 1
 
+	alert_holder = new(src)
+
 	..()
 
 //	spawn(15)
@@ -61,6 +64,9 @@ var/area/space_area
 /area/Destroy()
 	..()
 	areaapc = null
+	if (alert_holder)
+		QDEL_NULL(alert_holder)
+
 
 /*
  * Added to fix mech fabs 05/2013 ~Sayu.
@@ -346,36 +352,8 @@ var/area/space_area
 		return ambience_list
 
 /area/proc/updateicon()
-	if (!areaapc)
-		icon_state = null
-		luminosity = 0
-		return
-	if ((fire || eject || party || radalert) && ((!requires_power)?(!requires_power):power_environ))//If it doesn't require power, can still activate this proc.
-		luminosity = 1
-		// Highest priority at the top.
-		if(radalert && !fire)
-			icon_state = "radiation"
-		else if(fire && !radalert && !eject && !party)
-			icon_state = "blue"
-		/*else if(atmosalm && !fire && !eject && !party)
-			icon_state = "bluenew"*/
-		else if(!fire && eject && !party)
-			icon_state = "red"
-		else if(party && !fire && !eject)
-			icon_state = "party"
-		else
-			icon_state = "blue-red"
-	else
-	//	new lighting behaviour with obj lights
-		icon_state = null
-		luminosity = 0
-
-
-/*
-#define EQUIP 1
-#define LIGHT 2
-#define ENVIRON 3
-*/
+	if (alert_holder)
+		alert_holder.update()
 
 /area/proc/powered(var/chan)		// return true if the area has power to given channel
 

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -1203,7 +1203,6 @@ steam.start() -- spawns the effect
 	mouse_opacity = 0
 	icon = 'icons/turf/areas.dmi'
 	var/area/parent_area = null
-	var/active = FALSE // if in parent_area.area_turfs' vis_contents or not
 
 /obj/effect/area_alert_holder/New(area/A)
 	..()
@@ -1235,29 +1234,8 @@ steam.start() -- spawns the effect
 	icon_state = new_state
 	luminosity = new_luminosity
 
-	if (new_state && !active)
-		add_to_turfs()
-	else if (!new_state && active)
-		remove_from_turfs()
-
-/obj/effect/area_alert_holder/proc/add_to_turfs()
-	if (!parent_area)
-		return
-	active = TRUE
-	for (var/turf/T in parent_area.area_turfs)
-		T.vis_contents |= src
-
-/obj/effect/area_alert_holder/proc/remove_from_turfs()
-	if (!parent_area)
-		return
-	active = FALSE
-	for (var/turf/T in parent_area.area_turfs)
-		T.vis_contents -= src
-
 /obj/effect/area_alert_holder/proc/add_turf(turf/T)
-	if (active)
-		T.vis_contents |= src
+	T.vis_contents |= src
 
 /obj/effect/area_alert_holder/proc/remove_turf(turf/T)
-	if (active)
-		T.vis_contents -= src
+    T.vis_contents -= src

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -1191,3 +1191,73 @@ steam.start() -- spawns the effect
 	. = ..()
 	if(corner)
 		overlays += image(icon, icon_state = overlay_state)
+
+// For area-wide effects like radstorm flashing and stuff
+/obj/effect/area_alert_holder
+	name = "area alert holder"
+	desc = "you shouldn't see this"
+	density = 0
+	anchored = 1
+	plane = LIGHTING_PLANE
+	layer = MAPPING_AREA_LAYER // from areas.dm
+	mouse_opacity = 0
+	icon = 'icons/turf/areas.dmi'
+	var/area/parent_area = null
+	var/active = FALSE // if in parent_area.area_turfs' vis_contents or not
+
+/obj/effect/area_alert_holder/New(area/A)
+	..()
+	parent_area = A
+
+/obj/effect/area_alert_holder/proc/update()
+	if (!parent_area)
+		return
+
+	var/new_state = null
+	var/new_luminosity = 0
+
+	if (parent_area.areaapc)
+		var/has_power = (!parent_area.requires_power || parent_area.power_environ)
+		if ((parent_area.fire || parent_area.eject || parent_area.party || parent_area.radalert) && has_power)
+			new_luminosity = 1
+			// priority follows original updateicon impl
+			if (parent_area.radalert && !parent_area.fire)
+				new_state = "radiation"
+			else if (parent_area.fire && !parent_area.radalert && !parent_area.eject && !parent_area.party)
+				new_state = "blue"
+			else if (!parent_area.fire && parent_area.eject && !parent_area.party)
+				new_state = "red"
+			else if(parent_area.party && !parent_area.fire && !parent_area.eject)
+				new_state = "party"
+			else
+				new_state = "blue-red"
+
+	icon_state = new_state
+	luminosity = new_luminosity
+
+	if (new_state && !active)
+		add_to_turfs()
+	else if (!new_state && active)
+		remove_from_turfs()
+
+/obj/effect/area_alert_holder/proc/add_to_turfs()
+	if (!parent_area)
+		return
+	active = TRUE
+	for (var/turf/T in parent_area.area_turfs)
+		T.vis_contents |= src
+
+/obj/effect/area_alert_holder/proc/remove_from_turfs()
+	if (!parent_area)
+		return
+	active = FALSE
+	for (var/turf/T in parent_area.area_turfs)
+		T.vis_contents -= src
+
+/obj/effect/area_alert_holder/proc/add_turf(turf/T)
+	if (active)
+		T.vis_contents |= src
+
+/obj/effect/area_alert_holder/proc/remove_turf(turf/T)
+	if (active)
+		T.vis_contents -= src

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -128,6 +128,8 @@
 	if(loc)
 		var/area/A = loc
 		A.area_turfs += src
+		if (A.alert_holder)
+			A.alert_holder.add_turf(src)
 	for(var/atom/movable/AM in src)
 		src.Entered(AM)
 		if(istype(AM, /obj/effect/edge_overlay))

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -78,6 +78,10 @@
 
 		else
 			lighting_clear_overlay()
+	if (old_area.alert_holder)
+		old_area.alert_holder.remove_turf(src)
+	if (new_area.alert_holder)
+		new_area.alert_holder.add_turf(src)
 
 /turf/proc/get_corners()
 	if (has_opaque_atom)


### PR DESCRIPTION
## What this does

radstorms and a couple of other effects were implemented by changing the `area.icon_state`. I remember this working fine a few years ago but for whatever reason at some point it changed such that changes to `area.icon_state` seem to not get immediately propagated to clients, rather it happens lazily and only changes when someone enters or leaves the area.
This PR moves the logic from `area.updateicon()` to a new holder that puts the effect into turf `vis_contents`. This is how the weather system does it and that seems to work fine

Byond changelogs show a few possibly relevant fixes regarding "area appearance" not updating properly (going back to 508 even) but clearly none of these actually addressed this particular issue. I'm pretty sure it started with a major version up but its easily been active for years by this point

Fixes #38769
Fixes #36258 
Fixes #35749
Fixes #34851 
Fixes #34289



## Why it's good
No more stupid areas not updating properly bug

## How it was tested
Pre-fix loaded local and fired a radstorm event. While walking around noted that a couple of rooms off the main hall continued flashing even after the radstorm was over.
Post-fix repeated above test but all overlays cleared as expected (repeated 5 times)

## Changelog
:cl:
 * bugfix: Areas now update properly when radstorms and such begin and end
