### PR TITLE
Fixed instant blindness + Adjusted eye_blind values across the board to account for the new behaviour

### DIFF
--- a/__DEFINES/planes+masters.dm
+++ b/__DEFINES/planes+masters.dm
@@ -255,6 +255,17 @@ var/static/impaired_scale = list(40, 40, 40, 20, 16, 12, 9, 6, 3, 1)
 /mob
 	var/filter_update_delay = -1//This prevents crashes!! Don't ask me why...
 
+//use when setting eye_blind if you want your mob to be immediately blinded without waiting for enable_nearsightedness() and animate() to do their job
+//remember that only _blind values of 10 and above cover the whole screen.
+/mob/living/proc/instant_blindness(var/_blind)
+	eye_blind = max(eye_blind, _blind)
+
+	var/_modifiers	= get_impaired_vision_modifiers()
+	if (_modifiers[1] > 0)//only do the thing if our mob actually can get blinded
+		overlay_fullscreen("blind", /obj/abstract/screen/fullscreen/blind)
+		spawn(20)
+		clear_fullscreen("blind")
+
 /mob/proc/enable_nearsightedness(var/_severity, var/_animate = TRUE)//actually handles blindess too
 	perception_filters.enabled_filters |= P_FILTER_IMPAIRED_VISION
 

--- a/__DEFINES/planes+masters.dm
+++ b/__DEFINES/planes+masters.dm
@@ -263,7 +263,7 @@ var/static/impaired_scale = list(40, 40, 40, 20, 16, 12, 9, 6, 3, 1)
 	var/_modifiers	= get_impaired_vision_modifiers()
 	if (_modifiers[1] > 0)//only do the thing if our mob actually can get blinded
 		overlay_fullscreen("blind", /obj/abstract/screen/fullscreen/blind)
-		spawn(20)
+		spawn(40)
 		clear_fullscreen("blind")
 
 /mob/proc/enable_nearsightedness(var/_severity, var/_animate = TRUE)//actually handles blindess too

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -122,7 +122,7 @@
 	icon = 'icons/mob/screen1.dmi'
 	screen_loc = "WEST,SOUTH to EAST,NORTH"
 	icon_state = "blurry"
-	alpha = 0//set to 255 by update_fullscreen_alpha();
+	//alpha = 0//set to 255 by update_fullscreen_alpha(); //not anymore, currently only used when getting pie'd
 
 /obj/abstract/screen/fullscreen/nearsighted
 	icon = 'icons/mob/screen1_blindness.dmi'

--- a/code/game/gamemodes/wizard/spellbook_oneuse.dm
+++ b/code/game/gamemodes/wizard/spellbook_oneuse.dm
@@ -81,10 +81,10 @@
 	icon_state ="bookblind"
 	desc = "This book looks blurry, no matter how you look at it."
 
-/obj/item/weapon/spellbook/oneuse/blind/recoil(mob/user)
+/obj/item/weapon/spellbook/oneuse/blind/recoil(mob/living/user)
 	..()
 	to_chat(user, "<span class='warning'>You go blind!</span>")
-	user.eye_blind = 10
+	user.instant_blindness(20)
 
 /obj/item/weapon/spellbook/oneuse/mindswap
 	spell = /spell/targeted/mind_transfer

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -383,7 +383,7 @@
 		var/mob/living/carbon/human/M = src.loc
 		to_chat(M, "<span class='warning'>\The [src] overloads and blinds you!</span>")
 		if(M.glasses == src)
-			M.eye_blind = 3
+			M.instant_blindness(13)
 			M.eye_blurry = 5
 			M.disabilities |= NEARSIGHTED
 			spawn(100)

--- a/code/modules/organs/internal/eyes/eyes.dm
+++ b/code/modules/organs/internal/eyes/eyes.dm
@@ -20,7 +20,7 @@
 
 /datum/organ/internal/eyes/process() //Eye damage replaces the old eye_stat var.
 	if(is_broken())
-		owner.eye_blind = max(2, owner.eye_blind)
+		owner.eye_blind = max(12, owner.eye_blind)
 //	if(is_bruised())
 //		owner.eye_blurry = max(2, owner.eye_blurry)
 //  stop eyeblur because we're already shortening the vision

