### PR TITLE
Fix piano UI 

### DIFF
--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -164,7 +164,7 @@
 	repeat = 0
 	ui_interact(user)
 
-/datum/song/ui_interact(mob/user, ui_key="main", datum/nanoui/ui=null, var/force_open=NANOUI_FOCUS)
+/datum/song/ui_interact(mob/user, ui_key="instrument", datum/nanoui/ui=null, var/force_open=NANOUI_FOCUS)
 	var/data = list(
 		"repeat" = repeat,
 		"ticklag" = world.tick_lag,


### PR DESCRIPTION
## What this does

ui_key mismatch (`"main"` vs. `"instrument"`) was causing the UI to be rapidly recreated resulting in flickering and inability to resize. Someone whose name starts with K apparently didnt notice this in his original testing but now its better

Fixes #38799

## Why it's good
piano ui shouldnt flicker and be shit

## How it was tested
- pre-fix: open piano ui, flicker
- post-fix: open piano ui, no flicker and can resize

## Changelog
:cl:
 * bugfix: Piano UI doesn't flicker any more and can even be resized too