### PR TITLE
Add sanity check to inflatable shelter exit

### DIFF
--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -447,6 +447,8 @@
 	..()
 
 /obj/structure/inflatable/shelter/container_resist(var/mob/user,var/turf/dest)
+	if (user.stat || !user.canmove)
+		return
 	if (user.loc != src)
 		exiting -= user
 		to_chat(user,"<span class='warning'>You cannot climb out of something you aren't even in!</span>")


### PR DESCRIPTION
## What this does

Adds sanity check to resisting out of shelters. For over two years corpses have been able to `Resist` out of inflatable shelters.
This adds a couple of generic checks for dead or unconscious as well as movement-impairing effects.

Fixes #34991
Fixes #34157

## Why it's good
Sanity

## How it was tested
Pre-fix confirmed bug by being able to `resist` out of an inflatable shelter while dead.
Post-fix confirmed unable to `resist` out while dead.

## Changelog
:cl:
 * bugfix: Dead, unconscious and otherwise movement-impaired people can no longer resist out of inflatable shelters