--- a/code/modules/paperwork/paper_folded.dm
+++ b/code/modules/paperwork/paper_folded.dm
@@ -117,14 +117,14 @@
 				if (src.nano)
 					to_chat(H, "<span class='warning'>OW! Something sharp stabs your [pick("right","left")] eye!</span>")
 					H.eye_blurry = max(H.eye_blurry, rand(10,15))
-					H.eye_blind = max(H.eye_blind, 2)
+					H.instant_blindness(12)
 					H.Stun(2)
 					var/datum/organ/internal/eyes/eyes = H.internal_organs_by_name["eyes"]
 					eyes.damage += 3
 				else
 					to_chat(H, "<span class='warning'>\The [src] flies right into your [pick("right","left")] eye!</span>")
 					H.eye_blurry = max(H.eye_blurry, rand(3,6))
-					H.eye_blind = max(H.eye_blind, src.nano)
+					H.instant_blindness(11)
 //at last, my block at a rest, bereft of all mortal doubts, I have been enlightened, touched by the sage wisdom, my undying gratitude goes to Comic in this emotional moment
 /obj/item/weapon/p_folded/plane/throw_at(var/atom/A, throw_range, throw_speed)
 	if (A.x > src.x)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1972,7 +1972,7 @@
 	if(..())
 		return
 	if(isliving(hit_atom))
-		var/mob/M = hit_atom
+		var/mob/living/M = hit_atom
 		src.visible_message("<span class='warning'>\The [src] splats in [M]'s face!</span>")
 
 		var/race_prefix = ""

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1989,10 +1989,10 @@
 
 		M.overlays += image('icons/mob/messiness.dmi',icon_state = "[race_prefix]pied")
 		sleep(55)
-		M.clear_fullscreen("blurry")
 		M.overlays -= image('icons/mob/messiness.dmi',icon_state = "[race_prefix]pied")
 		M.overlays += image('icons/mob/messiness.dmi',icon_state = "[race_prefix]pied-2")
 		sleep(120)
+		M.clear_fullscreen("blurry")
 		M.overlays -= image('icons/mob/messiness.dmi',icon_state = "[race_prefix]pied-2")
 
 		if(luckiness)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1971,7 +1971,7 @@
 	set waitfor = FALSE
 	if(..())
 		return
-	if(ismob(hit_atom))
+	if(isliving(hit_atom))
 		var/mob/M = hit_atom
 		src.visible_message("<span class='warning'>\The [src] splats in [M]'s face!</span>")
 
@@ -1983,13 +1983,13 @@
 		else if (isinsectoid(M))
 			race_prefix = "insect"
 
-		M.eye_blind = 12
+		M.instant_blindness(12)
 
-		overlay_fullscreen("blurry", /obj/abstract/screen/fullscreen/blurry)//cumvision
+		M.overlay_fullscreen("blurry", /obj/abstract/screen/fullscreen/blurry)//cumvision
 
 		M.overlays += image('icons/mob/messiness.dmi',icon_state = "[race_prefix]pied")
 		sleep(55)
-		clear_fullscreen("blurry")
+		M.clear_fullscreen("blurry")
 		M.overlays -= image('icons/mob/messiness.dmi',icon_state = "[race_prefix]pied")
 		M.overlays += image('icons/mob/messiness.dmi',icon_state = "[race_prefix]pied-2")
 		sleep(120)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1983,9 +1983,13 @@
 		else if (isinsectoid(M))
 			race_prefix = "insect"
 
-		M.eye_blind = 2
+		M.eye_blind = 12
+
+		overlay_fullscreen("blurry", /obj/abstract/screen/fullscreen/blurry)//cumvision
+
 		M.overlays += image('icons/mob/messiness.dmi',icon_state = "[race_prefix]pied")
 		sleep(55)
+		clear_fullscreen("blurry")
 		M.overlays -= image('icons/mob/messiness.dmi',icon_state = "[race_prefix]pied")
 		M.overlays += image('icons/mob/messiness.dmi',icon_state = "[race_prefix]pied-2")
 		sleep(120)

--- a/code/modules/reagents/reagents/reagents_food.dm
+++ b/code/modules/reagents/reagents/reagents_food.dm
@@ -185,7 +185,7 @@
 		else if(mouth_covered)	//Reduced effects if partially protected
 			H << "<span class='warning'>Your [mouth_covered] protects your mouth from the pepperspray!</span>"
 			H.eye_blurry = max(M.eye_blurry, 15)
-			H.eye_blind = max(M.eye_blind, 15)
+			H.instant_blindness(15)
 			H.Paralyse(1)
 			H.drop_item()
 			return

