### PR TITLE
Some small QoL for the cult rune-drawing interface

### DIFF
--- a/code/_onclick/mindUI/_mindUI.dm
+++ b/code/_onclick/mindUI/_mindUI.dm
@@ -390,26 +390,7 @@ var/list/mind_ui_ID2type = list()
 	if (element_flags & MINDUI_FLAG_TOOLTIP)
 		var/mob/M = GetUser()
 		if (M)
-			//I hate this, I hate this, but somehow the tooltips won't appear in the right place unless I do this black magic
-			//this only happens with mindUI elements, but the more offset from the center the elements are, tooltips become even more offset.
-			//this code corrects this extra offset.
-			var/list/param_list = params2list(params)
-			var/screenloc = param_list["screen-loc"]
-			var/x_index = findtext(screenloc, ":", 1, 0)
-			var/comma_index = findtext(screenloc,",", x_index, 0)
-			var/y_index = findtext(screenloc,":", comma_index, 0)
-			var/x_loc = text2num(copytext(screenloc, 1, x_index))
-			var/y_loc = text2num(copytext(screenloc, comma_index+1, y_index))
-			if (x_loc <= 7)
-				x_loc = 7
-			else
-				x_loc = 9
-			if (y_loc <= 7)
-				y_loc = 7
-			else
-				y_loc = 9
 			M.client?.tooltips.show(src,mouse=params,title = tooltip_title, content=tooltip_content, theme=tooltip_theme)
-			//openToolTip(M,src,"icon-x=1;icon-y=1;screen-loc=[x_loc]:1,[y_loc]:1",title = tooltip_title,content = tooltip_content,theme = tooltip_theme)
 
 /obj/abstract/mind_ui_element/hoverable/proc/StopHovering()
 	if (hover_state)

--- a/code/_onclick/mindUI/bloodcult/draw_runes.dm
+++ b/code/_onclick/mindUI/bloodcult/draw_runes.dm
@@ -98,13 +98,42 @@
 			animate(word_overlay, alpha = 255, time = 5)
 		overlays += word_overlay
 
-/obj/abstract/mind_ui_element/hoverable/rune_word/StartHovering()
+/obj/abstract/mind_ui_element/hoverable/rune_word/StartHovering(var/location,var/control,var/params)
 	hovering = TRUE
 	UpdateIcon()
+
+	if (element_flags & MINDUI_FLAG_TOOLTIP)//copied from _mindUI.dm
+		var/mob/M = GetUser()
+		if (M)
+			//I hate this, I hate this, but somehow the tooltips won't appear in the right place unless I do this black magic
+			//this only happens with mindUI elements, but the more offset from the center the elements are, tooltips become even more offset.
+			//this code corrects this extra offset.
+			var/list/param_list = params2list(params)
+			var/screenloc = param_list["screen-loc"]
+			var/x_index = findtext(screenloc, ":", 1, 0)
+			var/comma_index = findtext(screenloc,",", x_index, 0)
+			var/y_index = findtext(screenloc,":", comma_index, 0)
+			var/x_loc = text2num(copytext(screenloc, 1, x_index))
+			var/y_loc = text2num(copytext(screenloc, comma_index+1, y_index))
+			if (x_loc <= 7)
+				x_loc = 7
+			else
+				x_loc = 9
+			if (y_loc <= 7)
+				y_loc = 7
+			else
+				y_loc = 9
+			M.client?.tooltips.show(src,mouse=params,title = tooltip_title, content=tooltip_content, theme=tooltip_theme)
+			//openToolTip(M,src,"icon-x=1;icon-y=1;screen-loc=[x_loc]:1,[y_loc]:1",title = tooltip_title,content = tooltip_content,theme = tooltip_theme)
 
 /obj/abstract/mind_ui_element/hoverable/rune_word/StopHovering()
 	hovering = FALSE
 	UpdateIcon()
+
+	if (element_flags & MINDUI_FLAG_TOOLTIP)
+		var/mob/M = GetUser()
+		if (M)
+			M.client?.tooltips.hide()
 
 ////////////////////////////////////////////////////////////////////
 //																  //
