### PR TITLE
Some fixes and tweaks to mecha unarmed punches

### DIFF
--- a/code/game/turfs/simulated/shuttle.dm
+++ b/code/game/turfs/simulated/shuttle.dm
@@ -44,7 +44,7 @@
 	return
 
 /turf/simulated/wall/shuttle/dismantle_wall(devastated, explode)
-	return
+	return 1
 
 /turf/simulated/wall/shuttle/attack_rotting(mob/user)
 	return

--- a/code/modules/mecha/combat/combat.dm
+++ b/code/modules/mecha/combat/combat.dm
@@ -26,6 +26,8 @@
 		target = safepick(oview(1,src))
 	if(!istype(target, /atom))
 		return
+	if(!Adjacent(target))
+		return
 	if(istype(target, /mob/living))
 		var/mob/living/M = target
 		if(src.occupant.a_intent == I_HURT)

--- a/code/modules/mecha/combat/combat.dm
+++ b/code/modules/mecha/combat/combat.dm
@@ -28,60 +28,21 @@
 		return
 	if(!Adjacent(target))
 		return
+	var/image/fist_icon = image(icon = 'icons/mob/screen_spells.dmi', icon_state = "wiz_fist") //wizard fist placeholder for robot fist
 	if(istype(target, /mob/living))
 		var/mob/living/M = target
 		if(src.occupant.a_intent == I_HURT)
 			playsound(src, mecha_punch_sound, 50, 1)
 			if(damtype == "brute")
 				step_away(M,src,15)
-
+			var/target_zone //null is acceptable here, apply_damage will just pick a target if it's necessary
 			if(istype(target, /mob/living/carbon/human))
 				var/mob/living/carbon/human/H = target
-
-				var/datum/organ/external/temp = H.get_organ(pick(LIMB_CHEST, LIMB_CHEST, LIMB_CHEST, LIMB_HEAD))
-				if(temp)
-					if (prob(50))//this is still busted but now you have a chance to get out of stunlock
-						H.Paralyse(1)
-					var/update = temp.take_damage(rand(force/2, force), 0)
-					//nothing to my knowledge changes mecha damage type, so this will most likely be the only case to ever proc
-					/*
-					switch(damtype)
-						if("brute")
-							H.Paralyse(1)
-							update |= temp.take_damage(rand(force/2, force), 0)
-						if("fire")
-							update |= temp.take_damage(0, rand(force/2, force))
-						if("tox")
-							if(H.reagents)
-								if(H.reagents.get_reagent_amount(CARPOTOXIN) + force < force*2)
-									H.reagents.add_reagent(CARPOTOXIN, force)
-								if(H.reagents.get_reagent_amount(CRYPTOBIOLIN) + force < force*2)
-									H.reagents.add_reagent(CRYPTOBIOLIN, force)
-					*/
-					if(update)
-						H.UpdateDamageIcon(1)
-				H.updatehealth()
-
-			else
-				if (prob(50))//this is still busted but now you have a chance to get out of stunlock
-					M.Paralyse(1)
-				M.take_overall_damage(rand(force/2, force))
-				//nothing to my knowledge changes mecha damage type, so this will most likely be the only case to ever proc
-				/*
-				switch(damtype)
-					if("brute")
-						M.Paralyse(1)
-						M.take_overall_damage(rand(force/2, force))
-					if("fire")
-						M.take_overall_damage(0, rand(force/2, force))
-					if("tox")
-						if(M.reagents)
-							if(M.reagents.get_reagent_amount(CARPOTOXIN) + force < force*2)
-								M.reagents.add_reagent(CARPOTOXIN, force)
-							if(M.reagents.get_reagent_amount(CRYPTOBIOLIN) + force < force*2)
-								M.reagents.add_reagent(CRYPTOBIOLIN, force)
-				*/
-				M.updatehealth()
+				target_zone = H.get_organ(pick(LIMB_CHEST, LIMB_CHEST, LIMB_CHEST, LIMB_HEAD)) //Mech attacks too unwieldly to directly target
+			var/armor_reduction = 0 //Disabled, use = M.run_armor_check(target_zone, "melee") to have this enabled
+			if (prob(50))//this is still busted but now you have a chance to get out of stunlock
+				M.Paralyse(1)
+			M.apply_damage(rand(force/2, force), damtype, target_zone, armor_reduction, 0, 0) //handles all the damage specifics such as updatehealth()
 			src.occupant_message("You hit [target].")
 			src.visible_message("<span class='red'><b>[src.name] hits [target].</b></span>")
 			message_admins("[key_name_and_info(src.occupant)] mech punched [target] with [src.name] ([formatJumpTo(src)])",0,1)
