### PR TITLE
Fix AIs not being able to toggle digital T valves

### DIFF
--- a/code/game/machinery/ATMOSPHERICS/components/trinary_devices/t_valve.dm
+++ b/code/game/machinery/ATMOSPHERICS/components/trinary_devices/t_valve.dm
@@ -219,6 +219,10 @@
 
 	return ..()
 
+/obj/machinery/atmospherics/trinary/tvalve/digital/attack_ai(mob/user as mob)
+	src.add_hiddenprint(user)
+	return src.attack_hand(user)
+
 /obj/machinery/atmospherics/trinary/tvalve/digital/attack_hand(mob/user as mob)
 	if(!src.allowed(user))
 		to_chat(user, "<span class='warning'>Access denied.</span>")

--- a/code/game/machinery/ATMOSPHERICS/components/trinary_devices/t_valve.dm
+++ b/code/game/machinery/ATMOSPHERICS/components/trinary_devices/t_valve.dm
@@ -220,8 +220,8 @@
 	return ..()
 
 /obj/machinery/atmospherics/trinary/tvalve/digital/attack_ai(mob/user as mob)
-	src.add_hiddenprint(user)
-	return src.attack_hand(user)
+	add_hiddenprint(user)
+	return attack_hand(user)
 
 /obj/machinery/atmospherics/trinary/tvalve/digital/attack_hand(mob/user as mob)
 	if(!src.allowed(user))


### PR DESCRIPTION
## What this does

Restores an overload for `attack_ai` that was mistakenly deleted from `t_valve.dm` that allowed AIs to toggle digital T valves

Fixes #38806

## Why it's good
AIs should be able to control digital stuff its DIGITAL like computers

## How it was tested
Made digital T valve, switched to AI, toggled the T valve open and closed and it was ok

## Changelog
:cl:

 * bugfix: AIs can once again toggle digital T valves

