### PR TITLE
A fistful of runtime fixes

### DIFF
--- a/code/_onclick/mindUI/_mindUI.dm
+++ b/code/_onclick/mindUI/_mindUI.dm
@@ -292,7 +292,8 @@ var/list/mind_ui_ID2type = list()
 	invisibility = 101
 
 /obj/abstract/mind_ui_element/proc/GetUser()
-	ASSERT(parent && parent.mind && parent.mind.current)
+	if (!parent?.mind?.current)
+		return null
 	return parent.mind.current
 
 /obj/abstract/mind_ui_element/proc/UpdateUIScreenLoc()
@@ -342,6 +343,8 @@ var/list/mind_ui_ID2type = list()
 	var/image/ui_image = image(icon, src, icon_state, layer)
 	ui_image.overlays = overlays
 	var/mob/U = GetUser()
+	if (!U)
+		return
 	U.client.images |= ui_image
 	animate(ui_image, pixel_x = new_x - offset_x, pixel_y = new_y - offset_y,  time = duration)
 	spawn(duration)
@@ -442,17 +445,23 @@ var/list/mind_ui_ID2type = list()
 		movement = I
 
 	var/mob/M = GetUser()
+	if (!M)
+		return
 	M.client.mouse_pointer_icon = movement
 	moving = TRUE
 
 /obj/abstract/mind_ui_element/hoverable/movable/MouseUp(location, control, params)
 	var/mob/M = GetUser()
+	if (!M)
+		return
 	M.client.mouse_pointer_icon = initial(M.client.mouse_pointer_icon)
 	if (moving)
 		MoveLoc(params)
 
 /obj/abstract/mind_ui_element/hoverable/movable/MouseDrop(over_object, src_location, over_location, src_control, over_control, params)
 	var/mob/M = GetUser()
+	if (!M)
+		return
 	M.client.mouse_pointer_icon = initial(M.client.mouse_pointer_icon)
 	MoveLoc(params)
 

--- a/code/_onclick/mindUI/bloodcult/cultist.dm
+++ b/code/_onclick/mindUI/bloodcult/cultist.dm
@@ -306,6 +306,8 @@
 	if(!required_tattoo)
 		return TRUE
 	var/mob/living/M = GetUser()
+	if (!M)
+		return
 	if(M.checkTattoo(required_tattoo))
 		return iscarbon(M)
 	return FALSE
@@ -327,6 +329,8 @@
 
 /obj/abstract/mind_ui_element/hoverable/bloodcult_spell/pool/UpdateIcon(var/appear = FALSE)
 	var/mob/living/M = GetUser()
+	if (!M)
+		return
 	var/datum/role/cultist/C = iscultist(M)
 	icon_state = "power_pool[C.blood_pool ? "" : "_off"]"
 	base_icon_state = icon_state
@@ -340,6 +344,8 @@
 
 /obj/abstract/mind_ui_element/hoverable/bloodcult_spell/pool/Click()
 	var/mob/living/M = GetUser()
+	if (!M)
+		return
 	var/datum/role/cultist/C = iscultist(M)
 
 	C.blood_pool = !C.blood_pool
@@ -380,6 +386,8 @@
 
 /obj/abstract/mind_ui_element/hoverable/bloodcult_spell/talisman/Click()
 	var/mob/living/M = GetUser()
+	if (!M)
+		return
 
 	if(talisman)
 		talisman.trigger(M)
@@ -410,6 +418,8 @@
 /obj/abstract/mind_ui_element/hoverable/bloodcult_spell/dagger/Click()
 
 	var/mob/living/carbon/user = GetUser()
+	if (!user)
+		return
 
 	if(!dagger)  // dagger not pulled out
 
@@ -483,6 +493,8 @@
 
 /obj/abstract/mind_ui_element/hoverable/bloodcult_spell/sigil/Click()
 	var/mob/living/M = GetUser()
+	if (!M)
+		return
 
 	to_chat(M, "<span class='notice'>Click an adjacent wall to manifest a sigil on top of it.</span>")
 
