### PR TITLE
Fixes shovels not creating snowballs from snow turfs

### DIFF
--- a/code/game/turfs/simulated/snow.dm
+++ b/code/game/turfs/simulated/snow.dm
@@ -71,7 +71,7 @@
 	var/extract_amount = min(snowballs, snowball_amount)
 
 	for(var/i = 0; i < extract_amount; i++)
-		var/obj/item/stack/sheet/snow/snowball = new /obj/item/stack/sheet/snow(loc)
+		var/obj/item/stack/sheet/snow/snowball = new /obj/item/stack/sheet/snow(src)
 		snowball.pixel_x = rand(-16, 16) * PIXEL_MULTIPLIER //Would be wise to move this into snowball New() down the line
 		snowball.pixel_y = rand(-16, 16) * PIXEL_MULTIPLIER
 

--- a/code/game/turfs/unsimulated/snow.dm
+++ b/code/game/turfs/unsimulated/snow.dm
@@ -234,7 +234,7 @@
 			snowball_stack.add(1)
 			snowballs--
 			break
-		var/obj/item/stack/sheet/snow/snowball = new /obj/item/stack/sheet/snow(loc)
+		var/obj/item/stack/sheet/snow/snowball = new /obj/item/stack/sheet/snow(src)
 		snowball.pixel_x = rand(-16, 16) * PIXEL_MULTIPLIER //Would be wise to move this into snowball New() down the line
 		snowball.pixel_y = rand(-16, 16) * PIXEL_MULTIPLIER
 


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Fixes attacking snow turfs with a shovel not producing any snowballs. A turf's loc is an area, so src (the turf itself) needed to be used here instead.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Fixes a bug introduced in #36362 and closes #38835.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Confirmed snowballs were created on both snow turf types using a shovel.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed using shovels on snow not producing snowballs.