### PR TITLE
Fix valve init randomly bricking valves

### DIFF
--- a/code/game/machinery/ATMOSPHERICS/components/binary_devices/valve.dm
+++ b/code/game/machinery/ATMOSPHERICS/components/binary_devices/valve.dm
@@ -92,20 +92,25 @@
 /obj/machinery/atmospherics/binary/valve/investigation_log(var/subject, var/message)
 	activity_log += ..()
 
+/obj/machinery/atmospherics/binary/valve/build_network()
+	..()
+	// due to init order the valve can end up in a bad state if it
+	//  initialises before its neighbouring pipes
+	if (open && network1 && network2)
+		network1.merge(network2)
+		network2 = network1
+
 /obj/machinery/atmospherics/binary/valve/initialize()
 	normalize_dir()
 
 	findAllConnections(initialize_directions)
 
-	build_network()
-
 	if(openDuringInit)
-		close()
-		open()
+		open = TRUE
 		openDuringInit = 0
 
-	else
-		update_icon()
+	build_network()
+	update_icon()
 
 /obj/machinery/atmospherics/binary/valve/digital		// can be controlled by AI
 	name = "digital valve"

--- a/code/game/machinery/ATMOSPHERICS/components/binary_devices/valve.dm
+++ b/code/game/machinery/ATMOSPHERICS/components/binary_devices/valve.dm
@@ -62,11 +62,9 @@
 		update_icon()
 
 		if(network1)
-			if(network1)
-				qdel(network1)
+			qdel(network1)
 		if(network2)
-			if(network1)
-				qdel(network2)
+			qdel(network2)
 
 		build_network()
 


### PR DESCRIPTION
## What this does

This bug was a bag of dicks to track down but I'm pretty sure I got it

BUG 1

When valves (both digital and manual) initialize (called by subsystem on startup), they implicitly depend on their neighbour pipes being initialized when they call `build_network`. However, if the digivalve appears _before_ its neighbour pipes in the map file AND that valve has been mapped to have `open` true and not `openDuringInit`, due to serious interdimensional fuckery, those neighbouring pipes won't be ready (`node1` `node2` are null) and the valve won't build the pipenet. This is FAILURE MODE ONE.
Note that the claim about mapfile order is not based on documentation and is the only reason I can come up with that explains how this happens so predictably on these valves.

Another thing that happens is that when a valve initialises, if it was mapped with `openDuringInit` true (as is the case for most open-at-start digivalves), it calls `close()` (despite already being closed from `New()`/vars), then `open()`, then sets `openDuringInit` false. The `close()` immediately returns because its already closed, the `open()` involves a `spawn` that sets `open` to TRUE then does a neighbour check for network resolution - this is the bit that merges the networks when a valve opens. By the time the `spawn` comes back, it is possible that the valve's neighbours still aren't in a ready state and the same bug manifests. This is FAILURE MODE TWO

FAILURE MODE ONE is (I'm pretty sure) guaranteed to occur. Deff's Mixed Air Output valve was like this (`open` true, `openDuringInit` false) which meant that it was (probably) initialised in mapfile order AND the neighbouring pipes appear AFTER the valve in the mapfile. 

FAILURE MODE TWO is much rarer and affects valves with `openDuringInit` true. All three open digivalves in box station (N2, O2, mix outlets) are like this. Specifically I believe that the `spawn(10)` inside `open()` adds some level of indeterminism to the overall ordering that allows for neighbouring pipes to still not be initialised by the time the spawn comes home, so the same failure of malformed pipenets occurs.

The end result of these failures is that the valve fails to build pipenets and exist in an invalid detached state.

#### **In brief, this is caused by valve calling build_network during obj init, prematurely building networks before the pipe subsystem is ready**

As for why these are manifesting now, #38663 revealed the ancient (10 year old) bug. Prior to that PR the pipelines were completely deleted before being rebuilt, which cleared out the bad state on the valves. After that PR the bad state was kept in the merged pipeline. The bug specifically exists in valve init, but up until recently was indirectly masked by other systems.

The solution is to force merge the networks if the valve is open. A better, more thorough fix would be to unify the `open`/`openDuringInit` thing and tidy up initialisation order. Maybe later

BUG 2

The above bug affects pipeline network building, so turning the valve off and on again should in theory make it rebuild - but it doesn't and the valve has to be replaced for it to work.
Originally this was found and thought of as strange but it turns out it actually is a bug: In `close()`, there was this weird shit:

```
	spawn(10)
		open = FALSE
		update_icon()

		if(network1)
			if(network1)
				qdel(network1)
		if(network2)
			if(network1)
				qdel(network2)

		build_network()
```

It checks network1 twice for some reason, then checks network2 then network1 (????). When the valve is OPEN, `network1 == network2`, so the first check passes, qdels `network1`, implicitly qdeling `network2`, so the next check on network2 fails and it moves on and creates fresh separate networks. Everything good.
However, when the pipenets are fucked up as occurs in BUG 1, it correctly qdels `network1`, checks `network2` (which still exists because it was a separate pipenet despite the valve being open!) but then checks `network1` again (!!!) and as a result never qdels `network2`. `network2` becomes stale and reopening the valve doesn't reconstruct it (in fact I think it adds the valve to `network2` twice, go figure) preventing it from recovering.

Fix is to remove the redundant checks. It looks like this snuck in several years ago, the code from 11 years ago didn't do this (it also used `del`) but something happened along the way and now its like this

Fixes #38805

## Why it's good
Digital valves not randomly bricking

## How it was tested
- Verified that the definite failures on deff are now correctly flowing at roundstart
- The less-deterministic one is harder to reproduce you're just gonna have to trust me on this one

## Changelog
:cl:
 * bugfix: Roundstart open digital/manual valves no longer have a chance to be bricked
