### PR TITLE
[Balance Discussion] Reworking the interaction between loyalty implants and cultists

### DIFF
--- a/__DEFINES/role_datums_defines.dm
+++ b/__DEFINES/role_datums_defines.dm
@@ -232,6 +232,15 @@
 #define DEVOTION_TIER_3		3
 #define DEVOTION_TIER_4		4
 
+#define DEVOTION_REQ_1		100
+#define DEVOTION_REQ_2		500
+#define DEVOTION_REQ_3		1000
+#define DEVOTION_REQ_4		2000
+
+#define CULT_IMPLANT_POP_NONE		0
+#define CULT_IMPLANT_POP_DELAYED	1
+#define CULT_IMPLANT_POP_IMMEDIATE	2
+
 #define RITUAL_CULTIST_1	"first_ritual"
 #define RITUAL_CULTIST_2	"second_ritual"
 

--- a/code/datums/gamemode/factions/bloodcult/bloodcult.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult.dm
@@ -84,14 +84,18 @@
 
 	var/countdown_to_first_rituals = 5
 
+	var/implant_pop = CULT_IMPLANT_POP_NONE
+
 /datum/faction/bloodcult/stage(var/value)
 	stage = value
 	switch(stage)
 		if (BLOODCULT_STAGE_READY)
+			implant_pop = CULT_IMPLANT_POP_IMMEDIATE
 			eclipse_trigger_cult()
 			for(var/obj/structure/cult/spire/S in cult_spires)
 				S.upgrade(3)
 		if (BLOODCULT_STAGE_MISSED)
+			implant_pop = CULT_IMPLANT_POP_NONE
 			for (var/datum/role/cultist in members)
 				var/mob/M = cultist.antag.current
 				if (M)
@@ -99,6 +103,7 @@
 			for(var/obj/structure/cult/spire/S in cult_spires)
 				S.upgrade(1)
 		if (BLOODCULT_STAGE_ECLIPSE)
+			implant_pop = CULT_IMPLANT_POP_IMMEDIATE
 			update_all_parallax()
 			var/datum/zLevel/ZL = map.zLevels[map.zMainStation]
 			ZL.transitionLoops = TRUE
@@ -363,7 +368,8 @@
 			for (var/datum/role/R in members)
 				var/mob/M = R.antag.current
 				calculate_eclipse_rate()
-				if (isliving(M) && !M.isDead())
+				if (isliving(M) && !M.isDead() && !M.occult_muted())
+					//if at least one cultist is alive, and not suffering from holliness
 					//we calculate the progress relative to the time since the last process so the overall time is independant from server lag and shit
 					delta = 1
 					if (last_process_time && (last_process_time < world.time))//carefully dealing with midnight rollover
@@ -373,6 +379,20 @@
 					last_process_time = world.time
 
 					eclipse_progress += max(0.1, eclipse_increments) * delta