@@ -90,25 +51,29 @@
 			step_away(M,src)
 			src.occupant_message("You push [target] out of the way.")
 			src.visible_message("[src] pushes [target] out of the way.")
+			fist_icon = image(icon = 'icons/mob/screen_spells.dmi', icon_state = "wiz_push") //wizard hand placeholder for robot hand
+		if(target) //in case target got gibbed, qdel'd, or some other horrible thing
+			do_attack_animation(target, src, fist_icon)
 	else
-		if(damtype == "brute")
-			for(var/target_type in src.destroyable_obj)
-				if(istype(target, target_type) && hascall(target, "attackby"))
-					playsound(src, mecha_punch_sound, 50, 1)
-					src.occupant_message("You hit [target].")
-					src.visible_message("<span class='red'><b>[src.name] hits [target].</b></span>")
-					if(!istype(target, /turf/simulated/wall))
-						target:attackby(src.fist,src.occupant)
-					else if(prob(5))
-						if ((force >= MECHA_FORCE_COMBAT) && !(target:dismantle_wall(1)))
-							//this currently won't do anything to shuttle walls!
-							//also this doesn't account for reinforced walls but whatever, I don't want to deal with this right now
-							src.occupant_message("<span class='notice'>You smash through the wall.</span>")
-							src.visible_message("<b>[src.name] smashes through the wall!</b>")
-							playsound(src, 'sound/effects/stone_crumble.ogg', 50, 1)
-						else
-							src.occupant_message("<span class='notice'>You get a feeling that this [target] isn't gonna break ever.</span>")
-					break
+		for(var/target_type in src.destroyable_obj)
+			if(istype(target, target_type) && hascall(target, "attackby"))
+				playsound(src, mecha_punch_sound, 50, 1)
+				src.occupant_message("You hit [target].")
+				src.visible_message("<span class='red'><b>[src.name] hits [target].</b></span>")
+				if(!istype(target, /turf/simulated/wall))
+					target:attackby(src.fist,src.occupant)
+				else if(prob(5))
+					if ((force >= MECHA_FORCE_COMBAT) && !(target:dismantle_wall(1)))
+						//this currently won't do anything to shuttle walls!
+						//also this doesn't account for reinforced walls but whatever, I don't want to deal with this right now
+						src.occupant_message("<span class='notice'>You smash through the wall.</span>")
+						src.visible_message("<b>[src.name] smashes through the wall!</b>")
+						playsound(src, 'sound/effects/stone_crumble.ogg', 50, 1)
+					else
+						src.occupant_message("<span class='notice'>You get a feeling that this [target] isn't gonna break ever.</span>")
+				if(target) //in case wall got obliterated
+					do_attack_animation(target, src, fist_icon)
+				break
 	occupant.delayNextAttack(MECHA_MELEE_DELAY)
 
 /*

--- a/code/modules/mecha/combat/combat.dm
+++ b/code/modules/mecha/combat/combat.dm
@@ -1,8 +1,8 @@
+
+
 /obj/mecha/combat
-	force = 30
-	var/melee_cooldown = 10
-	var/melee_can_hit = 1
-	var/list/destroyable_obj = list(/obj/mecha, /obj/structure/window, /obj/structure/grille, /turf/simulated/wall)
+	force = MECHA_FORCE_COMBAT
+	mecha_punch_sound = 'sound/mecha/mechsmash.ogg'
 	internal_damage_threshold = 50
 	light_range_off = 0 //combat mechs leak no cabin light for stealth operation
 	cursor_enabled = 1 //cursor is enabled by default for combat mechs
@@ -21,35 +21,28 @@
 	return
 */
 
