### PR TITLE
Fix bug in atmos network merging

### DIFF
--- a/code/game/machinery/ATMOSPHERICS/datum_pipeline.dm
+++ b/code/game/machinery/ATMOSPHERICS/datum_pipeline.dm
@@ -97,14 +97,10 @@
 						if (other.air && other.air != air)
 							air.merge(other.air)
 
-						if (other.network && other.network != network)
-							if (network)
-								network.merge(other.network)
-							else
-								network = other.network
-								network.line_members -= other
-								if (!(src in network.line_members)) // sins against the nesting god
-									network.line_members += src
+						if (other.network)
+							// force a network rebuild later
+							// right now we are still unifying the pipeline
+							qdel(other.network)
 
 						other.members = null
 						other.edges = null


### PR DESCRIPTION
## What this does

The merge fix #38663 from 3 weeks ago revealed some ancient bugs but it is actually also partially the culprit here - the merge logic itself contained a bug when handling networks. This presents as devices not flowing correctly to pipes.
(Briefly: `pipeline` is only the raw pipes, where the gas lives, `network` is comprised of pipeline and devices like vents and scrubbers and stuff).

Before that change, networks would just delete and attempt to rebuild entirely (including pipeline) from scratch, but it was too simple and had a problem where networks with devices and adjacent manifolds failed to ever rebuild (main manifestation was distro and waste being merged would brick both pipenets as they got caught in rebuild loops).

The change made one network consume the other rather than simply deleting both, however the bug was that the resulting network didn't rebuild critical devices data (`normal_members`). Which specific devices are affected is down to initialisation order (aka nightmares to reproduce).

Prior to this PR:

```
if (other.network && other.network != network)
    if (network)
        network.merge(other.network)
    else
        network = other.network // <-- haram
        network.line_members -= other
        if (!(src in network.line_members))
            network.line_members += src //<-- insufficient
```
Later this is called:
```
/datum/pipeline/proc/return_network(obj/machinery/atmospherics/reference)
	if(!network) <-- fuck
		network = new /datum/pipe_network 
		network.build_network(src, null) <-- doesnt run
```

Because `network` gets set to `other.network`, inside `return_network` `network` is not null so `network.build_network` doesn't run. As a result, when `other.network` is consumed in the first block of code, it never runs `build_network` on the new unified collection. `build_network` crucially calls `network_expand` which essentially syncs up the network with all the connected devices along the full pipeline. tl;dr, the merge incompletely merged, the adopted networks missed machines from newly-merged edges.
To ensure the new network actually gets fully properly built, this PR changes the network merge to qdel the old network(s) such that a complete new one gets built.

While #38663 tried to preserve everything (pipeline build **and** network), this change deletes _only the other network_ but preserves pipeline. 

## Why it's good
gas flow good for grug pipe experiment 

## How it was tested
A number of restarts, building various random atmos setups, testing canisters on connectors, testing merging waste and distro, checking digivalves for flow

## Changelog
:cl:
 * bugfix: Pipenets should build more reliably now, fixing strange cases where gas wouldn't flow through devices
