### PR TITLE
Various more blur/blind hotfixes

### DIFF
--- a/__DEFINES/planes+masters.dm
+++ b/__DEFINES/planes+masters.dm
@@ -308,8 +308,9 @@ var/static/impaired_scale = list(40, 40, 40, 20, 16, 12, 9, 6, 3, 1)
 	var/matrix/M = matrix()
 	M.Scale(_nearsightedness_scale, _nearsightedness_scale)
 	if (_animate)
-		animate(screen, transform = M, time = 20)
+		animate(screen, transform = M, alpha = 255, time = 20)
 	else
+		screen.alpha = 255
 		screen.transform = M
 
 /mob/proc/disable_nearsightedness()
@@ -329,7 +330,7 @@ var/static/impaired_scale = list(40, 40, 40, 20, 16, 12, 9, 6, 3, 1)
 	var/obj/abstract/screen/fullscreen/screen = screens["impaired_crit"]
 	var/matrix/M = matrix()
 	M.Scale(40, 40)
-	animate(screen, transform = M, time = 20)
+	animate(screen, transform = M, alpha = 0, time = 20)
 
 #undef IMPAIRED_VISION_RADIUS_OUT_OF_VIEW
 #undef IMPAIRED_VISION_RADIUS_START

--- a/code/modules/mob/dead/observer/login.dm
+++ b/code/modules/mob/dead/observer/login.dm
@@ -1,7 +1,10 @@
 /mob/dead/observer/Login()
 	..()
 	observers += src
-	
+
+	var/obj/abstract/screen/fullscreen/impaired_screen = screens["impaired_crit"]
+	impaired_screen.alpha = 0
+
 	client.show_popup_menus = TRUE
 
 	if(src.check_rights(R_ADMIN|R_FUN))

--- a/code/modules/mob/living/carbon/complex/life.dm
+++ b/code/modules/mob/living/carbon/complex/life.dm
@@ -454,7 +454,6 @@
 
 
 	if(stat != DEAD)
-
 		var/impaired_vision = get_impaired_vision_range()
 		if(impaired_vision > 0)
 			enable_nearsightedness(impaired_vision)
@@ -470,6 +469,11 @@
 			enable_druggy_overlays()
 		else
 			disable_druggy_overlays()
+	else
+		if (perception_filters.enabled_filters & P_FILTER_IMPAIRED_VISION)
+			disable_nearsightedness()
+		if (perception_filters.enabled_filters & P_FILTER_BLURRY_VISION)
+			disable_blurriness()
 
 	if (stat != DEAD)
 		if (machine)

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -698,7 +698,6 @@
 		clear_alert(SCREEN_ALARM_TEMPERATURE)
 
 	if(stat != DEAD)
-
 		var/impaired_vision = get_impaired_vision_range()
 		if(impaired_vision > 0)
 			enable_nearsightedness(impaired_vision)
@@ -714,6 +713,11 @@
 			enable_druggy_overlays()
 		else
 			disable_druggy_overlays()
+	else
+		if (perception_filters.enabled_filters & P_FILTER_IMPAIRED_VISION)
+			disable_nearsightedness()
+		if (perception_filters.enabled_filters & P_FILTER_BLURRY_VISION)
+			disable_blurriness()
 
 	if (stat != 2)
 		if (machine)

--- a/code/modules/mob/living/standard_damage_overlay_updates.dm
+++ b/code/modules/mob/living/standard_damage_overlay_updates.dm
@@ -111,8 +111,11 @@
 			overlay_fullscreen("high_red", /obj/abstract/screen/fullscreen/high/red)
 		else
 			clear_fullscreen("high_red")
-
-
+	else
+		if (perception_filters.enabled_filters & P_FILTER_IMPAIRED_VISION)
+			disable_nearsightedness()
+		if (perception_filters.enabled_filters & P_FILTER_BLURRY_VISION)
+			disable_blurriness()
 
 /mob/living/proc/get_impaired_vision_range()
 	var/_modifiers	= get_impaired_vision_modifiers()

--- a/code/modules/reagents/reagents/reagents_food.dm
+++ b/code/modules/reagents/reagents/reagents_food.dm
@@ -198,7 +198,7 @@
 			H.audible_scream()
 			to_chat(H, "<span class='danger'>You are sprayed directly in the eyes with pepperspray!</span>")
 			H.eye_blurry = max(M.eye_blurry, 25)
-			H.eye_blind = max(M.eye_blind, 20)
+			H.instant_blindness(20)
 			H.Paralyse(1)
 			H.drop_item()
 
@@ -208,7 +208,7 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		H.eye_blurry = max(M.eye_blurry, 25)
-		H.eye_blind = max(M.eye_blind, 20)
+		H.instant_blindness(20)
 		H.Paralyse(1)
 		H.drop_item()
 	return ..()


### PR DESCRIPTION
Fixes #38875

:cl:
* bugfix: Fixed pepper spray specifically still having delayed blindness unless your mouth was covered.
* bugfix: The nearsightedness and blurriness effects are now disabled when you die even if you remain in your corpse.
* bugfix: Fixed the blindness overlay becoming visible to observers should they de-zoom far enough.