### PR TITLE
nerfs SCP-173

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/scp_173.dm
+++ b/code/modules/mob/living/simple_animal/hostile/scp_173.dm
@@ -1,4 +1,3 @@
-//scp_173
 //SCP-173, nothing more need be said
 /mob/living/simple_animal/scp_173
 	name = "SCP-173"
@@ -7,6 +6,8 @@
 	icon_state = "sculpture"
 	icon_living = "sculpture"
 	icon_dead = "sculpture"
+	health = 500
+	maxHealth = 500
 	emote_hear = list("makes a faint scraping sound")
 	emote_see = list("twitches slightly", "shivers")
 	response_help  = "touches the"
@@ -26,11 +27,12 @@
 	var/obj/machinery/atmospherics/unary/vent_pump/entry_vent //Graciously stolen from spider code
 	var/turf/target_turf
 
-	blooded = FALSE
+	var/scare_cooldown
+	var/scare_cooldown_time = 5 SECONDS
 
 /mob/living/simple_animal/scp_173/New()
 	. = ..()
-	flags |= INVULNERABLE
+	blooded = FALSE
 
 /mob/living/simple_animal/scp_173/Life()
 	if(timestopped)
@@ -69,6 +71,9 @@
 	else
 		handle_idle()
 
+/mob/living/simple_animal/scp_173/death(var/gibbed = FALSE)
+	if(!gibbed)
+		gib()
 
 //Check if any human mob can see SPC-173, including darkness exception
 /mob/living/simple_animal/scp_173/proc/check_los()
@@ -111,13 +116,16 @@
 
 /mob/living/simple_animal/scp_173/proc/handle_target(var/atom/target)
 
+	if(scare_cooldown > world.time)
+		return
+
 	if(!istype(target)) //Sanity
 		return
 
 	if(!check_los())
 		return
 
-	//Send the warning that SPC is homing in
+	//Send the warning that SCP is homing in
 	target_turf = get_turf(target)
 	if(!scare_played && ishuman(target)) //Let's minimize the spam
 		playsound(src, pick(scare_sound), 100, 1, -1)
@@ -162,9 +170,14 @@
 			num_turfs--
 		target_turf = null
 
+	scare_cooldown = world.time + scare_cooldown_time
+
 /mob/living/simple_animal/scp_173/proc/handle_idle()
 
 	if(!check_los())
+		return
+
+	if(scare_cooldown > world.time)
 		return
 
 	//If we're not strangling anyone, take a stroll
@@ -250,6 +263,8 @@
 		else
 			entry_vent = null
 
+	scare_cooldown = world.time + scare_cooldown_time
+
 //This performs an immediate neck snap check, meant to avoid people cheesing SCP-173 by just running faster than Life() refresh
 /mob/living/simple_animal/scp_173/proc/check_snap_neck()
 	//See if we're able to strangle anyone
@@ -283,11 +298,6 @@
 		log_admin("[target] ([target.ckey]) has had his neck snapped by an active [src].")
 		message_admins("ALERT: <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[target.x];Y=[target.y];Z=[target.z]'>[target.real_name]</a> has had his neck snapped by an active [src].")
 
-/mob/living/simple_animal/scp_173/attackby(var/obj/item/O as obj, var/mob/user as mob)
-	..()
-
-/mob/living/simple_animal/scp_173/Topic(href, href_list)
-	..()
 
 /mob/living/simple_animal/scp_173/to_bump(atom/movable/AM as mob)
 	if(!check_los())
@@ -297,9 +307,6 @@
 /mob/living/simple_animal/scp_173/Bumped(atom/movable/AM as mob, yes)
 	if(!check_los())
 		snap_neck(AM)
-
-//You cannot destroy SCP-173, fool!
-/mob/living/simple_animal/scp_173/ex_act(var/severity)
 
 // player control funstuffs below
 /mob/living/simple_animal/scp_173/movement_tally_multiplier()
@@ -314,8 +321,10 @@
 			handle_target(A)
 
 /mob/living/simple_animal/scp_173/Move(NewLoc, Dir, step_x, step_y, glide_size_override)
-	if(check_los() && !target_turf)
-		..()
+	if(mind || client || key || ckey) // AI movement already checks LoS
+		if(!check_los())
+			return
+	..()
 
 /mob/living/simple_animal/scp_173/verb/ventcrawl()
 	set name = "Crawl through Vent"

--- a/code/modules/mob/living/simple_animal/hostile/scp_173.dm
+++ b/code/modules/mob/living/simple_animal/hostile/scp_173.dm
@@ -29,10 +29,10 @@
 
 	var/scare_cooldown
 	var/scare_cooldown_time = 5 SECONDS
+	blooded = FALSE
 
 /mob/living/simple_animal/scp_173/New()
 	. = ..()
-	blooded = FALSE
 
 /mob/living/simple_animal/scp_173/Life()
 	if(timestopped)
@@ -125,6 +125,7 @@
 	if(!check_los())
 		return
 
+	canmove = 0
 	//Send the warning that SCP is homing in
 	target_turf = get_turf(target)
 	if(!scare_played && ishuman(target)) //Let's minimize the spam
@@ -169,6 +170,7 @@
 			next_turf = get_step(src, get_dir(next_turf,target))
 			num_turfs--
 		target_turf = null
+		canmove = 1
 
 	scare_cooldown = world.time + scare_cooldown_time
 
@@ -180,6 +182,7 @@
 	if(scare_cooldown > world.time)
 		return
 
+	scare_cooldown = world.time + scare_cooldown_time
 	//If we're not strangling anyone, take a stroll
 	if(prob(25)) //1 in 4 chance of checking out something new
 		var/list/turfs = new/list()
@@ -263,7 +266,6 @@
 		else
 			entry_vent = null
 
-	scare_cooldown = world.time + scare_cooldown_time
 
 //This performs an immediate neck snap check, meant to avoid people cheesing SCP-173 by just running faster than Life() refresh
 /mob/living/simple_animal/scp_173/proc/check_snap_neck()


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
What it says on the tin.

>But **how** does it nerf that, Mr.Heavenly?

- It is no longer invincible, boasting a 500 HP stat. Won't mean much once you get the chance to look at it, and it can be destroyed with explosions.
- Both forms of teleports now have a 5-second cooldown, affecting both its AI and player-controlled behaviors. Players controlling SCP-173 can still walk normally.
- Player-controlled SCP-173 cannot move during these actions.

Also fixes a minor bug that SCP-173 could not be pulled while in view of a player. May still occur when a player is possessing the mob.

Intended to introduce it into non-adminbus content such as #38776 

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
SCP-173 was always an interesting treat when spawned by admins, but it's still a bit excessive. It can move extremely quickly while controlled by a player, and forcemoves without any sanity would often lead to rubberbanding behavior. This PR fixes those issues without reducing its lethality too drastically.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Most tests consisted of the mob being spawned at Box Station arrivals, with a dummy human in view if my player was needed alive.

Cooldowns were stress-tested by writing say() commands into the cooldowns, while spawning a horizontal row of human dummies for it to attack.

Other times, I controlled it directly and started smashing windows, moving as quickly as possible throughout the station and gauging how much the cooldown affected it.


## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed the fact that SCP-173 could not be pushed or pulled.
 * tweak: SCP-173 invulnerability removed and cooldowns assigned
