### PR TITLE
Dead code removal (`defective`)

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -34,7 +34,6 @@ var/global/list/reagents_to_always_log = list(AMUTATIONTOXIN, CYANIDE, CHEFSPECI
 
 	plane = OBJ_PLANE
 
-	var/defective = 0
 	var/quality = B_AVERAGE //What level of quality this object is.
 	var/datum/material/material_type //What material this thing is made out of
 	var/sheet_type = /obj/item/stack/sheet/metal
@@ -810,11 +809,6 @@ a {
 			if(istype(U) && U.intact)
 				invisibility = old_invisibility
 				alpha = old_alpha
-
-/obj/proc/become_defective()
-	if(!defective)
-		defective = 1
-		desc += "\nIt doesn't look to be in the best shape."
 
 /obj/proc/clumsy_check(var/mob/living/user)
 	if(istype(user))

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -594,12 +594,6 @@
 			if(I)
 				I.stripped(wearer, stripper)
 
-/obj/item/clothing/become_defective()
-	if(!defective)
-		..()
-		for(var/A in armor)
-			armor[A] -= rand(armor[A]/3, armor[A])
-
 /obj/item/clothing/attack(var/mob/living/M, var/mob/living/user, def_zone, var/originator = null)
 	if (!(iscarbon(user) && user.a_intent == I_HELP && (clothing_flags & CANEXTINGUISH) && ishuman(M) && M.on_fire))
 		..()

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -199,30 +199,6 @@
 	species_fit = list(VOX_SHAPED, GREY_SHAPED, INSECT_SHAPED)
 	prescription_type = /obj/item/clothing/glasses/hud/security/sunglasses/prescription
 
-/obj/item/clothing/glasses/hud/security/sunglasses/become_defective()
-	if(!defective)
-		..()
-		if(prob(15))
-			new /obj/item/weapon/shard(loc)
-			playsound(src, "shatter", 50, 1)
-			qdel(src)
-			return
-		if(prob(15))
-			new/obj/item/clothing/glasses/sunglasses(get_turf(src))
-			playsound(src, 'sound/effects/glass_step.ogg', 50, 1)
-			qdel(src)
-			return
-		if(prob(55))
-			eyeprot = 0
-		if(prob(55))
-			if(istype(src.loc, /mob/living/carbon/human))
-				var/mob/living/carbon/human/M = src.loc
-				if(M.glasses == src)
-					for(var/datum/visioneffect/H in stored_huds)
-						M.remove_hud(H)
-			hud_types = null
-			stored_huds = null
-
 /obj/item/clothing/glasses/hud/security/sunglasses/syndishades
 	name = "sunglasses"
 	desc = "Strangely ancient technology used to help provide rudimentary eye cover. Enhanced shielding blocks many flashes."

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -332,16 +332,6 @@
 
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
 
-/obj/item/clothing/suit/armor/laserproof/become_defective()
-	if(!defective)
-		..()
-		if(prob(75))
-			basereflectchance -= rand(basereflectchance/3, basereflectchance)
-		if(prob(50))
-			slowdown++
-		if(prob(50))
-			slowdown++
-
 /obj/item/clothing/suit/armor/swat/officer
 	name = "officer jacket"
 	desc = "An armored jacket used in special operations."

--- a/code/modules/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/mecha/equipment/weapons/weapons.dm
@@ -15,21 +15,12 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/energy
 	name = "\improper General Energy Weapon"
 
-/obj/item/mecha_parts/mecha_equipment/weapon/energy/become_defective()
-	if(!defective)
-		..()
-		equip_cooldown = rand(equip_cooldown*1.5, equip_cooldown*2.5)
-		energy_drain = rand(energy_drain*3, energy_drain*5)
-
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/action(atom/target)
 	if(!action_checks(target))
 		return
 	var/originaltarget = target
 	var/turf/curloc = chassis.loc
 	var/atom/targloc = get_turf(target)
-	if(defective)
-		target = get_inaccuracy(originaltarget, 1, chassis)
-		targloc = get_turf(target)
 	if (!targloc || !istype(targloc, /turf) || !curloc)
 		return
 	if (targloc == curloc)
@@ -174,15 +165,6 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/alt_action()
 	rearm()
 
-/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/become_defective()
-	if(!defective)
-		..()
-		equip_cooldown = rand(equip_cooldown*2, equip_cooldown*3)
-		projectile_energy_cost = rand(projectile_energy_cost*1.5, projectile_energy_cost*3)
-		max_projectiles = rand(max_projectiles/4, max_projectiles*0.75)
-		if(max_projectiles < projectiles)
-			projectiles = max_projectiles
-
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/action_checks(atom/target)
 	if(..())
 		if(projectiles > 0)
@@ -237,9 +219,6 @@
 //	targloc = null
 	for(var/i=1 to min(projectiles, projectiles_per_shot))
 //		targloc = locate(target_x+GaussRandRound(deviation,1),target_y+GaussRandRound(deviation,1),target_z)
-		if(defective)
-			target = get_inaccuracy(originaltarget, 2, chassis)
-			targloc = get_turf(target)
 		if(!targloc || targloc == curloc)
 			break
 		playsound(chassis, fire_sound, 80, 1)
@@ -287,9 +266,6 @@
 			break
 		var/turf/curloc = get_turf(chassis)
 //		targloc = locate(target_x+GaussRandRound(deviation,1),target_y+GaussRandRound(deviation,1),target_z)
-		if(defective)
-			target = get_inaccuracy(originaltarget, 2, chassis)
-			targloc = get_turf(target)
 		if (!targloc || !curloc)
 			continue
 		if (targloc == curloc)
@@ -333,8 +309,6 @@
 	M.primed = 1
 	playsound(chassis, fire_sound, 50, 1)
 	var/originaltarget = target
-	if(defective)
-		target = get_inaccuracy(originaltarget, 2, chassis)
 	M.throw_at(target, missile_range, missile_speed)
 	projectiles--
 	log_message("Fired from [src.name], targeting [originaltarget].")
@@ -383,8 +357,6 @@
 	grenade = G
 	playsound(chassis, fire_sound, 50, 1)
 	var/originaltarget = target
-	if(defective)
-		target = get_inaccuracy(originaltarget, 3, chassis)
 	G.throw_at(target, missile_range, missile_speed)
 	projectiles--
 	log_message("Fired from [src.name], targeting [originaltarget].")
@@ -586,8 +558,6 @@
 	var/obj/item/weapon/legcuffs/bolas/mech/M = new projectile(chassis.loc)
 	playsound(chassis, fire_sound, 50, 1)
 	var/originaltarget = target
-	if(defective)
-		target = get_inaccuracy(originaltarget, 1, chassis)
 	M.throw_at(target, missile_range, missile_speed)
 	playsound(src,'sound/weapons/whip.ogg', 20, 1) //because mechs play the sound anyways
 	projectiles--

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -247,10 +247,6 @@
 	if (!istype(targloc) || !istype(curloc))
 		return
 
-	if(defective)
-		target = get_inaccuracy(originaltarget, 1+recoil)
-		targloc = get_turf(target)
-
 	if(!special_check(user))
 		return
 
@@ -267,9 +263,7 @@
 
 	if(!in_chamber)
 		return
-	if(defective)
-		if(!failure_check(user))
-			return
+
 	if(!istype(src, /obj/item/weapon/gun/energy/tag))
 		log_attack("[user.name] ([user.ckey]) fired \the [src] (proj:[in_chamber.name]) at [originaltarget] [ismob(target) ? "([originaltarget:ckey])" : ""] ([originaltarget.x],[originaltarget.y],[originaltarget.z])[struggle ? " due to being disarmed." :""]" )
 	in_chamber.firer = user
@@ -361,13 +355,6 @@
 	update_icon()
 
 	user.update_inv_hand(user.active_hand)
-
-	if(defective && recoil && prob(3))
-		var/throwturf = get_ranged_target_turf(user, pick(alldirs), 7)
-		user.drop_item()
-		user.visible_message("\The [src] jumps out of [user]'s hands!","\The [src] jumps out of your hands!")
-		throw_at(throwturf, rand(3, 6), 3)
-		return 1
 
 	return 1
 

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -624,11 +624,6 @@
 	cell_type = "/obj/item/weapon/cell"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/guns_experimental.dmi', "right_hand" = 'icons/mob/in-hand/right/guns_experimental.dmi')
 
-/obj/item/weapon/gun/energy/ricochet/Fire(atom/target, mob/living/user, params, reflex = 0, struggle = 0, var/use_shooter_turf = FALSE)
-	if(defective && prob(30))
-		target = get_ranged_target_turf(user, pick(diagonal), 7)
-	..()
-
 /obj/item/weapon/gun/energy/bison
 	name = "\improper Righteous Bison"
 	desc = "A replica of Lord Cockswain's very own personal ray gun."

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -44,21 +44,12 @@
 			return 1
 		var/shots_fired = 0 //haha, I'm so clever
 		var/to_shoot = min(burst_count, getAmmo())
-		if(defective && prob(20))
-			to_shoot = getAmmo()
 		for(var/i = 1 to to_shoot)
 			..()
 			burstfiring = 1
 			shots_fired++
 			if(!user.contents.Find(src) || jammed)
 				break
-			if(defective && shots_fired > burst_count)
-				recoil = 1 + min(shots_fired - burst_count, 6)
-			if(defective && prob(max(0, shots_fired - burst_count * 4)))
-				to_chat(user, "<span class='danger'>\The [src] explodes!.</span>")
-				explosion(get_turf(loc), -1, 0, 2)
-				user.drop_item(src, force_drop = 1)
-				qdel(src)
 		recoil = initial(recoil)
 		burstfiring = 0
 		return 1


### PR DESCRIPTION
## What this does

In October 2016, a very unpopular PR called #11753 was merged. It was very unpopular and made a lot of people sad. 300 things were said about it
The same day, a revert PR #12152 was raised and closed after 50 things were said about it. The PR removed basically everything from the original PR (even the not bad things, atomicity hadn't been invented back then) rather than just the offending parts and the author of the original defective system even convinced the guy to just leave a ton of dead code lying around (this is foreshadowing)
The next day, another revert #12157 was raised that was closed because the guy kept hitting conflicts and decided to just start again (lol)
Three days later he raised a PR #12162 which just disabled the `defective` code.

For 9 years this code has been dead, doing absolutely nothing. Its bad because:
- Every single /obj has `var/defective` and a proc declaration to become defective, but the thing is only really relevant for weapons (ignoring a couple of random edge cases)
- become_defective is never called any more thanks to the above revert. `defective` is always 0 and it is still always checked and quietly contributing to /obj bloat
- No one ever touched it or thought about it since
- Pomf didn't like it anyway

This PR cleans out the dead code

## Why it's good
Cleaner /obj, fewer spurious checks, tech debt maintenance

## How it was tested
Build success, tested a handful of guns and confirmed no runtimes or weird behaviour

## Changelog
No user-facing change