@@ -116,6 +145,7 @@
 	uniqueID = "Bloodcult Runes"
 	element_types_to_spawn = list(
 		/obj/abstract/mind_ui_element/hoverable/rune_close,
+		/obj/abstract/mind_ui_element/hoverable/rune_close_corner,
 		/obj/abstract/mind_ui_element/hoverable/rune_word/rune_travel,
 		/obj/abstract/mind_ui_element/hoverable/rune_word/rune_blood,
 		/obj/abstract/mind_ui_element/hoverable/rune_word/rune_join,
@@ -183,11 +213,43 @@
 
 //------------------------------------------------------------
 
+/obj/abstract/mind_ui_element/hoverable/rune_close_corner
+	name = "Hide Interface"
+	icon = 'icons/ui/bloodcult/32x32.dmi'
+	icon_state = "return"
+	layer = MIND_UI_BUTTON
+	offset_x = 96
+	offset_y = -76
+
+/obj/abstract/mind_ui_element/hoverable/rune_close_corner/StartHovering()
+	hovering = TRUE
+	UpdateIcon()
+
+/obj/abstract/mind_ui_element/hoverable/rune_close_corner/StopHovering()
+	hovering = FALSE
+	UpdateIcon()
+
+/obj/abstract/mind_ui_element/hoverable/rune_close_corner/Click()
+	parent.Hide()
+	var/datum/mind_ui/bloodcult_runes/P = parent
+	P.queued_rune = null
+
+/obj/abstract/mind_ui_element/hoverable/rune_close_corner/UpdateIcon()
+	overlays.len = 0
+	if (hovering)
+		overlays += "select"
+
+//------------------------------------------------------------
+
 /obj/abstract/mind_ui_element/hoverable/rune_word/rune_travel
 	name = "Travel"
 	word = "travel"
 	offset_x = -61
 	offset_y = 19
+	tooltip_title = "Travel"
+	tooltip_content = ""
+	tooltip_theme = "radial-cult"
+	element_flags = MINDUI_FLAG_TOOLTIP
 
 //------------------------------------------------------------
 
@@ -196,6 +258,10 @@
 	word = "blood"
 	offset_x = -37
 	offset_y = 52
+	tooltip_title = "Blood"
+	tooltip_content = ""
+	tooltip_theme = "radial-cult"
+	element_flags = MINDUI_FLAG_TOOLTIP
 
 //------------------------------------------------------------
 
@@ -204,6 +270,10 @@
 	word = "join"
 	offset_x = 0
 	offset_y = 64
+	tooltip_title = "Join"
+	tooltip_content = ""
+	tooltip_theme = "radial-cult"
+	element_flags = MINDUI_FLAG_TOOLTIP
 
 //------------------------------------------------------------
 
@@ -212,6 +282,10 @@
 	word = "hell"
 	offset_x = 37
 	offset_y = 52
+	tooltip_title = "Hell"
+	tooltip_content = ""
+	tooltip_theme = "radial-cult"
+	element_flags = MINDUI_FLAG_TOOLTIP
 
 //------------------------------------------------------------
 
@@ -220,6 +294,10 @@
 	word = "destroy"
 	offset_x = 61
 	offset_y = 19
+	tooltip_title = "Destroy"
+	tooltip_content = ""
+	tooltip_theme = "radial-cult"
+	element_flags = MINDUI_FLAG_TOOLTIP
 
 //------------------------------------------------------------
 
@@ -228,6 +306,10 @@
 	word = "technology"
 	offset_x = 61
 	offset_y = -19
+	tooltip_title = "Technology"
+	tooltip_content = ""
+	tooltip_theme = "radial-cult"
+	element_flags = MINDUI_FLAG_TOOLTIP
 
 //------------------------------------------------------------
 
@@ -236,6 +318,10 @@
 	word = "self"
 	offset_x = 37
 	offset_y = -52
+	tooltip_title = "Self"
+	tooltip_content = ""
+	tooltip_theme = "radial-cult"
+	element_flags = MINDUI_FLAG_TOOLTIP
 
 //------------------------------------------------------------
 
@@ -244,6 +330,10 @@
 	word = "see"
 	offset_x = 0
 	offset_y = -64
+	tooltip_title = "See"
+	tooltip_content = ""
+	tooltip_theme = "radial-cult"
+	element_flags = MINDUI_FLAG_TOOLTIP
 
 //------------------------------------------------------------
 
@@ -252,6 +342,10 @@
 	word = "other"
 	offset_x = -37
 	offset_y = -52
+	tooltip_title = "Other"
+	tooltip_content = ""
+	tooltip_theme = "radial-cult"
+	element_flags = MINDUI_FLAG_TOOLTIP
 
 //------------------------------------------------------------
 
@@ -260,5 +354,9 @@
 	word = "hide"
 	offset_x = -61
 	offset_y = -19
+	tooltip_title = "Hide"
+	tooltip_content = ""
+	tooltip_theme = "radial-cult"
+	element_flags = MINDUI_FLAG_TOOLTIP
 
 //------------------------------------------------------------

--- a/code/_onclick/mindUI/bloodcult/draw_runes.dm
+++ b/code/_onclick/mindUI/bloodcult/draw_runes.dm
@@ -105,26 +105,7 @@
 	if (element_flags & MINDUI_FLAG_TOOLTIP)//copied from _mindUI.dm
 		var/mob/M = GetUser()
 		if (M)
-			//I hate this, I hate this, but somehow the tooltips won't appear in the right place unless I do this black magic
-			//this only happens with mindUI elements, but the more offset from the center the elements are, tooltips become even more offset.
-			//this code corrects this extra offset.
-			var/list/param_list = params2list(params)
-			var/screenloc = param_list["screen-loc"]
-			var/x_index = findtext(screenloc, ":", 1, 0)
-			var/comma_index = findtext(screenloc,",", x_index, 0)
-			var/y_index = findtext(screenloc,":", comma_index, 0)
-			var/x_loc = text2num(copytext(screenloc, 1, x_index))
-			var/y_loc = text2num(copytext(screenloc, comma_index+1, y_index))
-			if (x_loc <= 7)
-				x_loc = 7
-			else
-				x_loc = 9
-			if (y_loc <= 7)
-				y_loc = 7
-			else
-				y_loc = 9
 			M.client?.tooltips.show(src,mouse=params,title = tooltip_title, content=tooltip_content, theme=tooltip_theme)
-			//openToolTip(M,src,"icon-x=1;icon-y=1;screen-loc=[x_loc]:1,[y_loc]:1",title = tooltip_title,content = tooltip_content,theme = tooltip_theme)
 
 /obj/abstract/mind_ui_element/hoverable/rune_word/StopHovering()
 	hovering = FALSE


### PR DESCRIPTION
<img width="434" height="421" alt="image" src="https://github.com/user-attachments/assets/485a23b8-240a-42ed-a76d-b6c1e6d7d4b1" />

https://github.com/user-attachments/assets/41390145-5a4f-4611-a1ae-69c7ad13c2d4

darn tooltips don't show on video unless I capture the screen

:cl:
* rscadd: Added a second close button to the rune drawing interface that isn't right on top of your character.
* rscadd: Hovering your cursor over the rune glyphs now displays a tooltip telling you their (english) name (which could already be read in the bottom left corner but many never noticed)