-/obj/mecha/combat/melee_action(target as obj|mob|turf)
+/obj/mecha/proc/melee_action(target as obj|mob|turf)
 	if(internal_damage&MECHA_INT_CONTROL_LOST)
 		target = safepick(oview(1,src))
-	if(!melee_can_hit || !istype(target, /atom))
+	if(!istype(target, /atom))
 		return
 	if(istype(target, /mob/living))
 		var/mob/living/M = target
 		if(src.occupant.a_intent == I_HURT)
-			playsound(src, 'sound/mecha/mechsmash.ogg', 50, 1)
+			playsound(src, mecha_punch_sound, 50, 1)
 			if(damtype == "brute")
 				step_away(M,src,15)
-			/*
-			if(M.stat>1)
-				M.gib()
-				melee_can_hit = 0
-				spawn(meele_cooldown)
-					melee_can_hit = 1
-				return
-			*/
+
 			if(istype(target, /mob/living/carbon/human))
 				var/mob/living/carbon/human/H = target
-	//			if (M.health <= 0) return
 
 				var/datum/organ/external/temp = H.get_organ(pick(LIMB_CHEST, LIMB_CHEST, LIMB_CHEST, LIMB_HEAD))
 				if(temp)
 					var/update = 0
 					switch(damtype)
-						if("brute")
-							H.Paralyse(1)
+						if("brute")//nothing to my knowledge changes mecha damage type, so this will most likely be the only case to ever proc
+							if (prob(50))
+								H.Paralyse(1)
 							update |= temp.take_damage(rand(force/2, force), 0)
 						if("fire")
 							update |= temp.take_damage(0, rand(force/2, force))
@@ -59,16 +52,15 @@
 									H.reagents.add_reagent(CARPOTOXIN, force)
 								if(H.reagents.get_reagent_amount(CRYPTOBIOLIN) + force < force*2)
 									H.reagents.add_reagent(CRYPTOBIOLIN, force)
-						else
-							return
 					if(update)
 						H.UpdateDamageIcon(1)
 				H.updatehealth()
 
 			else
 				switch(damtype)
-					if("brute")
-						M.Paralyse(1)
+					if("brute")//nothing to my knowledge changes mecha damage type, so this will most likely be the only case to ever proc
+						if (prob(50))
+							M.Paralyse(1)
 						M.take_overall_damage(rand(force/2, force))
 					if("fire")
 						M.take_overall_damage(0, rand(force/2, force))
@@ -78,8 +70,6 @@
 								M.reagents.add_reagent(CARPOTOXIN, force)
 							if(M.reagents.get_reagent_amount(CRYPTOBIOLIN) + force < force*2)
 								M.reagents.add_reagent(CRYPTOBIOLIN, force)
-					else
-						return
 				M.updatehealth()
 			src.occupant_message("You hit [target].")
 			src.visible_message("<span class='red'><b>[src.name] hits [target].</b></span>")
@@ -89,30 +79,26 @@
 			step_away(M,src)
 			src.occupant_message("You push [target] out of the way.")
 			src.visible_message("[src] pushes [target] out of the way.")
-
-		melee_can_hit = 0
-		spawn(melee_cooldown)
-			melee_can_hit = 1
-		return
-
 	else
 		if(damtype == "brute")
 			for(var/target_type in src.destroyable_obj)
 				if(istype(target, target_type) && hascall(target, "attackby"))
+					playsound(src, mecha_punch_sound, 50, 1)
 					src.occupant_message("You hit [target].")
 					src.visible_message("<span class='red'><b>[src.name] hits [target].</b></span>")
 					if(!istype(target, /turf/simulated/wall))
 						target:attackby(src.fist,src.occupant)
 					else if(prob(5))
