### PR TITLE
Runtimes20260101

### DIFF
--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -290,8 +290,10 @@
 							icon_state = "flashburnt"
 
 						// log the recruitment
-						var/datum/stat/role/revolutionary/leader/SD = rev.stat_datum
-						SD.recruits_converted++
+						var/datum/role/revolutionary/leader/R = user.mind.GetRole(HEADREV)
+						if (R?.stat_datum)
+							var/datum/stat/role/revolutionary/leader/SD = R.stat_datum
+							SD.recruits_converted++
 
 					else if(result == ADD_REVOLUTIONARY_FAIL_IS_COMMAND)
 						to_chat(user, "<span class='warning'>This mind seems resistant to the flash!</span>")

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -922,13 +922,14 @@ a {
 		additional_description = "On \the [src] is a carving, it depicts:\n"
 		var/list/characters = list()
 		for(var/i = 1 to material_mod)
+			var/add_character
 			if(prob(50)) //We're gonna use an atom
 				var/atom/AM = pick(existing_typesof(/mob/living/simple_animal))
-				characters |= initial(AM.name)
+				add_character =  initial(AM.name)
 			else
-				var/strangething = pick("captain","clown","mime","\improper CMO","cargo technician","medical doctor","[user ? user : "stranger"]","octopus","changeling","\improper Nuclear Operative", "[pick("greyshirt", "greytide", "assistant")]", "xenomorph","catbeast","[user && user.mind && user.mind.heard_before.len ? pick(user.mind.heard_before) : "strange thing"]","Central Command","\improper Ian","[ticker.Bible_deity_name]","Nar-Sie","\improper Poly the Parrot","\improper Wizard","vox")
-				characters |= strangething
-			additional_description += "[i == material_mod ? " & a " : "[i > 1 ? ", a ": " A "]"][characters[i]]"
+				add_character = pick("captain","clown","mime","\improper CMO","cargo technician","medical doctor","[user ? user : "stranger"]","octopus","changeling","\improper Nuclear Operative", "[pick("greyshirt", "greytide", "assistant")]", "xenomorph","catbeast","[user && user.mind && user.mind.heard_before.len ? pick(user.mind.heard_before) : "strange thing"]","Central Command","\improper Ian","[ticker.Bible_deity_name]","Nar-Sie","\improper Poly the Parrot","\improper Wizard","vox")
+			characters |= add_character
+			additional_description += "[i == material_mod ? " & a " : "[i > 1 ? ", a ": " A "]"][add_character]"
 		additional_description += ". They are in \the [pick("captains office","Space","mining outpost","vox outpost","a space station","[station_name()]","bar","kitchen","library","Science","void","Bluespace","Hell","Central Command")]"
 		if(material_mod > 2)
 			additional_description += ". They are [pick("[pick("fighting","robusting","attacking","beating up", "abusing")] [pick("each other", pick(characters))]","playing cards","firing lasers at [pick("something",pick(characters))]","crying","laughing","blank faced","screaming","cooking [pick("something", pick(characters))]", "eating [pick("something", pick(characters))]")]. "

--- a/code/modules/html_interface/html_interface.dm
+++ b/code/modules/html_interface/html_interface.dm
@@ -156,6 +156,8 @@ mob/verb/test()
 	sendAssets(hclient.client)
 
 /datum/html_interface/proc/sendAssets(var/client/client)
+	if (!client)
+		return
 	send_asset(client, "jquery.min.js")
 	send_asset(client, "bootstrap.min.js")
 	send_asset(client, "bootstrap.min.css")

--- a/code/modules/jobs/job_controller.dm
+++ b/code/modules/jobs/job_controller.dm
@@ -280,11 +280,12 @@ var/global/alt_job_limit = 0 //list of alternate jobs available for new hires
  *  gets the current number of 'security' roles currently assigned to the station
  **/
 /datum/controller/occupations/proc/GetSecurityCount()
-	var/datum/job/officer = job_master.GetJob("Security Officer")
-	var/datum/job/warden = job_master.GetJob("Warden")
-	var/datum/job/hos = job_master.GetJob("Head of Security")
-	var/datum/job/detective = job_master.GetJob("Detective")
-	return (officer.current_positions + warden.current_positions + hos.current_positions + detective.current_positions)
+	var/count = 0
+	for (var/job_title in list("Security Officer", "Warden", "Head of Security", "Detective"))
+		var/datum/job/J = job_master.GetJob(job_title)
+		if (J)
+			count += J.current_positions
+	return count
 
 /** Proc DivideOccupations
  *  fills var "assigned_role" for all ready players.

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -1011,9 +1011,11 @@ var/list/icon_state_to_appearance = list()
 
 /turf/unsimulated/mineral/gibtonite/proc/countdown()
 	spawn(0)
-		while(stage == 1 && det_time > 0 && mineral.result_amount >= 1)
+		while(istype(src, /turf/unsimulated/mineral/gibtonite) && stage == 1 && det_time > 0 && mineral.result_amount >= 1)
 			det_time--
 			sleep(5)
+		if (!istype(src, /turf/unsimulated/mineral/gibtonite))
+			return
 		if(stage == 1 && det_time <= 0 && mineral.result_amount >= 1)
 			var/turf/bombturf = get_turf(src)
 			mineral.result_amount = 0

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1076,6 +1076,7 @@ var/global/list/damage_icon_parts = list()
 			else
 				to_chat(src, span_warning("You burst out of \the [wear_suit]!"))
 				drop_from_inventory(wear_suit)
+				return
 		else
 			if(SP.name in wear_suit.species_fit) //Allows clothes to display differently for multiple species
 				if(SP.wear_suit_icons && has_icon(SP.wear_suit_icons, wear_suit.icon_state))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1029,7 +1029,7 @@ Use this proc preferably at the end of an equipment loadout
 		update_pull_icon()
 		if(ismob(P))
 			var/mob/M = P
-			M.assaulted_by(usr, TRUE)
+			M.assaulted_by(src, TRUE)
 
 /mob/verb/stop_pulling()
 	set name = "Stop Pulling"

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -2096,11 +2096,11 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "robotic head"
 
 /obj/item/organ/external/head/New(loc, mob/living/carbon/human/H, var/datum/organ/external/head/O)
-	origin_body = makeweakref(H)
-
 	..()
 	if(!istype(H)) //It's entirely possible for stuff to call this without a human, such as headpoles with heads in maps for some reason...
 		return
+
+	origin_body = makeweakref(H)
 	src.icon_state = H.gender == MALE? "head_m" : "head_f"
 	if(isgolem(H)) //Golems don't inhabit their severed heads, they turn to dust when they die.
 		var/mob/living/simple_animal/borer/B = H.has_brain_worms()

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -42,12 +42,10 @@
 	if(burstfire == TRUE)
 		if(!ready_to_fire())
 			return 1
-		var/shots_fired = 0 //haha, I'm so clever
 		var/to_shoot = min(burst_count, getAmmo())
 		for(var/i = 1 to to_shoot)
 			..()
 			burstfiring = 1
-			shots_fired++
 			if(!user.contents.Find(src) || jammed)
 				break
 		recoil = initial(recoil)

--- a/code/modules/tooltip/tooltip.dm
+++ b/code/modules/tooltip/tooltip.dm
@@ -47,7 +47,8 @@
 	/// Send browser assets to the client
 
 /datum/tooltips/proc/loadAssets()
-
+	if (!owner)
+		return
 	register_asset("tooltip.css", 'code/modules/tooltip/tooltip.css')
 	send_asset(owner, "tooltip.css")
 	register_asset("eta.min.js", 'code/modules/tooltip/eta.min.js')

--- a/maps/fixedvaults/misc_derelict_west.dmm
+++ b/maps/fixedvaults/misc_derelict_west.dmm
@@ -74,7 +74,7 @@
 /area/derelict/atmos)
 "dh" = (
 /obj/machinery/door/window{
-	dir = 3
+	dir = 2
 	},
 /turf/simulated/floor,
 /area/derelict/bridge/access)


### PR DESCRIPTION
## What this does

Fixes the below runtimes:

```
[01:19:13] Runtime in code/modules/client/global cache.dm,54: Cannot read null.cache
  proc name: send asset (/proc/send_asset)
  src: null
  call stack:
  send asset(null, "jquery.min.js", 1)
  /datum/html_interface/nanotras... (/datum/html_interface/nanotrasen/vote): sendAssets(null)
  /datum/html_interface/nanotras... (/datum/html_interface/nanotrasen/vote): sendAssets(null)
  /datum/html_interface/nanotras... (/datum/html_interface/nanotrasen/vote): sendAssets(null)
  send html resources()
  send resources()

[01:19:13] Runtime in code/modules/client/global cache.dm,54: Cannot read null.cache
  proc name: send asset (/proc/send_asset)
  src: null
  call stack:
  send asset(null, "tooltip.css", 1)
  /datum/tooltips (/datum/tooltips): loadAssets()
  /datum/tooltips (/datum/tooltips): New(null)
```

- Caused when a client disconnects before fully connecting (I'm pretty sure) - `client` can seemingly become null partway through. Add additional guarding

```
[01:24:17] Runtime in code/modules/runescape/runescape_pvp.dm,77: Cannot execute null.just fought().
  proc name: assaulted by (/mob/proc/assaulted_by)
  src: Shaft Miner (/mob/living/carbon/human)
  src.loc: the floor (250,196,6) (/turf/simulated/floor/airless)
  call stack:
  Shaft Miner (/mob/living/carbon/human): assaulted by(null, 1)
  the alien sentinel (/mob/living/simple_animal/hostile/alien/sentinel): start pulling(Shaft Miner (/mob/living/carbon/human))
  the alien sentinel (/mob/living/simple_animal/hostile/alien/sentinel): MovetoPrey()
  the alien sentinel (/mob/living/simple_animal/hostile/alien/sentinel): Life()
  Mob (/datum/subsystem/mob): fire(1)
  Mob (/datum/subsystem/mob): ignite(1)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
```
- Can occur when simplemobs are fighting each other. `start_pulling` calls `assaulted_by` with `usr` but it should be `src`, simplemobs can also call `start_pulling`

```
[01:18:28] Runtime in code/game/atoms_movable.dm,1293: border_dummy has invalid dir 3
  proc name: update dir (/atom/movable/border_dummy/update_dir)
  src: the border dummy (/atom/movable/border_dummy)
  src.loc: the floor (146,211,4) (/turf/simulated/floor)
  call stack:
  the border dummy (/atom/movable/border_dummy): update dir()
  the border dummy (/atom/movable/border_dummy): change dir(3, the window door (/obj/machinery/door/window))
  /datum/locking_category/border... (/datum/locking_category/border_dummy): lock(the border dummy (/atom/movable/border_dummy))
  the window door (/obj/machinery/door/window): lock atom(the border dummy (/atom/movable/border_dummy), /datum/locking_category/border... (/datum/locking_category/border_dummy))
  the window door (/obj/machinery/door/window): setup border dummy()
  the window door (/obj/machinery/door/window): New(the floor (146,210,4) (/turf/simulated/floor))
  /dmm_suite (/dmm_suite): instance atom(/obj/machinery/door/window (/obj/machinery/door/window), /list (/list), 146, 210, 4, 0, 0)
  /dmm_suite (/dmm_suite): parse grid("/obj/machinery/door/window{dir...", 146, 210, 4, 0, 0)
  /dmm_suite (/dmm_suite): load map(maps/fixedvaults/misc_derelict..., 4, 137, 198, derelict west (/datum/map_element/fixedvault/misc_derelict_west), 0, 0, 1, 34, 1, 44, 1, inf)
  derelict west (/datum/map_element/fixedvault/misc_derelict_west): load(137, 198, 4, 0, 0, 0, 0, inf, 0, inf, 0, inf)
  the map_element (/obj/effect/landmark/map_element/misc_derelict_west): mapload()
  generate fixedvaults()
  Mapping (/datum/subsystem/mapping): Initialize(227079)
  Master (/datum/controller/master): Setup()
```
- Occurs during map setup, the `misc_derelict_west.dmm` thing has a windoor with `dir = 3` which doesn't make sense for a windoor (dir should be 1,2,4 or 8). Set to 2 in StrongDMM

```
[16:35:37] Runtime in code/__HELPERS/weakref.dm,18: Cannot read null.weakref
  proc name: makeweakref (/proc/makeweakref)
  src: null
  call stack:
  makeweakref(null)
  the head (/obj/item/organ/external/head): New(the pole (/obj/structure/headpole/with_head), null, null)
  the pole (/obj/structure/headpole/with_head): New(the floor (480,357,3) (/turf/unsimulated/floor))
  /dmm_suite (/dmm_suite): instance atom(/obj/structure/headpole/with_h... (/obj/structure/headpole/with_head), /list (/list), 480, 357, 3, 0, 0)
  /dmm_suite (/dmm_suite): parse grid("/obj/structure/headpole/with_h...", 480, 357, 3, 0, 0)
  /dmm_suite (/dmm_suite): load map(maps/randomvaults/croesus_vaul..., 3, 447, 297, /datum/map_element/vault/croes... (/datum/map_element/vault/croesus_vault), 0, 0, 1, 66, 1, 66, 1, inf)
  /datum/map_element/vault/croes... (/datum/map_element/vault/croesus_vault): load(447, 297, 3, 0, 0, 0, 0, inf, 0, inf, 0, inf)
  populate area with vaults(the random vault area (/area/random_vault), /list (/list), 12, 2, /proc/stay_in_vault_area (/proc/stay_in_vault_area), 0)
  generate vaults()
  Mapping (/datum/subsystem/mapping): Initialize(777235)
  Master (/datum/controller/master): Setup()
```
- Occurs during map setup, it tries to make headpoles (a spear with a head mounted on it) but without an origin H. As a result making the weakref will runtime. We can safely delay the setting of `origin_body` here that will prevent the runtime, H being null will return before that so headpoles form properly

```
[21:57:24] Runtime in code/modules/mob/living/carbon/human/update_icons.dm,1087: Cannot read null.dynamic_overlay
  proc name: update inv wear suit (/mob/living/carbon/human/update_inv_wear_suit)
  src: Paris Flickinger (/mob/living/carbon/human)
  src.loc: the floor (274,228,1) (/turf/simulated/floor)
  call stack:
  Paris Flickinger (/mob/living/carbon/human): update inv wear suit(1)
  Paris Flickinger (/mob/living/carbon/human): handle chemicals in body()
  Paris Flickinger (/mob/living/carbon/human): Life()
  Mob (/datum/subsystem/mob): fire(1)
  Mob (/datum/subsystem/mob): ignite(1)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
```
- Occurs when someone becomes fat and bursts out of their clothing. The `wear_suit` is dropped and becomes null but the code didn't return and then tried to read `wear_suit` later in the same proc. Added early return

```
[01:31:07] Runtime in code/modules/mining/mine_turfs.dm,1016: undefined variable /turf/unsimulated/floor/asteroid/var/stage
  proc name: countdown (/turf/unsimulated/mineral/gibtonite/proc/countdown)
  src: Asteroid (167,141,6) (/turf/unsimulated/floor/asteroid)
  call stack:
  Asteroid (167,141,6) (/turf/unsimulated/floor/asteroid): countdown()
```
- Occurs when a `spawn` comes back to a turf that had undergone `ChangeTurf` and attempts to access a var on the old turf. In this case while mining out gibtonite. Added typechecking

```
[21:12:33] Runtime in code/modules/jobs/job_controller.dm,287: Cannot read null.current_positions
  proc name: GetSecurityCount (/datum/controller/occupations/proc/GetSecurityCount)
  src: /datum/controller/occupations (/datum/controller/occupations)
  call stack:
  /datum/controller/occupations (/datum/controller/occupations): GetSecurityCount()
  /datum/controller/occupations (/datum/controller/occupations): CheckAssistantCount(ZizianFuries (/mob/new_player), 3)
  /datum/controller/occupations (/datum/controller/occupations): TryAssignJob(ZizianFuries (/mob/new_player), 3, /datum/job/assistant (/datum/job/assistant))
  /datum/controller/occupations (/datum/controller/occupations): DivideOccupations()
  /datum/controller/gameticker (/datum/controller/gameticker): setup()
  /datum/controller/gameticker (/datum/controller/gameticker): pregame()
  Ticker (/datum/subsystem/ticker): Initialize(76521)
```
- Occurs on Castle. There are no Security jobs but the code assumes there are and unconditionally accesses them. Rewrote proc to iterate over a list, with guard

```
[20:54:29] Runtime in code/game/objects/items/devices/flash.dm,294: undefined variable /datum/stat/faction/var/recruits_converted
  proc name: attack (/obj/item/device/flash/rev/attack)
  usr: Foodoro Riker (reimusarmpit) (/mob/living/carbon/human)
  usr.loc: The floor (173, 255, 1) (/turf/simulated/floor)
  src: the flash (/obj/item/device/flash/rev)
  src.loc: Foodoro Riker (/mob/living/carbon/human)
  call stack:
  the flash (/obj/item/device/flash/rev): attack(Stan Zarond (/mob/living/carbon/human), Foodoro Riker (/mob/living/carbon/human), null)
  Stan Zarond (/mob/living/carbon/human): attackby(the flash (/obj/item/device/flash/rev), Foodoro Riker (/mob/living/carbon/human), "icon-x=21;icon-y=15;left=1;but...", null, null)
  Foodoro Riker (/mob/living/carbon/human): ClickOn(Stan Zarond (/mob/living/carbon/human), "icon-x=21;icon-y=15;left=1;but...")
  Stan Zarond (/mob/living/carbon/human): Click(Stan Zarond (/mob/living/carbon/human), "mapwindow.map", "icon-x=21;icon-y=15;left=1;but...")
  Stan Zarond (/mob/living/carbon/human): MouseDrop(Comemmorative Plaque (173,254,1) (/turf/simulated/floor), the floor (173,253,1) (/turf/simulated/floor), Comemmorative Plaque (173,254,1) (/turf/simulated/floor), "mapwindow.map", "mapwindow.map", "icon-x=21;icon-y=15;left=1;but...")
  Stan Zarond (/mob/living/carbon/human): MouseDrop(Comemmorative Plaque (173,254,1) (/turf/simulated/floor), the floor (173,253,1) (/turf/simulated/floor), Comemmorative Plaque (173,254,1) (/turf/simulated/floor), "mapwindow.map", "mapwindow.map", "icon-x=21;icon-y=15;left=1;but...")
  ReimusArmpit (/client): MouseDrop(Stan Zarond (/mob/living/carbon/human), Comemmorative Plaque (173,254,1) (/turf/simulated/floor), the floor (173,253,1) (/turf/simulated/floor), Comemmorative Plaque (173,254,1) (/turf/simulated/floor), "mapwindow.map", "mapwindow.map", "icon-x=21;icon-y=15;left=1;but...")
  ReimusArmpit (/client): MouseDrop(Stan Zarond (/mob/living/carbon/human), Comemmorative Plaque (173,254,1) (/turf/simulated/floor), the floor (173,253,1) (/turf/simulated/floor), Comemmorative Plaque (173,254,1) (/turf/simulated/floor), "mapwindow.map", "mapwindow.map", "icon-x=21;icon-y=15;left=1;but...")
```
- Occurs when a revhead flashes someone. The code accesses the wrong datum for `recruits_converted`, made it access the correct datum

```
[21:46:04] Runtime in code/game/objects/objs.dm,931: list index out of bounds
  proc name: gen description (/obj/proc/gen_description)
  usr: Roberto Prevatt (bomthar) (/mob/living/carbon/human)
  usr.loc: The floor (199, 235, 1) (/turf/simulated/floor)
  src: the smithing hammer (/obj/item/weapon/hammer)
  src.loc: the floor (199,235,1) (/turf/simulated/floor)
  call stack:
  the smithing hammer (/obj/item/weapon/hammer): gen description(null)
  the smithing hammer (/obj/item/weapon/hammer): dorfify(Gold (/datum/material/gold), 0, 8)
  the smithing hammer (/obj/item/weapon/hammer): dorfify(Gold (/datum/material/gold), 0, 8)
  the excellent gold hammer head (/obj/item/item_head/hammer_head): attackby(the item handle (/obj/item/item_handle), Roberto Prevatt (/mob/living/carbon/human), "icon-x=17;icon-y=19;left=1;but...")
  Roberto Prevatt (/mob/living/carbon/human): ClickOn(the excellent gold hammer head (/obj/item/item_head/hammer_head), "icon-x=17;icon-y=19;left=1;but...")
  the excellent gold hammer head (/obj/item/item_head/hammer_head): Click(null, "mapwindow.map", "icon-x=17;icon-y=19;left=1;but...")
```
- Occurs when smithing something that gets a description. The `characters` list is added to with `|=` that avoids duplicates but the `additional_description` assumes that `characters.len` is always equal to `material_mod` when accessing `characters[i]`. If there was a duplicate pick and `characters` wasn't added to, it's len will be less than `i`. Introduced new var in place of `characters[i]`


- ~~Also cleans up an unused variable I missed while stripping out the `defective` dead code~~ Handled in different PR

## Why it's good
runtimes bad

## How it was tested
Build success
General testing covered most of them

## Changelog
No user-facing change