### PR TITLE
Makes shuttle buy() checks block shuttle structure turfs again.

### DIFF
--- a/code/controllers/subsystem/supply_shuttle.dm
+++ b/code/controllers/subsystem/supply_shuttle.dm
@@ -318,7 +318,7 @@ var/datum/subsystem/supply_shuttle/SSsupply_shuttle
 			continue
 		var/contcount
 		for(var/atom/movable/MA in T.contents)
-			if(MA.anchored && !ismecha(MA))
+			if(MA.anchored && !istype(MA,/obj/structure/shuttle))
 				continue
 			contcount++
 		if(contcount)


### PR DESCRIPTION
[bugfix]

## What this does
Closes #38801.
removes the mecha check because it only mattered in sell(), won't affect gameplay unless someone bussed one onto the supply shuttle from centcomm

## How it was tested
ordering crates

## Changelog
:cl:
 * bugfix: Shuttle turfs now count as blocked again for supply crate buying.