### PR TITLE
whiskey on the rocks

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -447,8 +447,8 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 		if(reagents.total_volume>=volume)
 			to_chat(user,"There's no room in \the [src] to fit \the [I]!")
 			return
-		reagents.add_reagent(ICE, 10)
 		to_chat(user,"You add \the [I] into \the [src].")
+		reagents.add_reagent(ICE, 10)
 		qdel(I)
 
 /obj/item/weapon/reagent_containers/attempt_heating(atom/A, mob/user)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -442,7 +442,7 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 	process_temperature()
 	if(istype(I,/obj/item/ice_crystal))
 		if(!is_open_container())
-			to_chat(user,"\The [src]'s lid gets in the way...")
+			to_chat(user,"\The [src]'s lid is in the way...")
 			return
 		if(reagents.total_volume>=volume)
 			to_chat(user,"There's no room in \the [src] to fit \the [I]!")

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -448,7 +448,7 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 			to_chat(user,"There's no room in \the [src] to fit \the [I]!")
 			return
 		to_chat(user,"You add \the [I] into \the [src].")
-		reagents.add_reagent(ICE, 10)
+		reagents.add_reagent(ICE, 10, reagtemp = T0C)
 		qdel(I)
 
 /obj/item/weapon/reagent_containers/attempt_heating(atom/A, mob/user)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -440,6 +440,16 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 	..()
 	attempt_heating(I, user)
 	process_temperature()
+	if(istype(I,/obj/item/ice_crystal))
+		if(!is_open_container())
+			to_chat(user,"\The [src]'s lid gets in the way...")
+			return
+		if(reagents.total_volume>=volume)
+			to_chat(user,"There's no room in \the [src] to fit \the [I]!")
+			return
+		reagents.add_reagent(ICE, 10)
+		to_chat(user,"You add \the [I] into \the [src].")
+		qdel(I)
 
 /obj/item/weapon/reagent_containers/attempt_heating(atom/A, mob/user)
 	var/temperature = A.is_hot()

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -2207,6 +2207,8 @@
 		if(reagents.total_volume)
 			var/obj/item/weapon/reagent_containers/food/snacks/donut/D = I
 			D.dip(src, user)
+			return
+	..()
 
 /obj/item/weapon/reagent_containers/food/drinks/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(!(molotov == 1))

--- a/code/modules/reagents/reagent_containers/food/drinks/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/drinkingglass.dm
@@ -79,6 +79,8 @@
 					desc += " Damn that looks hot!"
 				else
 					can_be_lit = 1
+			if(reagents.has_reagent(ICE) && R.id!=ICE)
+				name+=" on the rocks"
 	else
 		icon_state = "glass_empty"
 		item_state = "glass_empty"

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -72,8 +72,7 @@
 			if(P.bloodied)
 				..()
 		set_tiny_label(user)
-	attempt_heating(W, user)
-	process_temperature()
+	..()
 
 /obj/item/weapon/reagent_containers/glass/fits_in_iv_drip()
 	return 1


### PR DESCRIPTION
[fluff] [tweak]

## What this does
allows you to put an ice crystal into a glass (or beaker), which will add 10 ice reagent to it
make it so that if a glass has ice in it, "on the rocks" will be appended to the name
<img width="1358" height="635" alt="Capture" src="https://github.com/user-attachments/assets/8d86afc9-0e26-44a3-855d-8b47d1d3ecc8" />


## Why it's good
it's fluff content for bartenders. also makes ice crystals a bit more convenient to use, and makes you think of it as a bit of fluff as being a solid block like picrel
![bourbon-whiskey-sphere-ice-cube-ready-to-drink-57959587-3802156019](https://github.com/user-attachments/assets/11bacdc8-0f44-4fbe-9e22-8aee3afe542c)


## How it was tested
went in game, added ice crystal to a glass of whiskey, it's on the rocks now.

## Changelog
:cl:
 * tweak: you can now directly add ice crystals into drinking glasses
 * tweak: crewmembers have now been informed about bartending terminology, and will now recognize that a drink with ice in it is "on the rocks"