+
+					if (implant_pop == CULT_IMPLANT_POP_NONE)
+						var/eclipse_remaining = eclipse_target - eclipse_progress
+						var/eclipse_ticks_to_go_at_current_rate = eclipse_remaining / max(0.1, eclipse_increments)
+						if(SSticker.initialized)
+							eclipse_ticks_to_go_at_current_rate *= (SSticker.wait / 10)//converting to seconds
+						var/minutes_to_go = floor(eclipse_ticks_to_go_at_current_rate / 60)
+						if (minutes_to_go < 10)
+							implant_pop = CULT_IMPLANT_POP_DELAYED
+							for (var/datum/role/RR in members)
+								var/mob/living/carbon/MM = RR.antag.current
+								if (istype(MM))
+									MM.implant_pop()//if there's no loyalty implant, this does nothing
+
 					if (eclipse_progress >= eclipse_target)
 						stage(BLOODCULT_STAGE_READY)
 					break

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_misc_procs.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_misc_procs.dm
@@ -137,8 +137,13 @@ var/static/list/valid_cultpower_slots = list(
 /mob/living/carbon/proc/implant_pop()
 	for(var/obj/item/weapon/implant/loyalty/I in src)
 		if (I.imp_in)
-			to_chat(src, "<span class='sinister'>Your blood pushes back against the loyalty implant, it will visibly pop out within seconds!</span>")
-			spawn(10 SECONDS)
+			to_chat(src, "<span class='userdanger'>As the veil grows thinner, the dark energies in your body disrupt \the [src].")
+			var/delay = 0
+			var/datum/faction/bloodcult/cult = find_active_faction_by_type(/datum/faction/bloodcult)
+			if (cult && cult.implant_pop == CULT_IMPLANT_POP_DELAYED)
+				to_chat(src, "<span class='userdanger'>It will visibly pop out in one minute!</span>")
+				delay = 60 SECONDS
+			spawn(delay)
 				if (I.remove())
 					visible_message("<span class='warning'>\The [I] pops out of \the [src]'s head.</span>")
 

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_misc_procs.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_misc_procs.dm
@@ -141,7 +141,7 @@ var/static/list/valid_cultpower_slots = list(
 			var/delay = 0
 			var/datum/faction/bloodcult/cult = find_active_faction_by_type(/datum/faction/bloodcult)
 			if (cult && cult.implant_pop == CULT_IMPLANT_POP_DELAYED)
-				to_chat(src, "<span class='userdanger'>It will visibly pop out in one minute!</span>")
+				to_chat(src, "<span class='userdanger'>It feels like it will be expelled from your body any minute now!</span>")
 				delay = 60 SECONDS
 			spawn(delay)
 				if (I.remove())

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_misc_procs.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_misc_procs.dm
@@ -137,7 +137,7 @@ var/static/list/valid_cultpower_slots = list(
 /mob/living/carbon/proc/implant_pop()
 	for(var/obj/item/weapon/implant/loyalty/I in src)
 		if (I.imp_in)
-			to_chat(src, "<span class='userdanger'>As the veil grows thinner, the dark energies in your body disrupt \the [src].")
+			to_chat(src, "<span class='userdanger'>As the veil grows thinner, the dark energies in your body disrupt \the [I.name].")
 			var/delay = 0
 			var/datum/faction/bloodcult/cult = find_active_faction_by_type(/datum/faction/bloodcult)
 			if (cult && cult.implant_pop == CULT_IMPLANT_POP_DELAYED)

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -1091,7 +1091,7 @@ var/list/converted_minds = list()
 				if (istype(victim.handcuffed,/obj/item/weapon/handcuffs/cult))
 					victim.drop_from_inventory(victim.handcuffed)
 				//and their loyalty implants are removed, so they can't mislead security, not that the conversion should even go through
-				victim.implant_pop()
+				victim.implant_pop()//but it does prevent funny players from implanting people right before the ritual concludes
 				for(var/obj/item/weapon/implant/holy/H in victim)
 					to_chat(victim, "<span class='warning'>The ritual's energies have completely fried the holy implant that was lodged in your skull.</span>")
 					qdel(H)

--- a/code/datums/gamemode/role/cultist.dm
+++ b/code/datums/gamemode/role/cultist.dm
@@ -1,3 +1,5 @@
+
+
 /datum/role/cultist
 	id = CULTIST
 	name = "Cultist"
@@ -270,13 +272,13 @@
 
 /datum/role/cultist/ExtraScoreboard()
 	switch(devotion)
-		if (2000 to INFINITY)
+		if (DEVOTION_REQ_4 to INFINITY)
 			return " <font color='#FF0000'>[devotion]</font>"
-		if (1000 to 2000)
+		if (DEVOTION_REQ_3 to DEVOTION_REQ_4)
 			return " <font color='#FF8800'>[devotion]</font>"
-		if (500 to 1000)
+		if (DEVOTION_REQ_2 to DEVOTION_REQ_3)
 			return " <font color='#FFFF00'>[devotion]</font>"
-		if (100 to 500)
+		if (DEVOTION_REQ_1 to DEVOTION_REQ_2)
 			return " <font color='#88FF00'>[devotion]</font>"
 		else
 			return " <font color='#00FF00'>[devotion]</font>"
@@ -372,15 +374,15 @@
 
 /datum/role/cultist/proc/get_devotion_rank()
 	switch(devotion)
-		if (2000 to INFINITY)
+		if (DEVOTION_REQ_4 to INFINITY)
 			return DEVOTION_TIER_4
-		if (1000 to 2000)
+		if (DEVOTION_REQ_3 to DEVOTION_REQ_4)
 			return DEVOTION_TIER_3
-		if (500 to 1000)
+		if (DEVOTION_REQ_2 to DEVOTION_REQ_3)
 			return DEVOTION_TIER_2
-		if (100 to 500)
+		if (DEVOTION_REQ_1 to DEVOTION_REQ_2)
 			return DEVOTION_TIER_1
-		if (0 to 100)
+		if (0 to DEVOTION_REQ_1)
 			return DEVOTION_TIER_0
 
 /datum/role/cultist/proc/gain_devotion(var/acquired_devotion = 0, var/tier = DEVOTION_TIER_0, var/key, var/extra)
@@ -534,13 +536,13 @@
 		if (DEVOTION_TIER_0)
 			return 0.10
 		if (DEVOTION_TIER_1)
-			return 0.10 + (devotion-100)*0.000375
+			return 0.10 + (devotion - DEVOTION_REQ_1) * 0.000375
 		if (DEVOTION_TIER_2)
-			return 0.25 + (devotion-500)*0.0003
+			return 0.25 + (devotion - DEVOTION_REQ_2) * 0.0003
 		if (DEVOTION_TIER_3)
-			return 0.40 + (devotion-1000)*0.0001
+			return 0.40 + (devotion - DEVOTION_REQ_3) * 0.0001
 		if (DEVOTION_TIER_4)
-			return 0.50 + (devotion-2000)*0.00005
+			return 0.50 + (devotion - DEVOTION_REQ_4) * 0.00005
 
 /datum/role/cultist/handle_reagent(var/reagent_id)
 	var/mob/living/carbon/human/H = antag.current
@@ -567,7 +569,7 @@
 			to_chat(H, "<span class='danger'>The burning touch of sacred water sears your skin.</span>")
 
 	switch(reagent_id)
-		if (HOLYWATER,INCENSE_HAREBELLS,SACREDWATER)
+		if (HOLYWATER, INCENSE_HAREBELLS, SACREDWATER)
 			H.eye_blurry = max(H.eye_blurry, 12)
 			H.Dizzy(12)
 			H.stuttering = max(H.stuttering, 12)

--- a/code/datums/gamemode/role/cultist.dm
+++ b/code/datums/gamemode/role/cultist.dm
@@ -136,7 +136,7 @@
 			assign_rituals()
 			var/mob/M = antag.current
 			if (M)
-				to_chat(M, "<span class='sinister'>Although you can generate devotion by performing most cult activities, a couple rituals for you to perform are now available. Check the cult panel.</span>")
+				to_chat(M, "<span class='sinister'>Although you can generate devotion by performing most cult activities, a couple rituals for you to perform are now available. Check the cult panel to the left.</span>")
 		if (!antag.current)
 			return
 		switch(cult.stage)

--- a/code/game/objects/items/weapons/implants/types/loyalty_implant.dm
+++ b/code/game/objects/items/weapons/implants/types/loyalty_implant.dm
@@ -29,10 +29,12 @@
 		qdel(src)
 		return
 	if(iscultist(imp_in))
-		to_chat(imp_in, "<span class='danger'>You feel the corporate tendrils of Nanotrasen trying to invade your mind!</span>")
-		var/mob/living/carbon/host = imp_in
-		if(istype(host))
-			host.implant_pop()
+		var/datum/faction/bloodcult/cult = find_active_faction_by_type(/datum/faction/bloodcult)
+		if (cult?.implant_pop)
+			to_chat(imp_in, "<span class='danger'>You feel the corporate tendrils of Nanotrasen trying to invade your mind!</span>")
+			var/mob/living/carbon/host = imp_in
+			if(istype(host))
+				host.implant_pop()
 	if(isrevnothead(imp_in))
 		var/datum/role/R = imp_in.mind.GetRole(REV)
 		R.Drop()


### PR DESCRIPTION
Aight this PR came about following some strong suggestions by members of the community. I'll first quickly recap the history of loyalty implants interactions with cultists, then what my stance on the matter is, and lastly what this PR does as a proposed change.

= 2012-2018 = Cult 1/2
* loyalty implants prevent conversion, but do not deconvert
* you can remove an implant surgically, convert, and then re-apply the implant

= 2018-2021 = Cult 3
* loyalty implants no longer prevent conversion, instead it takes even longer & the implant pops out afterwards
* implanting a cultist causes the implant to pop after some time starting from ACT 2 (after the cult has completed their first 2 objectives)

This change came about from a strong case by security players about the need for a 100% sure way to know if a player is cult or not, which I agreed was fair, especially when shit goes does and bloodstones rise.

= 2021-today = Cult 4
* loyalty implants prevent conversion, but do not deconvert
* AND implanting a cultist causes the implant to pop after some time

Arguably this is the worst deal cultists ever had. Security gets a guaranteed meta check that works from the start, and cultists must still take time to de-implant to convert.

My stance on this today is that now that cultists become visually identifiable by all during the eclipse (smoke + red halo) security doesn't need the green square that badly anymore to identify allies.
Two days ago a cultist that had done nothing but break some cameras and carried no occult items was identified simply from the implant popping out and was immediately killed for it (also because that round's sec officers were still Cult 3-brained, so they didn't even attempt deconversion)

So here's my proposed change:
* We go back to the original implant behavior (prevents conversions, but can be applied on cultists without any obvious meta-check happening)
* BUT the implant pops out once the Eclipse is 10 minutes away, and it always pops out again when implanting cultist past that time, until the Eclipse ends (after which it stops popping out if the cult didn't attempt to summon Nar-Sie)
* ALSO the implant now takes 60 seconds to pop-out (up from 10 seconds) before the Eclipse, and instantly during the eclipse

I'm aware it's a touchy subject and so I'd like you all to weigh in on this.
Personally I'd like holy implants to see more use during cult round instead of loyalty implants, but that comes with the potentially controversial change of changing restrictions on implant lockboxes.