### PR TITLE
Optimizes zLevel Creation

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -22,6 +22,7 @@
 #define SPATIAL_BUCKET_SIZE 15
 
 var/datum/subsystem/mapping/SSmapping
+var/skip_turf_init = FALSE
 
 /datum/subsystem/mapping
 	name       = "Mapping"
@@ -450,7 +451,9 @@ var/datum/subsystem/mapping/SSmapping
  * separating each sector. Each sector can hold a different planet.
  */
 /datum/subsystem/mapping/proc/create_procgen_level()
+	skip_turf_init = TRUE
 	world.maxz += 1
+	skip_turf_init = FALSE
 	map.addZLevel(new /datum/zLevel/away, world.maxz, TRUE, TRUE)
 	for(var/x = 1,  x < world.maxx, x++)
 		for(var/y = 1, y < world.maxy, y++)

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -22,7 +22,7 @@
 #define SPATIAL_BUCKET_SIZE 15
 
 var/datum/subsystem/mapping/SSmapping
-var/skip_turf_init = FALSE
+var/skip_turf_init = FALSE //NEVER change this var for anything other than incrementing world.maxz it breaks EVERYTHING!!
 
 /datum/subsystem/mapping
 	name       = "Mapping"

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -981,7 +981,34 @@ its easier to just keep the beam vertical.
 		if(uppertext(C.ckey) == uppertext(fingerprintslast))
 			return C.mob
 
+/atom/New()
+	if(skip_turf_init)
+		return
+
+	// Incase any lighting vars are on in the typepath we turn the light on in New().
+	if (light_power && light_range)
+		update_light()
+
+	if (opacity && isturf(loc))
+		var/turf/T = loc
+		T.has_opaque_atom = TRUE // No need to recalculate it in this case, it's guaranteed to be on afterwards anyways.
+
+	//atom creation method that preloads variables at creation
+	if(use_preloader && (src.type == _preloader.target_path))//in case the instanciated atom is creating other atoms in New()
+		_preloader.load(src)
+
+	. = ..()
+
+	particle_systems = list() //Lazy init
+
+	if(ticker && ticker.current_state >= GAME_STATE_PLAYING && canSmoothWith())
+		relativewall()
+		relativewall_neighbours()
+
 /atom/initialize()
+	if(skip_turf_init)
+		flags |= ATOM_INITIALIZED
+		return
 	if(canSmoothWith())
 		relativewall()
 	flags |= ATOM_INITIALIZED

--- a/code/game/objects/effects/particles_system.dm
+++ b/code/game/objects/effects/particles_system.dm
@@ -27,6 +27,8 @@
 /atom/proc/add_particles(var/particle_string)
 	if (!particle_string)
 		return
+	if (!particle_systems)
+		particle_systems = list()
 	if (particle_string in particle_systems)
 		return
 

--- a/code/game/objects/effects/particles_system.dm
+++ b/code/game/objects/effects/particles_system.dm
@@ -1,7 +1,7 @@
 //Because BYOND only lets atoms have 1 type of particles at a given time, we use holders to let atoms stack particle effects
 
 /atom
-	var/list/particle_systems = list()
+	var/list/particle_systems
 
 //-----------------------------------------------
 /atom/proc/add_to_vis(var/stuff)

--- a/code/game/smoothwall.dm
+++ b/code/game/smoothwall.dm
@@ -58,7 +58,7 @@
 		var/turf/simulated/wall/W = A
 		return src.mineral == W.mineral && !(cannotSmoothWith() && is_type_in_list(A, cannotSmoothWith()))
 	return is_type_in_list(A, canSmoothWith()) && !(cannotSmoothWith() && (is_type_in_list(A, cannotSmoothWith())))
