### PR TITLE
Fix AI State Laws window choking on doublequotes

### DIFF
--- a/code/modules/mob/living/silicon/state_laws.dm
+++ b/code/modules/mob/living/silicon/state_laws.dm
@@ -12,7 +12,7 @@
     for(var/law in to_state)
         if(!law["enabled"])
             continue
-        say("[radiokey][law["text"]]")
+        say("[radiokey][html_decode(law["text"])]")
         sleep(10)
 
 //Smelly UI code below
@@ -157,10 +157,10 @@
 		state_laws_ui.freeform = FALSE
 	if(state_laws_ui.freeform_editing_unlocked == null)
 		state_laws_ui.freeform_editing_unlocked = FALSE
-	
+
 	if(state_laws_ui.freeform == FALSE)
 		state_laws_ui.freeform_editing_unlocked = FALSE //can't edit if not in freeform mode
-	
+
 	if(state_laws_ui.radio_key == null)
 		state_laws_ui.radio_key = ""
 

--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -416,6 +416,7 @@ nanoui is used to open and update nano browser uis
 
 	var/list/send_data = get_send_data(initial_data)
 	var/initial_data_json = url_encode(json_encode(send_data))
+	initial_data_json = replacetext(initial_data_json, "+", "%20") // dont let the window show the spaces as + instead
 
 	var/url_parameters_json = json_encode(list("src" = "\ref[src]"))
 

--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -415,7 +415,7 @@ nanoui is used to open and update nano browser uis
 		template_data_json = replacetext(json_encode(templates), "'", "&#39;")
 
 	var/list/send_data = get_send_data(initial_data)
-	var/initial_data_json = replacetext(json_encode(send_data), "'", "&#39;")
+	var/initial_data_json = url_encode(json_encode(send_data))
 
 	var/url_parameters_json = json_encode(list("src" = "\ref[src]"))
 

--- a/nano/js/nano_state_manager.js
+++ b/nano/js/nano_state_manager.js
@@ -38,9 +38,10 @@ NanoStateManager = function ()
 	var init = function ()
 	{
 		// We store initialData and templateData in the body tag, it's as good a place as any
-		_data = $('body').data('initialData');
+		var rawAttr = $('body').attr('data-initial-data');
+		_data = JSON.parse(decodeURIComponent(rawAttr));
 
-		_data = parseBYOND(JSON.stringify(_data)) //Can't pass a reviver to data(), so this is the easiest way to parse the special BYOND values. Hilarious in a morbid sense.
+		_data = parseBYOND(JSON.stringify(_data)); //Can't pass a reviver to data(), so this is the easiest way to parse the special BYOND values. Hilarious in a morbid sense.
 
 		if (_data == null || !_data.hasOwnProperty('config') || !_data.hasOwnProperty('data'))
 		{


### PR DESCRIPTION
## What this does

Recently some based chad has been uploading laws to the AI that contain the humble doublequote `"` and as a result the pinnacle of software known as NanoUI completely shat the bed because doublequotes are too hard
NO MORE

NanoUI embeds jason in an HTML attribute but doublequotes inside jason would make the HTML sick. the original implementation for some reason only dealt with singlequotes (?)
the solution is to encode all the special chars inside jason before putting him in HTML then decode it on the other side, its a more general solution

is it stupid?  yes
but is it cool? no

## Why it's good & how it was tested

before:

<img width="611" height="773" alt="image" src="https://github.com/user-attachments/assets/4fe164ea-1c69-4bae-85d4-65cf5184303c" />



after:

<img width="724" height="772" alt="image" src="https://github.com/user-attachments/assets/846e07d1-440c-4600-ad36-fa3211170ed4" />


Fixes #38737
Fixes #38276 
Fixes #38051 shut up toomy its a nanoui issue
Fixes #32304 general fix covers it
Maybe #30243, report needs more investigation
Fixes #34286
Fixes #24281



## Changelog
:cl:
 * bugfix: AIs can once again state laws containing " without crashing their nanoui

