### PR TITLE
You can now make snowballs from simmed snow with less tedium

### DIFF
--- a/code/game/turfs/simulated/snow.dm
+++ b/code/game/turfs/simulated/snow.dm
@@ -46,6 +46,12 @@
 			"<span class='notice'>You dig out some snow with \the [W].</span>")
 			extract_snowballs(5, FALSE, user)
 
+	if(istype(W,/obj/item/stack/sheet/snow))
+		user.visible_message("<span class='notice'>[user] reaches down and gathers more snow.</span>", \
+		"<span class='notice'>You reach down and bolster your snowball.</span>")
+		user.delayNextAttack(10)
+		extract_snowballs(1, TRUE, user, W)
+
 /turf/simulated/floor/plating/snow/CtrlClick(mob/user)
 
 	//Reach down and make a snowball


### PR DESCRIPTION
## What this does
Making a snowball from simulated snow (box of winter) no longer requires your hand to be empty, needing you to drop your last snowball. You can now grow your existing snowball stack.
## Why it's good
Parity with unsimulated snow AND is way less tedious when making snowballs stationside.
:cl:
 * tweak: You can now make snowballs from box of winter snow easier without needing to drop your existing snowball first.