### PR TITLE
Runtimes20251231

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -243,10 +243,10 @@
 
 /obj/abstract/screen/gun/MouseEntered(location,control,params)
 	//openToolTip(usr,src,params,title = name,content = desc)
-	usr.client?.tooltips.show(src, mouse=params, title=name, content=desc)
+	usr.client?.tooltips?.show(src, mouse=params, title=name, content=desc)
 
 /obj/abstract/screen/gun/MouseExited()
-	usr.client?.tooltips.hide()
+	usr.client?.tooltips?.hide()
 
 /proc/get_random_zone_sel()
 	return pick("l_foot", "r_foot", "l_leg", "r_leg", "l_hand", "r_hand", "l_arm", "r_arm", "chest", "groin", "eyes", "mouth", "head")

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -101,7 +101,7 @@
 
 	for(var/wallDir in cardinal)
 		var/turf/newTurf = get_step(location,wallDir)
-		if(newTurf.density)
+		if(newTurf?.density)
 			direction |= wallDir
 
 	for(var/obj/effect/glowshroom/shroom in location)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1274,7 +1274,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(is_malfunctioning())
 		// owner.u_equip(c_hand, 1)
 		owner.emote("me", 1, "drops what they were holding, their [hand_name] malfunctioning!")
-		spark(src, 5, FALSE)
+		spark(owner, 5, FALSE)
 		owner.drop_item(c_hand)
 
 /datum/organ/external/proc/embed(var/obj/item/weapon/W, var/silent = 0)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -706,7 +706,8 @@ var/list/impact_master = list()
 /obj/item/projectile/proc/rebound(var/atom/A)//Projectiles bouncing off walls and obstacles
 	var/turf/T = get_turf(src)
 	var/turf/W = get_turf(A)
-	playsound(T, bounce_sound, 30, 1)
+	if (bounce_sound)
+		playsound(T, bounce_sound, 30, 1)
 	reflected = 1
 	var/orientation = SOUTH
 	if(T == W)


### PR DESCRIPTION
## What this does

Fixes below runtimes:

```
[13:59:58] Runtime in code/game/objects/effects/glowshroom.dm,104: Cannot read null.density
  proc name: CalcDir (/obj/effect/glowshroom/proc/CalcDir)
  src: the glowshroom (/obj/effect/glowshroom)
  src.loc: the dirt (1,71,7) (/turf/unsimulated/floor/planetary/dirt)
  call stack:
  the glowshroom (/obj/effect/glowshroom): CalcDir(the dirt (1,71,7) (/turf/unsimulated/floor/planetary/dirt))
  the glowshroom (/obj/effect/glowshroom): New(the dirt (1,71,7) (/turf/unsimulated/floor/planetary/dirt))
  /datum/biome/cave/grass/lush (/datum/biome/cave/grass/lush): try spawn flora(the dirt (1,71,7) (/turf/unsimulated/floor/planetary/dirt), 232, 0)
  /datum/biome/cave/grass/lush (/datum/biome/cave/grass/lush): populate turf(the dirt (1,71,7) (/turf/unsimulated/floor/planetary/dirt), /list (/list), /list (/list), null, "Ultra Terra")
  /datum/planetGenerator/grass (/datum/planetGenerator/grass): populate turf(the dirt (1,71,7) (/turf/unsimulated/floor/planetary/dirt), /list (/list), /list (/list), null, "Ultra Terra")
  Mapping (/datum/subsystem/mapping): fire(1)
  Mapping (/datum/subsystem/mapping): ignite(1)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
```
- Occurs during map setup, glowshrooms test a wall direction that could be a null turf and unconditionally accesses a turf var