-						target:dismantle_wall(1)
-						src.occupant_message("<span class='notice'>You smash through the wall.</span>")
-						src.visible_message("<b>[src.name] smashes through the wall!</b>")
-						playsound(src, 'sound/weapons/smash.ogg', 50, 1)
-					melee_can_hit = 0
-					spawn(melee_cooldown)
-						melee_can_hit = 1
+						if ((force >= MECHA_FORCE_COMBAT) && !(target:dismantle_wall(1)))
+							//this currently won't do anything to shuttle walls!
+							//also this doesn't account for reinforced walls but whatever, I don't want to deal with this right now
+							src.occupant_message("<span class='notice'>You smash through the wall.</span>")
+							src.visible_message("<b>[src.name] smashes through the wall!</b>")
+							playsound(src, 'sound/effects/stone_crumble.ogg', 50, 1)
+						else
+							src.occupant_message("<span class='notice'>You get a feeling that this [target] isn't gonna break ever.</span>")
 					break
-	return
+	occupant.delayNextAttack(MECHA_MELEE_DELAY)
 
 /*
 /obj/mecha/combat/proc/mega_shake(target)

--- a/code/modules/mecha/combat/combat.dm
+++ b/code/modules/mecha/combat/combat.dm
@@ -38,11 +38,14 @@
 
 				var/datum/organ/external/temp = H.get_organ(pick(LIMB_CHEST, LIMB_CHEST, LIMB_CHEST, LIMB_HEAD))
 				if(temp)
-					var/update = 0
+					if (prob(50))//this is still busted but now you have a chance to get out of stunlock
+						H.Paralyse(1)
+					var/update = temp.take_damage(rand(force/2, force), 0)
+					//nothing to my knowledge changes mecha damage type, so this will most likely be the only case to ever proc
+					/*
 					switch(damtype)
-						if("brute")//nothing to my knowledge changes mecha damage type, so this will most likely be the only case to ever proc
-							if (prob(50))
-								H.Paralyse(1)
+						if("brute")
+							H.Paralyse(1)
 							update |= temp.take_damage(rand(force/2, force), 0)
 						if("fire")
 							update |= temp.take_damage(0, rand(force/2, force))
@@ -52,15 +55,20 @@
 									H.reagents.add_reagent(CARPOTOXIN, force)
 								if(H.reagents.get_reagent_amount(CRYPTOBIOLIN) + force < force*2)
 									H.reagents.add_reagent(CRYPTOBIOLIN, force)
+					*/
 					if(update)
 						H.UpdateDamageIcon(1)
 				H.updatehealth()
 
 			else
+				if (prob(50))//this is still busted but now you have a chance to get out of stunlock
+					M.Paralyse(1)
+				M.take_overall_damage(rand(force/2, force))
+				//nothing to my knowledge changes mecha damage type, so this will most likely be the only case to ever proc
+				/*
 				switch(damtype)
-					if("brute")//nothing to my knowledge changes mecha damage type, so this will most likely be the only case to ever proc
-						if (prob(50))
-							M.Paralyse(1)
+					if("brute")
+						M.Paralyse(1)
 						M.take_overall_damage(rand(force/2, force))
 					if("fire")
 						M.take_overall_damage(0, rand(force/2, force))
@@ -70,6 +78,7 @@
 								M.reagents.add_reagent(CARPOTOXIN, force)
 							if(M.reagents.get_reagent_amount(CRYPTOBIOLIN) + force < force*2)
 								M.reagents.add_reagent(CRYPTOBIOLIN, force)
+				*/
 				M.updatehealth()
 			src.occupant_message("You hit [target].")
 			src.visible_message("<span class='red'><b>[src.name] hits [target].</b></span>")

--- a/code/modules/mecha/combat/honker.dm
+++ b/code/modules/mecha/combat/honker.dm
@@ -33,6 +33,8 @@
 	if(istype(target, /mob))
 		playsound(src, mecha_punch_sound, 50, 1)
 		step_away(target,src,15)
+		var/image/fist_icon = image(icon = 'icons/obj/items.dmi', icon_state = "bike_horn") //bike horn placeholder for clown fist
+		do_attack_animation(target, src, fist_icon)
 		occupant.delayNextAttack(MECHA_MELEE_DELAY)
 	return
 

