### PR TITLE
Stops ending the world if a crystal explodes offstation

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -4111,6 +4111,10 @@ access_sec_doors,access_salvage_captain,access_cent_ert,access_syndicate,access_
 				feedback_add_details("admin_secrets_fun_used","SC")
 				var/choice = input("You sure you want to destroy the universe and create a large explosion at your location? Misuse of this could result in removal of flags or hilarity.") in list("NO TIME TO EXPLAIN", "Cancel")
 				if(choice == "NO TIME TO EXPLAIN")
+					var/turf/T = get_turf(usr)
+					if(T.z != map.zMainStation)
+						to_chat(usr, "You must be on the main station z to do this.")
+						return
 					explosion(get_turf(usr), 8, 16, 24, 32, 1, whodunnit = usr)
 					new /turf/unsimulated/wall/supermatter(get_turf(usr))
 					SetUniversalState(/datum/universal_state/supermatter_cascade)

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -145,8 +145,9 @@
 	if (has_exploded <= 1)
 		if(!istype(universe,/datum/universal_state/supermatter_cascade))
 			var/turf/turff = get_turf(src)
-			new /turf/unsimulated/wall/supermatter(turff)
-			SetUniversalState(/datum/universal_state/supermatter_cascade)
+			if(turff.z == map.zMainStation)
+				new /turf/unsimulated/wall/supermatter(turff)
+				SetUniversalState(/datum/universal_state/supermatter_cascade)
 			explosion(turff, explosion_power, explosion_power * 2, explosion_power * 3, explosion_power * 4, 1, whodunnit = user)
 			empulse(turff, 100, 200, 1)
 
@@ -209,10 +210,12 @@
 	if(src.fingerprintshidden)
 		prints = ", all touchers: [list2params(src.fingerprintshidden)]"
 	if(current_size == STAGE_SUPER) // and this is to go even further beyond
-		if(!istype(universe,/datum/universal_state/supermatter_cascade))
-			SetUniversalState(/datum/universal_state/supermatter_cascade)
-		S.expand(STAGE_SSGSS, 1)
-		ssgss = TRUE
+		var/turf/T = get_turf(src)
+		if(T.z == map.zMainStation) // no SSGGSSes offstation
+			if(!istype(universe,/datum/universal_state/supermatter_cascade))
+				SetUniversalState(/datum/universal_state/supermatter_cascade)
+			S.expand(STAGE_SSGSS, 1)
+			ssgss = TRUE
 	log_admin("[ssgss ? "New SSGSS made" : "Singularity gained 20000 energy"] by eating a SM crystal with prints: [prints]. Last touched by [src.fingerprintslast].")
 	message_admins("[ssgss ? "New SSGSS made" : "Singularity gained 20000 energy"] by eating a SM crystal with prints: [prints]. Last touched by [src.fingerprintslast].")
 	qdel(src)
@@ -308,7 +311,7 @@
 	var/datum/gas_mixture/removed = env.remove_volume(gasefficency * CELL_VOLUME)
 
 	var/radonenergyfactor=1.0+removed[GAS_RADON]*RADON_EXCITATION_FACTOR //wowza power. prepare your butts for delams.
-	
+
 	var/cryoheatdamping = 1/((removed[GAS_CRYOTHEUM]/CRYOTHEUM_DAMPING_FACTOR)+1)
 
 	power+=emitterpower*radonenergyfactor //radon affects emitter power (as well as temp+atmos related power gen.)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Stops Supermatter Crystal delamination creating a cascade and ending the world if it's detonated off-station. This causes an awkward five minute wait for the round to end despite everything being perfectly fine stationside.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Consistency. Closes #38864.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
- Detonated a crystal on the station and welcomed oblivion.
- Detonated a crystal on a planet and enjoyed a nice non-world-ending explosion.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed supermatter crystal explosions ending the world while offstation.