### PR TITLE
Fixes mechas, vehicles and bots being unable to open table doors.

### DIFF
--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -733,6 +733,10 @@
 		else
 			..()
 
+/obj/machinery/bot/GetAccess()
+	if(botcard)
+		return botcard.GetAccess()
+
 /obj/machinery/bot/kick_act(mob/living/H)
 	..()
 

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -93,7 +93,7 @@ var/list/poddoors = list()
 				setDensity(FALSE)
 				operating = FALSE
 
-/obj/machinery/door/poddoor/allowed(mob/M)
+/obj/machinery/door/poddoor/allowed(atom/A)
 	return 0
 
 /obj/machinery/door/poddoor/open()

--- a/code/game/machinery/doors/table.dm
+++ b/code/game/machinery/doors/table.dm
@@ -55,7 +55,7 @@
 	if(!density || operating)
 		return
 
-	var/can_enter = FALSE
+	var/can_enter = emagged
 	if(istype(user,/obj/machinery/bot))
 		var/obj/machinery/bot/bot = user
 		if(check_access(bot.botcard))
@@ -72,7 +72,7 @@
 			can_enter = TRUE
 	else if(allowed(user))
 		can_enter = TRUE
-	if(!emagged && !can_enter)
+	if(!can_enter)
 		denied()
 	else
 		open()

--- a/code/game/machinery/doors/table.dm
+++ b/code/game/machinery/doors/table.dm
@@ -55,7 +55,24 @@
 	if(!density || operating)
 		return
 
-	if(!emagged && !allowed(user))
+	var/can_enter = FALSE
+	if(istype(user,/obj/machinery/bot))
+		var/obj/machinery/bot/bot = user
+		if(check_access(bot.botcard))
+			can_enter = TRUE
+	else if(istype(user, /obj/mecha))
+		var/obj/mecha/mecha = user
+		if(mecha.occupant && allowed(mecha.occupant))
+			can_enter = TRUE
+	else if(istype(user, /obj/structure/bed/chair/vehicle))
+		var/obj/structure/bed/chair/vehicle/vehicle = user
+		if(vehicle.is_locking(/datum/locking_category/buckle/chair/vehicle, subtypes=TRUE) && allowed(vehicle.get_locked(/datum/locking_category/buckle/chair/vehicle, subtypes=TRUE)[1]))
+			if(istype(vehicle, /obj/structure/bed/chair/vehicle/firebird))
+				vehicle.forceMove(get_step(vehicle,vehicle.dir))//Firebird doesn't wait for no slowpoke door to fully open before dashing through!
+			can_enter = TRUE
+	else if(allowed(user))
+		can_enter = TRUE
+	if(!emagged && !can_enter)
 		denied()
 	else
 		open()

--- a/code/game/machinery/doors/table.dm
+++ b/code/game/machinery/doors/table.dm
@@ -54,27 +54,12 @@
 /obj/machinery/door/table/Bumped(atom/user)
 	if(!density || operating)
 		return
-
-	var/can_enter = emagged
-	if(istype(user,/obj/machinery/bot))
-		var/obj/machinery/bot/bot = user
-		if(check_access(bot.botcard))
-			can_enter = TRUE
-	else if(istype(user, /obj/mecha))
-		var/obj/mecha/mecha = user
-		if(mecha.occupant && allowed(mecha.occupant))
-			can_enter = TRUE
-	else if(istype(user, /obj/structure/bed/chair/vehicle))
-		var/obj/structure/bed/chair/vehicle/vehicle = user
-		if(vehicle.is_locking(/datum/locking_category/buckle/chair/vehicle, subtypes=TRUE) && allowed(vehicle.get_locked(/datum/locking_category/buckle/chair/vehicle, subtypes=TRUE)[1]))
-			if(istype(vehicle, /obj/structure/bed/chair/vehicle/firebird))
-				vehicle.forceMove(get_step(vehicle,vehicle.dir))//Firebird doesn't wait for no slowpoke door to fully open before dashing through!
-			can_enter = TRUE
-	else if(allowed(user))
-		can_enter = TRUE
-	if(!can_enter)
+	if(!allowed(user) && !emagged)
 		denied()
 	else
+		if(istype(user, /obj/structure/bed/chair/vehicle/firebird))
+			var/obj/structure/bed/chair/vehicle/firebird/F = user
+			F.forceMove(get_step(F,F.dir))//Firebird doesn't wait for no slowpoke door to fully open before dashing through!
 		open()
 		spawn(2 SECONDS)
 			close()

--- a/code/game/machinery/doors/table.dm
+++ b/code/game/machinery/doors/table.dm
@@ -54,7 +54,7 @@
 /obj/machinery/door/table/Bumped(atom/user)
 	if(!density || operating)
 		return
