### PR TITLE
Allows bots, vehicles and mechas to cross tape with access

### DIFF
--- a/code/game/objects/items/policetape.dm
+++ b/code/game/objects/items/policetape.dm
@@ -194,7 +194,7 @@
 	if(allowed(AM))
 		var/turf/T = get_turf(src)
 		for(var/atom/A in T) //Check to see if there's anything solid on the tape's turf (it's possible to build on it)
-			if(A != AM && A.density)
+			if(A.density && A != AM)
 				return
 		if (T) // no sending things into nullspace!
 			AM.forceMove(T)

--- a/code/game/objects/items/policetape.dm
+++ b/code/game/objects/items/policetape.dm
@@ -190,12 +190,21 @@
 		return FALSE
 	return TRUE
 
+/obj/item/tape/Bumped(var/atom/movable/AM)
+	if(allowed(AM))
+		var/turf/T = get_turf(src)
+		for(var/atom/A in T) //Check to see if there's anything solid on the tape's turf (it's possible to build on it)
+			if(A.density && A != AM)
+				return
+		if (T) // no sending things into nullspace!
+			AM.forceMove(T)
+
 /obj/item/tape/Cross(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
 	if(!density)
 		return 1
 	if(air_group || (height == 0))
 		return 1
-	if(mover.checkpass(pass_flags_self) || istype(mover, /obj/item/projectile/meteor) || mover.throwing == 1 || allowed(mover))
+	if((mover.checkpass(pass_flags_self) || istype(mover, /obj/item/projectile/meteor) || mover.throwing == 1))
 		return 1
 	else
 		return 0

--- a/code/game/objects/items/policetape.dm
+++ b/code/game/objects/items/policetape.dm
@@ -190,21 +190,12 @@
 		return FALSE
 	return TRUE
 
-/obj/item/tape/Bumped(var/atom/movable/AM)
-	if(allowed(AM))
-		var/turf/T = get_turf(src)
-		for(var/atom/A in T) //Check to see if there's anything solid on the tape's turf (it's possible to build on it)
-			if(A.density && A != AM)
-				return
-		if (T) // no sending things into nullspace!
-			AM.forceMove(T)
-
 /obj/item/tape/Cross(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
 	if(!density)
 		return 1
 	if(air_group || (height == 0))
 		return 1
-	if((mover.checkpass(pass_flags_self) || istype(mover, /obj/item/projectile/meteor) || mover.throwing == 1))
+	if(mover.checkpass(pass_flags_self) || istype(mover, /obj/item/projectile/meteor) || mover.throwing == 1 || allowed(mover))
 		return 1
 	else
 		return 0

--- a/code/game/objects/items/policetape.dm
+++ b/code/game/objects/items/policetape.dm
@@ -194,7 +194,7 @@
 	if(allowed(AM))
 		var/turf/T = get_turf(src)
 		for(var/atom/A in T) //Check to see if there's anything solid on the tape's turf (it's possible to build on it)
-			if(A.density)
+			if(A != AM && A.density)
 				return
 		if (T) // no sending things into nullspace!
 			AM.forceMove(T)

--- a/code/game/objects/items/policetape.dm
+++ b/code/game/objects/items/policetape.dm
@@ -234,8 +234,7 @@
 		var/mob/living/silicon/robot/R = A
 		return HAS_MODULE_QUIRK(R, robot_compatibility)
 
-	if(ismob(A)) // this line was added for atomicity to keep a PR related to bugfixes, remove this if you'd like to see secbots be able to cross this
-		return ..()
+	return ..()
 
 /obj/item/tape/attack_paw(mob/user as mob)
 	breaktape(null,user, TRUE)

--- a/code/game/objects/items/policetape.dm
+++ b/code/game/objects/items/policetape.dm
@@ -194,7 +194,7 @@
 	if(allowed(AM))
 		var/turf/T = get_turf(src)
 		for(var/atom/A in T) //Check to see if there's anything solid on the tape's turf (it's possible to build on it)
-			if(A.density && A != AM)
+			if(A.density)
 				return
 		if (T) // no sending things into nullspace!
 			AM.forceMove(T)


### PR DESCRIPTION
[tweak]

## What this does
Removes the line of code I added to stop them doing this to keep the last PR to just a bugfix.
In draft until #38870 is merged.

## Why it's good
[consistency]

## How it was tested
Crossing the tape in a mecha and gokart with and without ID. Dragging a secbot and floorbot through police tape.

## Changelog
:cl:
 * tweak: Bots, mechas, and vehicles with valid access can now cross tape with valid access.