### PR TITLE
Fixes plague mice disease origin log

### DIFF
--- a/code/datums/gamemode/factions/plague_mice.dm
+++ b/code/datums/gamemode/factions/plague_mice.dm
@@ -76,14 +76,7 @@
 			EFFECT_DANGER_HARMFUL	= 3,
 			EFFECT_DANGER_DEADLY	= 5,
 			)
-		if(prob(2)) //Dan's Discount products are notoriously bad
-			plague.origin = "Discount Dan's Gas Station Sushi"
-		else if(Holiday == APRIL_FOOLS_DAY)
-			plague.origin = pick("Nurgle's Cauldron", "Deadly Africanized Water", "Public Bathroom", "Thrax",
-								"A spaceman got a mouse disease, this is what happened to his body")
-		else
-			plague.origin = pick("Black Plague", "Javorian Pox", "Gray Death", "Doom of Pandyssia", "Thrassian Plague",
-								"Redlight", "Khaara Bacterium", "MEV-1")
+		plague.origin = "Black Plague"//for the admin panel
 
 		plague.spread = SPREAD_BLOOD|SPREAD_CONTACT|SPREAD_AIRBORNE //gotta ensure that our mice can spread that disease
 


### PR DESCRIPTION
Because the origin disease var is in fact not used at all as flavor text, it's only used for the Admin Disease Panel and should not randomly change.