-		
+
 
 /**
  * WALL SMOOTHING SHIT
@@ -75,12 +75,6 @@
 	else
 		junction = 0
 	return junction // PREVIOUSLY DID NOTHING, NOW INHERITS THIS FOR COMMON BEHAVIOUR.
-
-/atom/New()
-	. = ..()
-	if(ticker && ticker.current_state >= GAME_STATE_PLAYING && canSmoothWith())
-		relativewall()
-		relativewall_neighbours()
 
 /*
  * SEE?  NOW WE ONLY HAVE TO PROGRAM THIS SHIT INTO WHAT WE WANT TO SMOOTH

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -19,6 +19,8 @@
 	if(loc)
 		var/area/A = loc
 		A.area_turfs += src
+	if(skip_turf_init)
+		return
 	if(!parallax_appearances)
 		parallax_appearances = list()
 		for(var/i in 0 to 25)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -16,7 +16,7 @@
 	var/edge_priority = 0 // higher priority edges are placed over lower-priority ones
 	var/edge_flags = 0
 	var/edge_overlay_type = /obj/effect/edge_overlay
-	var/list/datum/weakref/edge_overlays = list()
+	var/list/datum/weakref/edge_overlays
 
 	//properties for open tiles (/floor)
 	var/oxygen = 0
@@ -86,12 +86,12 @@
 
 	var/datum/paint_overlay/paint_overlay = null
 
-	var/list/footstep_sound = list()
-	var/list/footstep_sound_barefoot = list()
-	var/list/footstep_sound_claw = list()
+	var/list/footstep_sound
+	var/list/footstep_sound_barefoot
+	var/list/footstep_sound_claw
 
 	//reagent stuff
-	var/list/turf_reagents = list() //a list of reagent ids, associated with their relative amount. eg WATER=1 these numbers should sum to 1, though.
+	var/list/turf_reagents //a list of reagent ids, associated with their relative amount. eg WATER=1 these numbers should sum to 1, though.
 	var/reagent_interaction_flags = 0
 	var/turf_reagent_amount = null // null = do not make any reagents and skip the code
 	var/turf_reagent_method = TOUCH
@@ -111,7 +111,18 @@
 			GiveReagentsTo(M)
 
 /turf/New()
+	// Lazy list inits
+	edge_overlays = list()
+	footstep_sound = list()
+	footstep_sound_barefoot = list()
+	footstep_sound_claw = list()
+	turf_reagents = list()
+
+	if(skip_turf_init)
+		return
+
 	..()
+
 	footstep_sound = sounds_floor
 	footstep_sound_barefoot = sounds_floor_barefoot
 	footstep_sound_claw = sounds_floor_claw
@@ -119,11 +130,24 @@
 		base_icon_state = icon_state
 	pick_icon_state()
 
+	// Fire stuff
+	if(!thermal_material)
+		flammable = FALSE
+		return
+	else
+		if(!autoignition_temperature)
+			autoignition_temperature = thermal_material.autoignition_temperature
+		if(thermal_mass)
+			initial_thermal_mass = thermal_mass
+		fire_protection = world.time
+
 /turf/proc/pick_icon_state()
 	if(base_icon_state && max_icon_states && prob(variance))
 		icon_state = "[base_icon_state][rand(min_icon_states,max_icon_states)]"
 
 /turf/initialize()
+	if(skip_turf_init)
+		return
 	..()
 	if(loc)
 		var/area/A = loc
@@ -138,6 +162,12 @@
 		has_opaque_atom = TRUE
 	if((edge_flags & EDGE_CARDINAL) && !(turf_flags & DEFER_EDGING))
 		update_edges()
+
+	// MultiZ support
+	if(HasBelow(src.z))
+		var/turf/below = GetBelow(src)
+		if(below)
+			below.openspace_update(src)
 
 /turf/ex_act(severity)
 	return 0

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -149,7 +149,6 @@
 	if(skip_turf_init)
 		return
 	..()
-	edge_overlays = list()
 	if(loc)
 		var/area/A = loc
 		A.area_turfs += src

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -149,6 +149,7 @@
 	if(skip_turf_init)
 		return
 	..()
+	edge_overlays = list()
 	if(loc)
 		var/area/A = loc
 		A.area_turfs += src
@@ -453,7 +454,7 @@
 		for(var/obj/effect/overlay/puddle/ice/P in src)
 			qdel(P)
 
-	if(edge_overlays.len)
+	if(edge_overlays && edge_overlays.len)
 		for(var/datum/weakref/EO in edge_overlays)
 			var/obj/effect/edge_overlay/E = EO.get()
 			if(E)
@@ -863,6 +864,8 @@
 	if(turf_reagent_amount!=null && (reagent_interaction_flags & TURF_REAGENT_FILLS_CONTAINERS) && istype(I,/obj/item/weapon/reagent_containers))
 		to_chat(user,"<span class='notice'>You fill \the [I] from \the [src]</span>")
 		var/obj/item/weapon/reagent_containers/RC=I
+		if(!turf_reagents)
+			turf_reagents = list()
 		for(var/RID in turf_reagents)
 			RC.reagents.add_reagent(RID,turf_reagents[RID]*RC.amount_per_transfer_from_this)
 		if(turf_reagents_limited!=null)
@@ -895,7 +898,8 @@
 		return
 	if(turf_reagent_amount==null)
 		return
-
+	if(!turf_reagents)
+		turf_reagents = list()
 	for(var/RID in turf_reagents)
 		var/datum/reagent/D = chemical_reagents_list[RID]
 		if(D)

--- a/code/game/turfs/unsimulated/jungle.dm
+++ b/code/game/turfs/unsimulated/jungle.dm
@@ -223,7 +223,7 @@ var/list/foliage_replacments=list(
 	edge_flags = 0
 	edge_priority = 1
 
-/turf/unsimulated/floor/jungle/mud/New()	
+/turf/unsimulated/floor/jungle/mud/New()
 	footstep_sound = sounds_water
 	footstep_sound_barefoot = sounds_water
 	footstep_sound_claw = sounds_water
@@ -309,9 +309,9 @@ var/list/foliage_replacments=list(
 /turf/unsimulated/floor/jungle/dirt/proc/can_dig_down(var/mob/user=null)
 	var/turf/T=locate(x,y,z==1 ? 2 : 6)
 	if(istype(T,/turf/unsimulated/floor/jungle))
-		return TRUE	
+		return TRUE
 	if(istype(T,/turf/unsimulated/mineral))
-		return TRUE		
+		return TRUE
 	if(user)
 		to_chat(user,"<span class='warning'>Something hard blocks you from digging downwards.</span>")
 	return FALSE
@@ -431,7 +431,7 @@ var/list/foliage_replacments=list(
 	return
 /atom/movable/junglewateroverlay/clean_act(var/cleanliness)
 	return
-	
+
 /turf/unsimulated/floor/jungle/water
 	name="Water"
 	desc="It's about knee-height. Probably not safe to drink from."
@@ -439,7 +439,6 @@ var/list/foliage_replacments=list(
 	icon_state = "water5"
 	turf_speed_multiplier=2.0
 	DIGGING_BLOCKED = "Something tells you that this is a really bad idea."
-	turf_reagents = list(WATER=1.0)
 	reagent_interaction_flags = TURF_REAGENT_ENTER | TURF_REAGENT_FILLS_CONTAINERS
 	turf_reagent_amount = 5
 	turf_flags = NO_FLORA
@@ -447,10 +446,11 @@ var/list/foliage_replacments=list(
 	edge_priority = WATER_EDGE_PRIORITY
 	edge_overlay_type = /obj/effect/edge_overlay/water
 	var/atom/movable/junglewateroverlay/wateroverlay=null
-	
+
 /turf/unsimulated/floor/jungle/water/New()
 	..()
 	update_icon()
+	turf_reagents = list(WATER=1.0)
 	footstep_sound = sounds_water
 	footstep_sound_barefoot = sounds_water
 	footstep_sound_claw = sounds_water
@@ -469,7 +469,6 @@ var/list/foliage_replacments=list(
 	icon_state = "water2"
 	turf_speed_multiplier=2.5
 	DIGGING_BLOCKED = "Something tells you that this is a really bad idea."
-	turf_reagents = list(WATER=1.0)
 	reagent_interaction_flags = TURF_REAGENT_ENTER | TURF_REAGENT_FILLS_CONTAINERS
 	turf_reagent_amount = 10
 	edge_flags = ALL_EDGES
@@ -477,10 +476,11 @@ var/list/foliage_replacments=list(
 	edge_priority = DEEPWATER_EDGE_PRIORITY
 	edge_overlay_type = /obj/effect/edge_overlay/water/deep
 	var/atom/movable/junglewateroverlay/wateroverlay=null
-	
+
 /turf/unsimulated/floor/jungle/water_deep/New()
 	..()
 	update_icon()
+	turf_reagents = list(WATER=1.0)
 	footstep_sound = sounds_water
 	footstep_sound_barefoot = sounds_water
 	footstep_sound_claw = sounds_water
@@ -600,7 +600,7 @@ var/list/foliage_replacments=list(
 
 /turf/unsimulated/mineral/jungle_underground/Bumped(AM)
 	. = ..()
-	
+
 	if(istype(AM,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = AM
 		if(istype(H.get_active_hand(),/obj/item/weapon/pickaxe) || istype(H.get_inactive_hand(),/obj/item/weapon/pickaxe)) //prevents double attacking the same turf because parent proc covers this
@@ -609,7 +609,7 @@ var/list/foliage_replacments=list(
 			attackby(H.get_active_hand(), H)
 		else if(item_terraforming_isshovel(H.get_inactive_hand()) || item_terraforming_ispickaxe(H.get_inactive_hand()))
 			attackby(H.get_inactive_hand(), H)
-			
+
 /turf/unsimulated/mineral/jungle_underground/MineralSpread() //do nothing
 	return
 
@@ -647,7 +647,7 @@ var/list/foliage_replacments=list(
 		overlays+=image('icons/turf/walls.dmi', "j_rfloor_overlay_l")
 	else if(cannot_dig_up())
 		overlays+=image('icons/turf/walls.dmi', "j_rfloor_overlay_d")
-		
+
 
 /turf/unsimulated/floor/jungle/bedrock/attackby(obj/item/C as obj, mob/user as mob)
 	..()
@@ -701,7 +701,7 @@ var/list/foliage_replacments=list(
 	//we reveal the state of surrounding bedrock. there was a better way to do this. how did i forget to use range?
 	for(var/turf/unsimulated/floor/jungle/bedrock/B in orange(1))
 		B.update_icon()
-	
+
 
 /turf/unsimulated/floor/jungle/bedrock/proc/cannot_dig_up()
 	var/turf/T=locate(x,y,z==2 ? 1 : 4)

--- a/code/modules/ZAS/Fire.dm
+++ b/code/modules/ZAS/Fire.dm
@@ -404,17 +404,6 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 /turf
 	var/soot_type = /obj/effect/decal/cleanable/soot
 
-/turf/New()
-	..()
-	if(!thermal_material)
-		flammable = FALSE
-		return
-	if(!autoignition_temperature)
-		autoignition_temperature = thermal_material.autoignition_temperature
-	if(thermal_mass)
-		initial_thermal_mass = thermal_mass
-	fire_protection = world.time
-
 /turf/ashify()
 	if(!on_fire)
 		return

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -515,22 +515,6 @@ var/list/map_dimension_cache = list()
 		placed.opacity = 1
 	placed.underlays += turfs_underlays
 
-/atom/New()
-	// Incase any lighting vars are on in the typepath we turn the light on in New().
-
-	if (light_power && light_range)
-		update_light()
-
-	if (opacity && isturf(loc))
-		var/turf/T = loc
-		T.has_opaque_atom = TRUE // No need to recalculate it in this case, it's guaranteed to be on afterwards anyways.
-
-	//atom creation method that preloads variables at creation
-	if(use_preloader && (src.type == _preloader.target_path))//in case the instanciated atom is creating other atoms in New()
-		_preloader.load(src)
-
-	. = ..()
-
 //////////////////
 //Preloader datum
 //////////////////

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -734,6 +734,7 @@ var/list/icon_state_to_appearance = list()
 	var/mineralChance = 10  //means 10% chance of this plot changing to a mineral deposit
 
 /turf/unsimulated/mineral/random/New()
+	edge_overlays = list()
 	if (prob(mineralChance) && !mineral && mineralPool)
 		if(!name_to_mineral)
 			SetupMinerals()

--- a/code/modules/multiz/turfs.dm
+++ b/code/modules/multiz/turfs.dm
@@ -140,13 +140,6 @@ var/list/open_overlay_depths
 /turf/proc/openspace_update(var/turf/above) // function for changes in stuff if above is no longer open
 	return
 
-/turf/initialize()
-	. = ..()
-	if(HasBelow(src.z))
-		var/turf/below = GetBelow(src)
-		if(below)
-			below.openspace_update(src)
-
 /turf/unsimulated/floor/snow/openspace_update(var/turf/above)
 	if(above && !isopenspace(above))
 		precip_intensity_override = WEATHER_CALM // should be at least a bit chilly

--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -356,3 +356,11 @@ var/global/list/accessable_z_levels = list()
 		feedback_add_details("admin_verb", "BTC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 		message_admins("[key_name_admin(usr)] has set the base turf for Z-level [choice] to [get_base_turf(choice)]. This will affect all destroyed turfs from now on.")
 		log_admin("[key_name(usr)] has set the base turf for Z-level [choice] to [get_base_turf(choice)]. This will affect all destroyed turfs from now on.")
+
+/proc/increment_z()
+	var/target_z = world.maxz + 1
+	skip_turf_init = TRUE
+	spawn(0)
+		world.maxz++
+	UNTIL(world.maxz == target_z)
+	skip_turf_init = FALSE


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Implements several performance optimizations to cut the world lag when creating a new zLevel in half:

- Removes all empty list declarations from /atom and /turf to prevent excessive hidden Byond (init) proc calls. These now use a lazy init in their respective New() calls.
- Adds a "skip_turf_init" global var which can be toggled on to skip ALL actions in atom and turf New & Initialize. Never EVER use this for anything other than incrementing world.maxz.
- Consolidated separate definitions of /atom/New() and /turf/New() into a single definition for each. Since proc calls are not free in Byond, multiple calls of New() can be laggy.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Saves time during creation of new zLevels during a round. Since this is unavoidable world lag which freezes the game for all players, minimizing its duration is critical. New zLevels are created for away missions and will be created for virtual zLevels in the (near) future.

**Before:**
<img width="990" height="143" alt="before" src="https://github.com/user-attachments/assets/14e66f71-72d4-44f5-ac3d-ac2ec0ac8de2" />
<img width="491" height="39" alt="1" src="https://github.com/user-attachments/assets/71e6e8b3-27a6-4b7c-ba9e-407a986b9031" />
**After:**
<img width="1027" height="58" alt="after" src="https://github.com/user-attachments/assets/5bcd2bba-24ef-4317-bd5b-9f3af8e165d2" />
<img width="506" height="35" alt="2" src="https://github.com/user-attachments/assets/07921d90-2404-4f1a-97a1-4a992e51cc44" />

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
- Benchmarked zLevel creation with and without this change (above).
- Verified footstep sounds, particle systems, edge overlays, and turf reagents are still functional without any runtimes.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Implemented backend changes to speed up zLevel creation.
