### PR TITLE
Another batch of runtimes

### DIFF
--- a/code/game/turfs/paint_overlay.dm
+++ b/code/game/turfs/paint_overlay.dm
@@ -283,7 +283,7 @@
 		blood_DNA = list()
 
 /datum/paint_overlay/proc/refresh_paintlights()
-	if (my_turf)
+	if (my_turf && SSlighting?.initialized)
 		my_turf.lighting_overlay.update_overlay()
 
 	for (var/obj/abstract/paint_light/PL in paintlights)

--- a/code/modules/client/preferences/preferences_ui.dm
+++ b/code/modules/client/preferences/preferences_ui.dm
@@ -133,7 +133,7 @@
 
 
 	dat += {"<b>UI Style:</b> <a href='?_src_=prefs;preference=UI_style;task=input'><b>[get_pref(/datum/preference_setting/string/UI_style)]</b></a><br>
-	<b>Custom UI</b>(recommended for White UI): <span style='border:1px solid #161616; background-color: #[get_pref(/datum/preference_setting/string/UI_style_color)];'>&nbsp;&nbsp;&nbsp;</span><br>Color: <a href='?_src_=prefs;preference=UIcolor'><b>[get_pref(/datum/preference_setting/string/UI_style_color)]</b></a><br>
+	<b>Custom UI</b>(recommended for White UI): <span style='border:1px solid #161616; background-color: #[get_pref(/datum/preference_setting/string/UI_style_color)];'>&nbsp;&nbsp;&nbsp;</span><br>Color: <a href='?_src_=prefs;preference=UI_style_color;task=input'><b>[get_pref(/datum/preference_setting/string/UI_style_color)]</b></a><br>
 	Alpha(transparency): <a href='?_src_=prefs;preference=UI_style_alpha;task=input'><b>[get_pref(/datum/preference_setting/numerical/UI_style_alpha)]</b></a><br>
 	"}
 

--- a/code/modules/mob/living/carbon/human/combat.dm
+++ b/code/modules/mob/living/carbon/human/combat.dm
@@ -82,7 +82,8 @@
 
 	if(!talked)
 		var/obj/item/dropped_item = target.drop_item()
-		dropped_item.on_disarm_drop(src)
+		if (dropped_item)
+			dropped_item.on_disarm_drop(src)
 		visible_message("<span class='danger'>[src] has disarmed [target]!</span>")
 	playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 	return 1


### PR DESCRIPTION
## What this does

Fixes the below runtimes:

```
[19:41:28] Runtime in code/modules/client/preferences/preferences.dm,442: unprocessed href for Kanef; data={"_src_":"prefs","preference":"UIcolor"}
  proc name: process link (/datum/preferences/proc/process_link)
  usr: Kanef (kanef) (/mob/new_player)
  usr.loc: The floor (8, 81, 2) (/turf/unsimulated/floor)
  src: /datum/preferences (/datum/preferences)
  call stack:
  /datum/preferences (/datum/preferences): process link(Kanef (/mob/new_player), /list (/list))
  Kanef (/client): Topic("_src_=prefs;preference=UIcolor", /list (/list), null)
```

- Occurs when you open character preferences -> UI Settings and try to change the UI colour - nothing happens (and you get a free runtime too!). Looks like an oversight from the preferences refactor of a few months ago. Typo `UIcolor` was supposed to be `UI_style_color` plus a `task=input`. After fix the colour picker properly appears and you can set what colour tint you want your UI to be, but you can only do it pre-round. Changing it mid-round doesn't update it immediately

```
[19:38:31] Runtime in code/game/turfs/paint_overlay.dm,287: Cannot execute null.update overlay().
  proc name: refresh paintlights (/datum/paint_overlay/proc/refresh_paintlights)
  src: /datum/paint_overlay (/datum/paint_overlay)
  call stack:
  /datum/paint_overlay (/datum/paint_overlay): refresh paintlights()
  /datum/paint_overlay (/datum/paint_overlay): update()
  the brick wall (104,141,4) (/turf/simulated/wall/mineral/brick): update paint overlay()
  the brick wall (104,141,4) (/turf/simulated/wall/mineral/brick): relativewall()
  the brick wall (104,141,4) (/turf/simulated/wall/mineral/brick): initialize()
  the brick wall (104,141,4) (/turf/simulated/wall/mineral/brick): initialize()
  the brick wall (104,141,4) (/turf/simulated/wall/mineral/brick): initialize()
  the brick wall (104,141,4) (/turf/simulated/wall/mineral/brick): initialize()
  Objects (/datum/subsystem/obj): Initialize(23053)
  Master (/datum/controller/master): Setup()
```

- Occurs during map init. Paint overlay tries to apply but the lighting subsystem hasn't initialised yet so it explodes. Added check for subsystem ready, a few other procs with subsystem dependencies already use this pattern

```
[19:47:09] Runtime in code/modules/mob/living/carbon/human/combat.dm,85: Cannot execute 0.on disarm drop().
  proc name: disarm mob (/mob/living/carbon/human/disarm_mob)
  usr: Algot Gudakuk (racismismysuperpower) (/mob/living/carbon/human)
  usr.loc: The floor (293, 230, 1) (/turf/simulated/floor)
  src: Algot Gudakuk (/mob/living/carbon/human)
  src.loc: the floor (293,230,1) (/turf/simulated/floor)
  call stack:
  Algot Gudakuk (/mob/living/carbon/human): disarm mob(Foodoro Riker (/mob/living/carbon/human))
  Foodoro Riker (/mob/living/carbon/human): attack hand(Algot Gudakuk (/mob/living/carbon/human), "icon-x=16;icon-y=8;left=1;butt...", 1)
  Algot Gudakuk (/mob/living/carbon/human): UnarmedAttack(Foodoro Riker (/mob/living/carbon/human), 1, "icon-x=16;icon-y=8;left=1;butt...")
  Algot Gudakuk (/mob/living/carbon/human): ClickOn(Foodoro Riker (/mob/living/carbon/human), "icon-x=16;icon-y=8;left=1;butt...")
  Foodoro Riker (/mob/living/carbon/human): Click(the floor (293,230,1) (/turf/simulated/floor), "mapwindow.map", "icon-x=16;icon-y=8;left=1;butt...")
```

- Occurs when disarming someone who isn't holding anything. It doesn't fail the disarm (sound plays and you can knock them over) but does make a runtime. Added null check

## Why it's good
runtime bad

## How it was tested
- UI colour : confirmed bug by clicking the `#ffffff` in character prefs -> ui settings, runtime appeared
  - confirmed could set colour post-fix
- paint overlay thing : Confirmed bug by loading up local until it spawned that particular vault, runtimes appeared
  - post-fix the runtimes did not appear and the vault looks the same
- Disarm : confirmed by spawning a dummy and disarming it, runtimes appeared
  - post-fix no more runtimes
 

## Changelog
:cl:
 * bugfix: UI colour can once again be set in Character Prefs (no immediate update mid-round)