@@ -1661,6 +1673,8 @@
 	..()
 	cult = find_active_faction_by_type(/datum/faction/bloodcult)
 	var/mob/M = GetUser()
+	if (!M)
+		return
 	cultist = iscultist(M)
 
 	//This horseshit magically lets have screen objects use animate(). Maybe I should make it a default mindUI feature at some point. -Deity
@@ -1678,7 +1692,7 @@
 	..()
 	//we constantly remove ourself from client.screen, as the holder we spawned in New() takes care of displaying us in our animate()'d glory
 	var/mob/M = GetUser()
-	if (!M.client)
+	if (!M?.client)
 		return
 	M.client.screen -= src
 
@@ -1854,7 +1868,7 @@
 	..()
 	//we constantly remove ourself from client.screen, as the holder we spawned in New() takes care of displaying us in our animate()'d glory
 	var/mob/M = GetUser()
-	if (!M.client)
+	if (!M?.client)
 		return
 	M.client.screen -= src
 

--- a/code/_onclick/mindUI/malf.dm
+++ b/code/_onclick/mindUI/malf.dm
@@ -42,6 +42,8 @@
 
 /obj/abstract/mind_ui_element/malf_power_gauge/UpdateIcon()
 	var/mob/living/silicon/ai/A = GetUser()
+	if (!A)
+		return
 	var/datum/role/malfAI/M = A.mind.GetRole(MALF)
 	if(!istype(A) || !istype(M))
 		return
@@ -57,7 +59,7 @@
 	gauge.transform = gauge_matrix
 	gauge.layer = MIND_UI_BUTTON
 	gauge.pixel_y = round(-79 + 100 * (M.processing_power/M.max_processing_power))
-	
+
 
 	overlays = 0
 	overlays += cover
@@ -74,6 +76,8 @@
 
 /obj/abstract/mind_ui_element/malf_power_count/UpdateIcon()
 	var/mob/living/silicon/ai/A = GetUser()
+	if (!A)
+		return
 	var/datum/role/malfAI/M = A.mind.GetRole(MALF)
 	if(!istype(M) || !istype(A))
 		return
@@ -104,15 +108,17 @@
 		/obj/abstract/mind_ui_element/hoverable/malf_win/nuke
 		)
 	display_with_parent = TRUE
-	
+
 
 /datum/mind_ui/malf_win_panel/Valid()
 	var/mob/living/silicon/ai/A = GetUser()
+	if (!A)
+		return
 	var/datum/role/malfAI/M = A.mind.GetRole(MALF)
 	if(!istype(M) || !istype(A))
-		return FALSE			
+		return FALSE
 	if(!M.takeover)
-		return FALSE			
+		return FALSE
 	return TRUE
 
 //------------------------------------------------------------
@@ -121,9 +127,11 @@
 	icon = 'icons/ui/malf/48x32.dmi'
 	icon_state = ""
 	layer = MIND_UI_FRONT+1
-	
+
 /obj/abstract/mind_ui_element/hoverable/malf_win/UpdateIcon()
 	var/mob/living/silicon/ai/A = GetUser()
+	if (!A)
+		return
 	var/datum/role/malfAI/M = A.mind.GetRole(MALF)
 	if(M.destroyed_station)
 		color = grayscale
@@ -139,6 +147,8 @@
 
 /obj/abstract/mind_ui_element/hoverable/malf_win/Click()
 	var/mob/living/silicon/ai/A = GetUser()
+	if (!A)
+		return
 	var/datum/role/malfAI/M = A.mind.GetRole(MALF)
 	if(!istype(M) || !istype(A))
 		return FALSE			// HAHA NOPE
@@ -148,7 +158,7 @@
 
 
 