-	if(!allowed(user) && !emagged)
+	if(!emagged && !allowed(user))
 		denied()
 	else
 		if(istype(user, /obj/structure/bed/chair/vehicle/firebird))

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -75,38 +75,15 @@
 		to_chat(user, "It is a secure windoor. It's stronger and closes more quickly.")
 
 /obj/machinery/door/window/Bumped(atom/movable/AM)
-	var/sleeptime = normalspeed ? 50 : 20 // secure doors close faster
-	if(!ismob(AM))
-		var/obj/machinery/bot/bot = AM
-		if(istype(bot))
-			if(density && check_access(bot.botcard))
-				open()
-				sleep(sleeptime)
-				close()
-		else if(istype(AM, /obj/mecha))
-			var/obj/mecha/mecha = AM
-			if(density)
-				if(mecha.occupant && allowed(mecha.occupant))
-					open()
-					sleep(sleeptime)
-					close()
-		else if(istype(AM, /obj/structure/bed/chair/vehicle))
-			var/obj/structure/bed/chair/vehicle/vehicle = AM
-			if(density)
-				if(vehicle.is_locking(/datum/locking_category/buckle/chair/vehicle, subtypes=TRUE) && !operating && allowed(vehicle.get_locked(/datum/locking_category/buckle/chair/vehicle, subtypes=TRUE)[1]))
-					if(istype(vehicle, /obj/structure/bed/chair/vehicle/firebird))
-						vehicle.forceMove(get_step(vehicle,vehicle.dir))//Firebird doesn't wait for no slowpoke door to fully open before dashing through!
-					open()
-					spawn(sleeptime)
-						close()
-				else if(!operating)
-					denied()
-		return
 	if(!(ticker))
 		return
 	if(operating)
 		return
 	if(density && allowed(AM))
+		var/sleeptime = normalspeed ? 50 : 20 // secure doors close faster
+		if(istype(AM, /obj/structure/bed/chair/vehicle/firebird))
+			var/obj/structure/bed/chair/vehicle/firebird/F = AM
+			F.forceMove(get_step(F,F.dir))//Firebird doesn't wait for no slowpoke door to fully open before dashing through!
 		open()
 		spawn(sleeptime)
 			close()
@@ -233,7 +210,7 @@
 	if(operating)
 		return
 	var/dmg=0
-	if(istype(user,/mob/living/simple_animal))	
+	if(istype(user,/mob/living/simple_animal))
 		var/mob/living/simple_animal/M = user
 		if(M.melee_damage_upper <= 0)
 			return

--- a/code/game/objects/items/policetape.dm
+++ b/code/game/objects/items/policetape.dm
@@ -234,7 +234,8 @@
 		var/mob/living/silicon/robot/R = A
 		return HAS_MODULE_QUIRK(R, robot_compatibility)
 
-	return ..()
+	if(ismob(A)) // this line was added for atomicity to keep a PR related to bugfixes, remove this if you'd like to see secbots be able to cross this
+		return ..()
 
 /obj/item/tape/attack_paw(mob/user as mob)
 	breaktape(null,user, TRUE)

--- a/code/game/objects/items/policetape.dm
+++ b/code/game/objects/items/policetape.dm
@@ -229,9 +229,9 @@
 	if(Adjacent(user))
 		return attack_hand(user)
 
-/obj/item/tape/allowed(mob/user)
-	if(isrobot(user) && !isMoMMI(user))
-		var/mob/living/silicon/robot/R = user
+/obj/item/tape/allowed(atom/A)
+	if(isrobot(A) && !isMoMMI(A))
+		var/mob/living/silicon/robot/R = A
 		return HAS_MODULE_QUIRK(R, robot_compatibility)
 
 	return ..()

--- a/code/game/objects/structures/vehicles/vehicle.dm
+++ b/code/game/objects/structures/vehicles/vehicle.dm
@@ -435,6 +435,11 @@
 	// Transfer salvagables here.
 	return
 
+/obj/structure/bed/chair/vehicle/GetAccess()
+	if(is_locking(/datum/locking_category/buckle/chair/vehicle, subtypes=TRUE))
+		var/atom/locked = get_locked(/datum/locking_category/buckle/chair/vehicle, subtypes=TRUE)[1]
+		return locked.GetAccess()
+
 /obj/structure/bed/chair/vehicle/to_bump(var/atom/movable/obstacle)
 	if(obstacle == src || (is_locking(/datum/locking_category/buckle/chair/vehicle, subtypes=TRUE) && obstacle == get_locked(/datum/locking_category/buckle/chair/vehicle, subtypes=TRUE)[1]))
 		return

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -112,30 +112,30 @@
 /obj/var/access_not_dir = TRUE			// Behaviour if the user is not in the access dir
 
 //returns 1 if this mob has sufficient access to use this object
-/obj/proc/allowed(var/mob/M)
+/obj/proc/allowed(var/atom/A)
 	set_up_access()