--- a/code/modules/mecha/combat/honker.dm
+++ b/code/modules/mecha/combat/honker.dm
@@ -14,6 +14,7 @@
 	wreckage = /obj/effect/decal/mecha_wreckage/honker
 	add_req_access = 0
 	max_equip = 3
+	mecha_punch_sound = 'sound/items/bikehorn.ogg'
 	var/squeak = 0
 
 /*
@@ -29,10 +30,10 @@
 
 
 /obj/mecha/combat/honker/melee_action(target)
-	if(!melee_can_hit)
-		return
-	else if(istype(target, /mob))
+	if(istype(target, /mob))
+		playsound(src, mecha_punch_sound, 50, 1)
 		step_away(target,src,15)
+		occupant.delayNextAttack(MECHA_MELEE_DELAY)
 	return
 
 /obj/mecha/combat/honker/get_stats_part()

--- a/code/modules/mecha/mecha.dm
+++ b/code/modules/mecha/mecha.dm
@@ -11,6 +11,12 @@
 #define STATE_BOLTSEXPOSED 1
 #define STATE_BOLTSOPENED 2
 
+#define MECHA_FORCE_DEFAULT 10
+#define MECHA_FORCE_WORKING 15
+#define MECHA_FORCE_COMBAT 30
+
+#define MECHA_MELEE_DELAY 10
+
 /obj/mecha
 	name = "Mecha"
 	desc = "Exosuit"
@@ -106,6 +112,18 @@
 
 	var/list/mech_sprites = list() //sprites alternatives for a given mech. Only have to enter the name of the paint scheme
 	var/paintable = 0
+
+	var/mecha_punch_sound = 'sound/weapons/smash.ogg'
+	//---------------------------------------------STUFF THAT WAS MOVED FROM COMBAT.DM BECAUSE LETS ALLOW EVERY MECHA TO PUNCH WHY NOT
+	force = MECHA_FORCE_DEFAULT
+	var/list/destroyable_obj = list(
+		/obj/mecha,
+		/obj/structure/window,
+		/obj/structure/grille,
+		/obj/structure/cult,
+		/turf/simulated/wall,
+		)//This is fucking disgraceful I hate mecha code so much
+	//----------------------------------------------
 
 /obj/mecha/get_cell()
 	return cell
@@ -340,8 +358,8 @@
 	return
 
 
-/obj/mecha/proc/melee_action(atom/target)
-	return
+///obj/mecha/proc/melee_action(atom/target)
+//	return now in combat.dm
 
 /obj/mecha/proc/range_action(atom/target)
 	return

--- a/code/modules/mecha/mecha.dm
+++ b/code/modules/mecha/mecha.dm
@@ -264,7 +264,7 @@
 
 /obj/mecha/proc/add_fist()
 	fist = new
-	fist.name = "[src]'s fist"
+	fist.name = "[src.name]'s fist"
 	fist.force = src.force
 
 /obj/mecha/proc/add_radio()

--- a/code/modules/mecha/working/working.dm
+++ b/code/modules/mecha/working/working.dm
@@ -1,4 +1,5 @@
 /obj/mecha/working
+	force = MECHA_FORCE_WORKING
 	internal_damage_threshold = 60
 	var/list/cargo = new
 	var/cargo_capacity = 15


### PR DESCRIPTION
:cl:
* rscadd: All mechas can now punch mobs, windows and grilles, when they have no weapons equipped, a feat no longer reserved to combat mechas. By default their punchs deal 10 damage to mobs, ripleys and clarkes deal 15, and combat mechas deal 30 (those are still the only one that can break walls).
* rscadd: Mecha punchs are now also compatible with attack animations, courtesy of Dilt
* rscadd: Honkers punch deal no damage but play the bikehorn sound.
* tweak: Unarmed mecha punchs now only have a 50% chance of paralyzing players, down from 100%, giving their victims a chance of escaping.
* bugfix: Unarmed mechas on harm intent can now punch down cult structures.
* bugfix: Fixed mechas being able to punch mobs and objects through windows.