--- a/code/modules/reagents/reagents/reagents_food.dm
+++ b/code/modules/reagents/reagents/reagents_food.dm
@@ -185,7 +185,7 @@
 		else if(mouth_covered)	//Reduced effects if partially protected
 			H << "<span class='warning'>Your [mouth_covered] protects your mouth from the pepperspray!</span>"
 			H.eye_blurry = max(M.eye_blurry, 15)
-			H.eye_blind = max(M.eye_blind, 5)
+			H.eye_blind = max(M.eye_blind, 15)
 			H.Paralyse(1)
 			H.drop_item()
 			return
@@ -198,7 +198,7 @@
 			H.audible_scream()
 			to_chat(H, "<span class='danger'>You are sprayed directly in the eyes with pepperspray!</span>")
 			H.eye_blurry = max(M.eye_blurry, 25)
-			H.eye_blind = max(M.eye_blind, 10)
+			H.eye_blind = max(M.eye_blind, 20)
 			H.Paralyse(1)
 			H.drop_item()
 
@@ -208,7 +208,7 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		H.eye_blurry = max(M.eye_blurry, 25)
-		H.eye_blind = max(M.eye_blind, 10)
+		H.eye_blind = max(M.eye_blind, 20)
 		H.Paralyse(1)
 		H.drop_item()
 	return ..()

--- a/code/modules/reagents/reagents/reagents_material.dm
+++ b/code/modules/reagents/reagents/reagents_material.dm
@@ -137,7 +137,7 @@
 			H.visible_message("<span class='warning'>[H] is blinded by the [src]!</span>", \
 				"<span class='warning'>\The [src] flies into your eyes!</span>")
 			H.eye_blurry = max(H.eye_blurry, rand(3,8))
-			H.eye_blind = max(H.eye_blind, rand(11,13))
+			H.instant_blindness(rand(11,13))
 			H.drop_hands(get_turf(H))
 		log_attack("<font color='red'>[M] ([H ? H.ckey : "what"]) was pocketsanded by ([holder.my_atom.fingerprintslast])</font>")
 	M.extinguish()

--- a/code/modules/reagents/reagents/reagents_material.dm
+++ b/code/modules/reagents/reagents/reagents_material.dm
@@ -137,7 +137,7 @@
 			H.visible_message("<span class='warning'>[H] is blinded by the [src]!</span>", \
 				"<span class='warning'>\The [src] flies into your eyes!</span>")
 			H.eye_blurry = max(H.eye_blurry, rand(3,8))
-			H.eye_blind = max(H.eye_blind, rand(1,3))
+			H.eye_blind = max(H.eye_blind, rand(11,13))
 			H.drop_hands(get_turf(H))
 		log_attack("<font color='red'>[M] ([H ? H.ckey : "what"]) was pocketsanded by ([holder.my_atom.fingerprintslast])</font>")
 	M.extinguish()

--- a/code/modules/reagents/reagents/reagents_tools.dm
+++ b/code/modules/reagents/reagents/reagents_tools.dm
@@ -484,7 +484,7 @@
 				H.audible_scream()
 				to_chat(H,"<span class='danger'>You are sprayed directly in the eyes with bleach!</span>")
 				H.eye_blurry = max(M.eye_blurry, 15)
-				H.eye_blind = max(M.eye_blind, 15)
+				H.instant_blindness(15)
 				H.adjustBruteLoss(2)
 				var/datum/organ/internal/eyes/E = H.internal_organs_by_name["eyes"]
 				E.take_damage(5, 1)

--- a/code/modules/reagents/reagents/reagents_tools.dm
+++ b/code/modules/reagents/reagents/reagents_tools.dm
@@ -484,7 +484,7 @@
 				H.audible_scream()
 				to_chat(H,"<span class='danger'>You are sprayed directly in the eyes with bleach!</span>")
 				H.eye_blurry = max(M.eye_blurry, 15)
-				H.eye_blind = max(M.eye_blind, 5)
+				H.eye_blind = max(M.eye_blind, 15)
 				H.adjustBruteLoss(2)
 				var/datum/organ/internal/eyes/E = H.internal_organs_by_name["eyes"]
 				E.take_damage(5, 1)