-	if(!M || !istype(M))
+	if(!A || !istype(A))
 		return 0 // I guess?  This seems to happen when AIs use something.
-	if(M.hasFullAccess()) // AI, adminghosts, etc.
+	if(A.hasFullAccess()) // AI, adminghosts, etc.
 		return 1
-	var/list/ACL = M.GetAccess()
+	var/list/ACL = A.GetAccess()
 	if(req_access_dir)
 		// A special check that combines dirs specified in this number by chaining the conditions below, for example NORTHEAST would add the north and east conditions together.
 		var/condition = FALSE
 		if((flow_flags & ON_BORDER) && opposite_dirs[req_access_dir] & dir) // For windoors and etc.
-			condition |= M.y == src.y && M.x == src.x
+			condition |= A.y == src.y && A.x == src.x
 		if(req_access_dir & NORTH)
-			condition |= M.y > src.y
+			condition |= A.y > src.y
 		if(req_access_dir & SOUTH)
-			condition |= M.y < src.y
+			condition |= A.y < src.y
 		if(req_access_dir & EAST)
-			condition |= M.x > src.x
+			condition |= A.x > src.x
 		if(req_access_dir & WEST)
-			condition |= M.x < src.x
+			condition |= A.x < src.x
 		if(HasAbove(z) && (req_access_dir & UP))
-			condition |= M.z > src.z
+			condition |= A.z > src.z
 		if(HasBelow(z) && (req_access_dir & DOWN))
-			condition |= M.z < src.z
+			condition |= A.z < src.z
 		if(condition)
 			return can_access(ACL,req_access,req_one_access)
 		else
@@ -155,7 +155,14 @@
 	..()
 	arcane_access.Cut()
 
-/obj/item/proc/GetAccess()
+// Skip over all the complex list checks.
+/atom/proc/hasFullAccess()
+	return 0
+
+/atom/proc/GetAccess()
+	return
+
+/obj/item/GetAccess()
 	if(arcanetampered)
 		if(!arcane_access || !arcane_access.len || (time_since_last_random_access + (30 SECONDS) < world.time))
 			for(var/i in 1 to rand(1,5))

--- a/code/modules/mecha/mecha.dm
+++ b/code/modules/mecha/mecha.dm
@@ -1621,6 +1621,9 @@
 				return 1
 	return 1
 
+/obj/mecha/GetAccess()
+	if(occupant)
+		return occupant.GetAccess()
 
 ////////////////////////////////////
 ///// Rendering stats window ///////

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -943,17 +943,17 @@
 		if(I_DISARM)
 			disarm_mob(user)
 
-/mob/living/silicon/robot/proc/allowed(mob/M)
+/mob/living/silicon/robot/proc/allowed(atom/A)
 	//check if it doesn't require any access at all
 	if(check_access(null))
 		return TRUE
-	if(istype(M, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = M
+	if(istype(A, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = A
 		//if they are holding or wearing a card that has access, that works
 		if(check_access(H.get_active_hand()) || check_access(H.wear_id))
 			return TRUE
-	else if(istype(M, /mob/living/carbon/monkey))
-		var/mob/living/carbon/monkey/george = M
+	else if(istype(A, /mob/living/carbon/monkey))
+		var/mob/living/carbon/monkey/george = A
 		//they can only hold things :(
 		if(istype(george.get_active_hand(), /obj/item))
 			return check_access(george.get_active_hand())

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1798,14 +1798,10 @@ Use this proc preferably at the end of an equipment loadout
 	return 1
 
 // Mobs tell access what access levels it has.
-/mob/proc/GetAccess()
+/mob/GetAccess()
 	return list()
 
 /mob/proc/get_visible_id()
-	return 0
-
-// Skip over all the complex list checks.
-/mob/proc/hasFullAccess()
 	return 0
 
 /mob/proc/assess_threat()

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -214,7 +214,7 @@ var/global/list/all_access_list = list()
 		to_chat(world, "<font size=4 color='red'>Attention!</font>")
 		to_chat(world, "<span class='red'>The [get_access_desc_list(accesses)] access requirement has been readded on all airlocks.</span>")
 
-/obj/machinery/door/airlock/allowed(mob/M)
+/obj/machinery/door/airlock/allowed(atom/A)
 	if(check_access_list(all_access_list))
 		return 1
-	return ..(M)
+	return ..(A)


### PR DESCRIPTION
[bugfix]

## What this does
Closes #38853.
Reformats GetAccess() to work on any atom, not just mobs and items. Implements this proc on bots, mechas and vehicles to get relevant accesses.

## How it was tested
Setting table door access to engineering, dragging a floorbot onto it, and bumping into it as a captain in a firebird, janicart, and H.O.N.K.

## Changelog
:cl:
 * bugfix: Table doors can now check access from bots, mechas and vehicles.