```
[16:58:17] Runtime in code/game/objects/effects/effect_system.dm,233: Cannot read null.contents
  proc name: spark (/proc/spark)
  src: null
  call stack:
  spark(null, 5, 0, 0, 0)
  r_arm (/datum/organ/external/r_arm): process grasp(the Mining Satchel (/obj/item/weapon/storage/bag/ore), "right hand")
  r_arm (/datum/organ/external/r_arm): process()
  Jon Summers (/mob/living/carbon/human): handle organs(0)
  Jon Summers (/mob/living/carbon/human): handle regular status updates()
  Jon Summers (/mob/living/carbon/human): Life()
  Mob (/datum/subsystem/mob): fire(0)
  Mob (/datum/subsystem/mob): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
```
- The `spark` proc is passed `src`, which tries to get turf, but instead of a `var/atom` it was passed a `/datum` and doesnt find a turf. Pass `owner` instead because thats the mob that owns the limb and the mob has a turf (hopefully). Occurs when a robotic limb is damaged/malfunctioning and drops something
- A bit on the fence about this one. Its an 8 year old bug if git logs are to be believed. While it _is_ a bugfix that restores the old behaviour from 2017 and the original intent of the code, after 8 years I wonder if it can be construed as an addition

```
[15:06:19] Runtime in code/game/sound.dm,53: code/game/sound.dm:53:Assertion Failed: !(isnull(soundin) && channel == 0)
  proc name: playsound (/proc/playsound)
  usr: Goop Sloop (astraorigins) (/mob/living/carbon/human)
  usr.loc: The cave floor (223, 7, 7) (/turf/unsimulated/floor/planetary/cave)
  src: null
  call stack:
  playsound(the cave floor (224,7,7) (/turf/unsimulated/floor/planetary/cave), null, 30, 1, null, null, 1, 0, 0, 0)
  the mahogany nut (/obj/item/projectile/bullet/mahoganut): to bump(the abandoned crate (/obj/structure/closet/crate/secure/loot/vg_lootget))
  the mahogany nut (/obj/item/projectile/bullet/mahoganut): perform bump()
  the mahogany nut (/obj/item/projectile/bullet/mahoganut): Move(the cave floor (224,7,7) (/turf/unsimulated/floor/planetary/cave), 0, 0, 0, 0)
  the mahogany nut (/obj/item/projectile/bullet/mahoganut): bresenham step(5, 0, 4, 2)
  the mahogany nut (/obj/item/projectile/bullet/mahoganut): process step()
  the mahogany nut (/obj/item/projectile/bullet/mahoganut): process()
```
- Mahoguny projectile mahoganut has a null `bounce_sound` but `playsound` was called unconditionally on `bounce_sound`. `playsound` shits the bed if the sound is null. added guard

```
[17:47:17] Runtime in code/_onclick/hud/screen_objects.dm,249: Cannot execute null.hide().
  proc name: MouseExited (/obj/abstract/screen/gun/MouseExited)
  usr: Jon Summers (13monkeys) (/mob/living/carbon/human)
  usr.loc: The plating (157, 253, 1) (/turf/simulated/floor/plating)
  src: Toggle Gun Mode (/obj/abstract/screen/gun/mode)
  src.loc: null
  call stack:
  Toggle Gun Mode (/obj/abstract/screen/gun/mode): MouseExited(null, "mapwindow.map", "icon-x=32;icon-y=19;screen-loc...")

...

[17:47:17] Runtime in code/_onclick/hud/screen_objects.dm,246: Cannot execute null.show().
  proc name: MouseEntered (/obj/abstract/screen/gun/MouseEntered)
  usr: Jon Summers (13monkeys) (/mob/living/carbon/human)
  usr.loc: The plating (157, 253, 1) (/turf/simulated/floor/plating)
  src: Toggle Gun Mode (/obj/abstract/screen/gun/mode)
  src.loc: null
  call stack:
  Toggle Gun Mode (/obj/abstract/screen/gun/mode): MouseEntered(null, "mapwindow.map", "icon-x=32;icon-y=19;screen-loc...")
```

Similar to previous fixes on hud elements, just missing a guard. There have been a few like this recently so I suspect the problem is widespread, will do a more thorough check tomorrow

## Why it's good
runtime bad

## How it was tested
Build success

## Changelog
:cl:
 * bugfix: After 8 years, robotic limbs once again spark when dropping something while malfunctioning