### PR TITLE
Fixes crates spawning under shuttle doors

### DIFF
--- a/code/controllers/subsystem/supply_shuttle.dm
+++ b/code/controllers/subsystem/supply_shuttle.dm
@@ -318,7 +318,7 @@ var/datum/subsystem/supply_shuttle/SSsupply_shuttle
 			continue
 		var/contcount
 		for(var/atom/movable/MA in T.contents)
-			if(MA.anchored && !istype(MA,/obj/structure/shuttle) && !istype(MA,/obj/machinery/door/unpowered/shuttle) && !istype(MA,/obj/machinery/door/poddoor))
+			if(MA.anchored && !istype(MA,/obj/structure/shuttle) && !istype(MA,/obj/machinery/door))
 				continue
 			contcount++
 		if(contcount)

--- a/code/controllers/subsystem/supply_shuttle.dm
+++ b/code/controllers/subsystem/supply_shuttle.dm
@@ -318,7 +318,7 @@ var/datum/subsystem/supply_shuttle/SSsupply_shuttle
 			continue
 		var/contcount
 		for(var/atom/movable/MA in T.contents)
-			if(MA.anchored && !istype(MA,/obj/structure/shuttle))
+			if(MA.anchored && !istype(MA,/obj/structure/shuttle) && !istype(MA,/obj/machinery/door/unpowered/shuttle) && !istype(MA,/obj/machinery/door/poddoor))
 				continue
 			contcount++
 		if(contcount)


### PR DESCRIPTION
[hotfix][bugfix]
quads check em

## What this does
Closes #38880.
logic could use tidying up but i'd rather just fix it for now

## How it was tested
ordering the shuttle with about 40 crates
<img width="953" height="1608" alt="image" src="https://github.com/user-attachments/assets/ab3bb91c-d13b-4a33-9e6d-1eb5698db355" />

## Changelog

:cl:
 * bugfix: Crates should no longer spawn under the shuttle doors when bought.