### PR TITLE
Removes supermatter shards and crystals from procgen loot pool

### DIFF
--- a/code/modules/procedural mapping/loot.dm
+++ b/code/modules/procedural mapping/loot.dm
@@ -385,7 +385,6 @@
 			/obj/structure/crystal,
 			/obj/item/clothing/under/grey/grey_soldier,
 			/obj/item/clothing/under/grey/grey_researcher,
-			/obj/machinery/power/supermatter/shard,
 			/obj/item/weapon/grenade/dudebomb,
 		),
 		VERY_RARE_LOOT = list(
@@ -398,7 +397,6 @@
 			/obj/machinery/auto_cloner,
 			/obj/machinery/communication,
 			/obj/machinery/replicator,
-			/obj/machinery/power/supermatter,
 		)
 	)
 


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Title

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Stops people from fairly easily getting their hands on weapons of mass destruction

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
0%

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Removed supermatter shards and crystals from the procgen loot pool