--- a/code/modules/spells/changeling/stings/blind.dm
+++ b/code/modules/spells/changeling/stings/blind.dm
@@ -13,7 +13,7 @@
 
 	if(target.disabilities & NEARSIGHTED)
 		to_chat(target, "<span class='userdanger'>Your eyes burn terribly!</span>")
-		target.eye_blind = 10
+		target.eye_blind = 20
 		target.eye_blurry = 20
 		return
 
@@ -22,6 +22,6 @@
 	spawn(300)
 		target.disabilities &= ~NEARSIGHTED
 
-	target.eye_blind = 10
+	target.eye_blind = 20
 	target.eye_blurry = 20
 	feedback_add_details("changeling_powers", "BS")

--- a/code/modules/spells/changeling/stings/blind.dm
+++ b/code/modules/spells/changeling/stings/blind.dm
@@ -13,7 +13,7 @@
 
 	if(target.disabilities & NEARSIGHTED)
 		to_chat(target, "<span class='userdanger'>Your eyes burn terribly!</span>")
-		target.eye_blind = 20
+		target.instant_blindness(20)
 		target.eye_blurry = 20
 		return
 
@@ -22,6 +22,6 @@
 	spawn(300)
 		target.disabilities &= ~NEARSIGHTED
 
-	target.eye_blind = 20
+	target.instant_blindness(20)
 	target.eye_blurry = 20
 	feedback_add_details("changeling_powers", "BS")

--- a/code/modules/spells/targeted/genetic.dm
+++ b/code/modules/spells/targeted/genetic.dm
@@ -53,7 +53,7 @@ code\game\\dna\genes\goon_powers.dm
 	range = 7
 	max_targets = 1
 
-	amt_eye_blind = 10
+	amt_eye_blind = 20
 	amt_eye_blurry = 20
 
 	hud_state = "wiz_blind"

--- a/code/modules/spells/targeted/targeted.dm
+++ b/code/modules/spells/targeted/targeted.dm
@@ -198,7 +198,8 @@ Targeted spells have two useful flags: INCLUDEUSER and SELECTABLE. These are exp
 	target.AdjustStunned(amt_stunned)
 	if(amt_knockdown || amt_paralysis || amt_stunned)
 		target.unlock_from()
-	target.eye_blind += amt_eye_blind
+	if (amt_eye_blind > 0)
+		target.instant_blindness(amt_eye_blind)
 	target.eye_blurry += amt_eye_blurry
 	target.dizziness += amt_dizziness
 	target.confused += amt_confused

--- a/code/modules/virus2/effect/stage_2.dm
+++ b/code/modules/virus2/effect/stage_2.dm
@@ -39,8 +39,8 @@
 	encyclopedia = "Turning them blind for a few seconds."
 	stage = 2
 	badness = EFFECT_DANGER_HINDRANCE
-	multiplier = 4
-	max_multiplier = 10
+	multiplier = 10
+	max_multiplier = 20
 	max_chance = 8
 
 /datum/disease2/effect/blind/activate(var/mob/living/mob)

--- a/code/modules/virus2/effect/stage_4.dm
+++ b/code/modules/virus2/effect/stage_4.dm
@@ -709,7 +709,7 @@
 						for(var/mob/living/target in range(7, get_turf(mob)))
 							if (target == mob)
 								continue
-							target.eye_blind += 10
+							target.instant_blindness(20)
 							target.eye_blurry += 20
 							target.disabilities |= DISABILITY_FLAG_NEARSIGHTED
 							spawn(300)
@@ -1209,7 +1209,7 @@
 					mob.client.images += I
 					null_images += I
 					animate(I, alpha = 0, time = 20)
-	
+
 /datum/disease2/effect/loneliness/side_effect(var/mob/living/mob)
 	if(mob && mob.client && world.time - activated > 20)
 		QDEL_LIST_CUT(null_images)


### PR DESCRIPTION
Fixes #38868

https://github.com/user-attachments/assets/83848ea7-eeec-4073-aeb6-d4618e8981c9

https://github.com/user-attachments/assets/8de1a94a-c4d9-4bdb-92be-d16222306f99

:cl:
* bugfix: Fixed stuff that was supposed to instantly blind you such as a changeling's sting, a pie to the face, or pepper spray. Those once again apply the full blindness overlay immediately.
* bugfix: Fixed temporary blindness durations that didn't account for the last 10 ticks no longer being full blindness, resulting it only the sides of the screen being slightly blurry.
* rscadd: Getting splatted by a pie now temporarily applies the old blurry (cumvision) overlay