-// The idea was to overload just about every machine on station but explosions are super slow 
+// The idea was to overload just about every machine on station but explosions are super slow
 // I'm leaving this as a comment in case anyone wants to optimize this
 
 /*
@@ -183,7 +193,7 @@
 			machine.shake_animation(4, 4, 0.2 SECONDS, 20)
 			spawn(4 SECONDS)
 				if(machine)
-					explosion(get_turf(machine), 1, 3, 5, 5) 
+					explosion(get_turf(machine), 1, 3, 5, 5)
 					qdel(machine)
 		CHECK_TICK
 
@@ -198,8 +208,10 @@
 	if(!..())
 		return
 	var/mob/living/silicon/ai/A = GetUser()
+	if (!A)
+		return
 	var/datum/role/malfAI/M = A.mind.GetRole(MALF)
-	
+
 	for(var/obj/machinery/nuclearbomb/N in nuclear_bombs)
 		if(N.z != map.zMainStation)
 			continue

--- a/code/datums/gamemode/factions/bloodcult/bloodrealm/fauna/bloodrealm_meatblob.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodrealm/fauna/bloodrealm_meatblob.dm
@@ -268,7 +268,7 @@
 		stuck_count = 0
 
 /datum/meat_blob/proc/set_target(var/turf/T)
-	if (!T || (T.z != blobZ))
+	if (!T || (T.z != blobZ) || !center_blob)
 		return
 	target_tile = T
 	target_dist = abs(abs(center_blob.x - T.x) + abs(center_blob.y - T.y))

--- a/code/datums/gamemode/factions/malf.dm
+++ b/code/datums/gamemode/factions/malf.dm
@@ -45,12 +45,13 @@
 				living_ais++
 			if(istype(R, /datum/role/malfAI))
 				M = R
-		if((!living_ais || !M) && stage<MALF_CHOOSING_NUKE)
-			command_alert(/datum/command_alert/malf_destroyed)
-			stage(FACTION_DEFEATED)
-			var/datum/gamemode/dynamic/dynamic_mode = ticker.mode
-			if (istype(dynamic_mode))
-				dynamic_mode.update_stillborn_rulesets()
+		if(!living_ais || !M)
+			if (stage < MALF_CHOOSING_NUKE)
+				command_alert(/datum/command_alert/malf_destroyed)
+				stage(FACTION_DEFEATED)
+				var/datum/gamemode/dynamic/dynamic_mode = ticker.mode
+				if (istype(dynamic_mode))
+					dynamic_mode.update_stillborn_rulesets()
 			return
 		if(M.apcs.len >= 3 && can_malf_ai_takeover())
 			AI_win_timeleft = max(0, AI_win_timeleft - ((M.apcs.len / 6) * SSticker.getLastTickerTimeDuration())) //Victory timer de-increments based on how many APCs are hacked.

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -153,7 +153,7 @@ var/list/wireColours = list("red", "blue", "green", "black", "orange", "brown", 
 				var/colour = href_list["attach"]
 				// Detach
 				if(IsAttached(colour))
-					if(I.arcanetampered)
+					if(I?.arcanetampered)
 						L.electrocute_act(30,holder)
 					else
 						var/obj/item/O = Detach(colour)


### PR DESCRIPTION
## What this does

Fixes the below runtimes (all were silenced for 10 mins on live):

```
[21:41:40] Runtime in code/_onclick/mindUI/_mindUI.dm,295: code/_onclick/mindUI/_mindUI.dm:295:Assertion Failed: parent && parent.mind && parent.mind.current
  proc name: GetUser (/obj/abstract/mind_ui_element/proc/GetUser)
  usr: Venya Karpoff (luzha) (/mob/dead/observer)
  usr.loc: The floor (127, 116, 1) (/turf/simulated/floor)
  src: Hide (/obj/abstract/mind_ui_element/hoverable/rune_word/rune_hide)
  src.loc: null
  call stack:
  Hide (/obj/abstract/mind_ui_element/hoverable/rune_word/rune_hide): GetUser()
  Hide (/obj/abstract/mind_ui_element/hoverable/rune_word/rune_hide): UpdateIcon(0)
  Hide (/obj/abstract/mind_ui_element/hoverable/rune_word/rune_hide): StopHovering()
  Hide (/obj/abstract/mind_ui_element/hoverable/rune_word/rune_hide): Hide()
  Hide (/obj/abstract/mind_ui_element/hoverable/rune_word/rune_hide): Hide()
```

- This assert was hit when a spawn came back to nulls - seems to be when the body is destroyed while hovering over runewords in the rune drawing interface. Looking at users of `GetUser` the vast majority of them already check the return for null, so the assert was replaced with a null return if it has nothing. Added missing null checks to all other `GetUser` callsites

```
[17:38:13] Runtime in code/datums/wires/wires.dm,156: Cannot read null.arcanetampered
  proc name: Topic (/datum/wires/Topic)
  usr: Khatkhat (eremite5) (/mob/living/carbon/human)
  usr.loc: The plating (168, 274, 1) (/turf/simulated/floor/plating)
  src: /datum/wires/airlock (/datum/wires/airlock)
  call stack:
  /datum/wires/airlock (/datum/wires/airlock): Topic("src=\[0x2100f013];action=1;att...", /list (/list))
  Eremite5 (/client): Topic("src=\[0x2100f013];action=1;att...", /list (/list), /datum/wires/airlock (/datum/wires/airlock))
```

- Happens when trying to detach an assembly from door wires with an empty hand. There is no null check for item `I` when it tries to check `arcanetampered`, surprisingly when you aren't holding an item then `I` is null so the above happens. The result is that you can't detach assemblies to an empty hand. Added null check

Fixes #33727

```
[21:44:34] Runtime in code/datums/gamemode/factions/bloodcult/bloodrealm/fauna/bloodrealm_meatblob.dm,274: Cannot read null.x
  proc name: set target (/datum/meat_blob/proc/set_target)
  src: /datum/meat_blob (/datum/meat_blob)
  call stack:
  /datum/meat_blob (/datum/meat_blob): set target(the heavy blizzard (266,9,1) (/turf/unsimulated/floor/snow/heavy_blizzard))
  /datum/meat_blob (/datum/meat_blob): custom process()
  /datum/meat_blob (/datum/meat_blob): custom process()
```

- Can happen when the meat blob is moving about. `center_blob` can be null so added null check

```
[23:57:23] Runtime in code/datums/gamemode/factions/malf.dm,55: Cannot read null.apcs
  proc name: process (/datum/faction/malf/process)
  src: Malfunctioning AI (/datum/faction/malf)
  call stack:
  Malfunctioning AI (/datum/faction/malf): process()
  Dynamic Mode (/datum/gamemode/dynamic): process()
  Dynamic Mode (/datum/gamemode/dynamic): process()
  /datum/controller/gameticker (/datum/controller/gameticker): process()
  Ticker (/datum/subsystem/ticker): fire(0)
  Ticker (/datum/subsystem/ticker): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
```

- Happens when a malf AI dies after it reaches the `MALF_CHOOSING_NUKE` stage. The guards are actually 99% already there but only check for null malf AI _before_ the `MALF_CHOOSING_NUKE` stage and its assumed that the malf AI won't be null at that stage. But today it was and a lot of runtimes were logged as a result

## Why it's good
runtime bad
detach assembly with empty hand good

## How it was tested
- malf : made myslef malf, set faction stage to 4 (MALF_CHOOSING_NUKE), deleted self -> runtimes
  - post-fix runtime no longer appeared
- wires : attached a timer to a door wire, tried to remove it with empty hand -> runtimes
  - post-fix was able to detach assembly to empty hand
- meatblob : couldn't figure out how to reproduce on local, tried deleting the meatblob's datum's `center_blob` but it just reassigned itself without making runtimes
- mindui: made myself cultist, opened the runewords interface, then stood near some expanding supermatter sea while hovering a runeword. when i was consumed it spewed the above runtime
  - post-fix just shaded with no runtimes

## Changelog
:cl:
 * bugfix: Assemblies can now be detached from door wires and vending machines and stuff using an empty hand
