### PR TITLE
Fixes mounted frames popping off the walls when shuttles depart/land

### DIFF
--- a/code/datums/shuttle.dm
+++ b/code/datums/shuttle.dm
@@ -416,7 +416,6 @@
 						P.shoot_exhaust()
 			for(var/atom/A in linked_area.contents)
 				animate(A)
-				A.pixel_y = initial(A.pixel_y)
 				if(istype(A,/mob/living))
 					var/mob/living/M = A
 					M << sound("sound/machines/hyperspace_progress.ogg", repeat = 0, wait = 1, channel = CHANNEL_AMBIENCE, volume = 75)
@@ -483,10 +482,11 @@
 					break
 		if(skip)
 			continue
-		var/base_y = initial(A.pixel_y) + 5
+		var/base_y = A.pixel_y + 5
 		animate(A, pixel_y = base_y, time = 5, easing = SINE_EASING | EASE_OUT)
 		animate(pixel_y = base_y + variation, time = 10, easing = SINE_EASING, loop = -1)
 		animate(pixel_y = base_y - variation, time = 10, easing = SINE_EASING)
+		A.pixel_y = base_y - 5
 
 /datum/shuttle/proc/animate_landing()
 	for(var/atom/A in linked_area.contents)
@@ -502,8 +502,8 @@
 					break
 		if(skip)
 			continue
-		A.pixel_y = 5
-		animate(A, pixel_y = initial(A.pixel_y), time = 10, easing = SINE_EASING|EASE_OUT)
+		A.pixel_y += 5
+		animate(A, pixel_y = A.pixel_y - 5, time = 10, easing = SINE_EASING|EASE_OUT)
 	spawn(15)
 		reset_visuals()
 
@@ -513,7 +513,6 @@
 			var/obj/structure/shuttle/engine/heater/H = A
 			H.deactivate()
 		animate(A)
-		A.pixel_y = initial(A.pixel_y)
 
 //This is the proc you want to use to FORCE a shuttle to move. It always moves it, unless the shuttle or its area don't exist. Transit is skipped, after_flight() is called
 /datum/shuttle/proc/move_to_dock(var/obj/docking_port/D, var/ignore_innacuracy = 0, var/rotate_after = 0) //A direct proc with no bullshit
@@ -1306,7 +1305,7 @@
 	var/y_min = bounds["y_min"]
 
 	// Create matrix with relative coordinates
-	var/datum/turf_matrix[SECTOR_SIZE][SECTOR_SIZE]
+	var/turf_matrix[SECTOR_SIZE][SECTOR_SIZE]
 	for(var/turf/T in search_turfs)
 		var/rel_x = T.x - x_min + 1
 		var/rel_y = T.y - y_min + 1


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Removes the initial(pixel_x/y) portion of the shuttle animations to prevent wall-mounted things from appearing on the wrong turf since they may have their pixel offset set in New(). Also fixed a linter fail in shuttles.dm.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Closes #38824.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Flew the Vox shuttle to and from the station multiple times and didn't notice anything falling off or any offsets stacking up incorrectly.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed things falling off shuttle walls when taking off or landing.
