### PR TITLE
Fix AIs not being able to toggle digital T valves

### DIFF
--- a/code/game/machinery/ATMOSPHERICS/components/binary_devices/valve.dm
+++ b/code/game/machinery/ATMOSPHERICS/components/binary_devices/valve.dm
@@ -92,20 +92,25 @@
 /obj/machinery/atmospherics/binary/valve/investigation_log(var/subject, var/message)
 	activity_log += ..()
 
+/obj/machinery/atmospherics/binary/valve/build_network()
+	..()
+	// due to init order the valve can end up in a bad state if it
+	//  initialises before its neighbouring pipes
+	if (open && network1 && network2)
+		network1.merge(network2)
+		network2 = network1
+
 /obj/machinery/atmospherics/binary/valve/initialize()
 	normalize_dir()
 
 	findAllConnections(initialize_directions)
 
-	build_network()
-
 	if(openDuringInit)
-		close()
-		open()
+		open = TRUE
 		openDuringInit = 0
 
-	else
-		update_icon()
+	build_network()
+	update_icon()
 
 /obj/machinery/atmospherics/binary/valve/digital		// can be controlled by AI
 	name = "digital valve"

--- a/code/game/machinery/ATMOSPHERICS/components/binary_devices/valve.dm
+++ b/code/game/machinery/ATMOSPHERICS/components/binary_devices/valve.dm
@@ -62,11 +62,9 @@
 		update_icon()
 
 		if(network1)
-			if(network1)
-				qdel(network1)
+			qdel(network1)
 		if(network2)
-			if(network1)
-				qdel(network2)
+			qdel(network2)
 
 		build_network()
 

--- a/code/game/machinery/ATMOSPHERICS/components/trinary_devices/t_valve.dm
+++ b/code/game/machinery/ATMOSPHERICS/components/trinary_devices/t_valve.dm
@@ -219,6 +219,10 @@
 
 	return ..()
 
+/obj/machinery/atmospherics/trinary/tvalve/digital/attack_ai(mob/user as mob)
+	src.add_hiddenprint(user)
+	return src.attack_hand(user)
+
 /obj/machinery/atmospherics/trinary/tvalve/digital/attack_hand(mob/user as mob)
 	if(!src.allowed(user))
 		to_chat(user, "<span class='warning'>Access denied.</span>")


### PR DESCRIPTION
## What this does

Restores an overload for `attack_ai` that was mistakenly deleted from `t_valve.dm` that allowed AIs to toggle digital T valves

Fixes #38806

## Why it's good
AIs should be able to control digital stuff its DIGITAL like computers

## How it was tested
Made digital T valve, switched to AI, toggled the T valve open and closed and it was ok

## Changelog
:cl:

 * bugfix: AIs can once again toggle digital T valves

