### PR TITLE
Lots of bugfixes (nearsightedness runtimes, noir blood plane, footprint trails,...)

### DIFF
--- a/__DEFINES/planes+masters.dm
+++ b/__DEFINES/planes+masters.dm
@@ -37,6 +37,7 @@ var/obj/abstract/screen/plane_master/clickmaster/clickmaster = new()
 
 var/obj/abstract/screen/plane_master/clickmaster_dummy/clickmaster_dummy = new()
 
+/* Now managed by the new perception_filters planemasters, each mob has their own
 // NOIR
 // Immutable, so we use a singleton implementation
 // (only one planemaster for everybody, they gain or lose the unique planemaster depending on whether they want the effect or not)
@@ -56,6 +57,7 @@ var/obj/abstract/screen/plane_master/clickmaster_dummy/clickmaster_dummy = new()
 	plane = NOIR_BLOOD_PLANE
 
 var/noir_master = list(new /obj/abstract/screen/plane_master/noir_master(),new /obj/abstract/screen/plane_master/noir_dummy())
+*/
 
 // GHOST PLANEMASTER
 // One planemaster for each client, which they gain during mob/login()
@@ -163,6 +165,7 @@ var/obj/abstract/screen/plane_master/overdark_planemaster_target/overdark_planem
 		"TURF_PLANE"			= TURF_PLANE,
 		"GLASSTILE_PLANE"		= GLASSTILE_PLANE,
 		"ABOVE_TURF_PLANE"		= ABOVE_TURF_PLANE,
+		"NOIR_BLOOD_PLANE"		= NOIR_BLOOD_PLANE,
 		"HIDING_MOB_PLANE"		= HIDING_MOB_PLANE,
 		"OBJ_PLANE"				= OBJ_PLANE,
 		"LYING_MOB_PLANE"		= LYING_MOB_PLANE,
@@ -245,7 +248,7 @@ var/obj/abstract/screen/plane_master/overdark_planemaster_target/overdark_planem
 		for (var/filter in perception_filters.perception_filters)
 			planemaster.filters -= filter
 
-
+//----------------------------------------------------------------------------------------------
 
 #define IMPAIRED_VISION_RADIUS_OUT_OF_VIEW 	512	//we go this high when impairment is at 0 to prevent it showing up for players with farsight, binoculars, etc
 #define IMPAIRED_VISION_RADIUS_START 		192 //the minimal radius blurriness starts at, when impairment is at least 1
@@ -304,7 +307,12 @@ var/static/impaired_scale = list(40, 40, 40, 20, 16, 12, 9, 6, 3, 1)
 	if (_b > 0)
 		_nearsightedness_scale = min(40, 3 * _b)
 
+
 	var/obj/abstract/screen/fullscreen/screen = screens["impaired_crit"]
+
+	if (!istype(screen))//might need to re-create if clear_fullscreens() was called.
+		overlay_fullscreen("impaired_crit", /obj/abstract/screen/fullscreen/impaired_crit)
+
 	var/matrix/M = matrix()
 	M.Scale(_nearsightedness_scale, _nearsightedness_scale)
 	if (_animate)
@@ -328,12 +336,18 @@ var/static/impaired_scale = list(40, 40, 40, 20, 16, 12, 9, 6, 3, 1)
 			animate(F2, size = 0.01, offset = IMPAIRED_VISION_RADIUS_OUT_OF_VIEW, time = 20)
 
 	var/obj/abstract/screen/fullscreen/screen = screens["impaired_crit"]
+
+	if (!istype(screen))//might need to re-create if clear_fullscreens() was called.
+		overlay_fullscreen("impaired_crit", /obj/abstract/screen/fullscreen/impaired_crit)
+
 	var/matrix/M = matrix()
 	M.Scale(40, 40)
 	animate(screen, transform = M, alpha = 0, time = 20)
 
 #undef IMPAIRED_VISION_RADIUS_OUT_OF_VIEW
 #undef IMPAIRED_VISION_RADIUS_START
+
+//----------------------------------------------------------------------------------------------
 
 /mob/proc/enable_blurriness(var/_blurriness)
 	perception_filters.enabled_filters |= P_FILTER_BLURRY_VISION
@@ -365,3 +379,21 @@ var/static/impaired_scale = list(40, 40, 40, 20, 16, 12, 9, 6, 3, 1)
 		for (var/obj/planemaster in perception_filters.perception_planemasters)
 			var/F2 = planemaster.filters["blurriness_displace"]
 			animate(F2, size = 0, time = 60)
+
+//----------------------------------------------------------------------------------------------
+//Everyone gets their own noir planemaster now instead of there being one shared by everyone.
+//Since blood gets draw on this plane, this is necessary to allow other filters to get applied to blood
+
+/mob/proc/enable_noir()
+	var/obj/abstract/screen/plane_master/PM = perception_filters.orphan_planemasters["NOIR_BLOOD_PLANE"]
+	PM.color =  list("#0000",
+					 "#0000",
+					 "#0000",
+					 "#000F",
+					 "#A110")//turns everything in the plane to the color human blood. unfortunate side effect is the loss of detail on gibs
+	PM.appearance_flags = NO_CLIENT_COLOR|PLANE_MASTER//NO_CLIENT_COLOR sadly doesn't prevent the blood itself from turning grey, which is why it has to be recolored with the above matrix
+
+/mob/proc/disable_noir()
+	var/obj/abstract/screen/plane_master/PM = perception_filters.orphan_planemasters["NOIR_BLOOD_PLANE"]
+	PM.color = null
+	PM.appearance_flags = PLANE_MASTER

--- a/__DEFINES/planes+masters.dm
+++ b/__DEFINES/planes+masters.dm
@@ -311,7 +311,7 @@ var/static/impaired_scale = list(40, 40, 40, 20, 16, 12, 9, 6, 3, 1)
 	var/obj/abstract/screen/fullscreen/screen = screens["impaired_crit"]
 
 	if (!istype(screen))//might need to re-create if clear_fullscreens() was called.
-		overlay_fullscreen("impaired_crit", /obj/abstract/screen/fullscreen/impaired_crit)
+		screen = overlay_fullscreen("impaired_crit", /obj/abstract/screen/fullscreen/impaired_crit)
 
 	var/matrix/M = matrix()
 	M.Scale(_nearsightedness_scale, _nearsightedness_scale)
@@ -338,7 +338,7 @@ var/static/impaired_scale = list(40, 40, 40, 20, 16, 12, 9, 6, 3, 1)
 	var/obj/abstract/screen/fullscreen/screen = screens["impaired_crit"]
 
 	if (!istype(screen))//might need to re-create if clear_fullscreens() was called.
-		overlay_fullscreen("impaired_crit", /obj/abstract/screen/fullscreen/impaired_crit)
+		screen = overlay_fullscreen("impaired_crit", /obj/abstract/screen/fullscreen/impaired_crit)
 
 	var/matrix/M = matrix()
 	M.Scale(40, 40)

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -38,11 +38,14 @@
 		animate(screen, alpha = a, time = t)
 		client.screen += screen
 
-/mob/proc/clear_fullscreen(category, animate = 10)
+/mob/proc/clear_fullscreen(category, animate = 10, var/dead_mob = FALSE)
 	set waitfor = 0
 	var/obj/abstract/screen/fullscreen/screen = screens[category]
 	if(!screen)
 		screens -= category
+		return
+
+	if (dead_mob && screen.keep_on_death)
 		return
 
 	if(animate)
@@ -57,8 +60,7 @@
 
 /mob/proc/clear_fullscreens(var/dead_mob = FALSE, var/animate = 10)
 	for(var/category in screens)
-		if (!dead_mob || ((category != "brute") && (category != "oxy")))
-			clear_fullscreen(category, animate)
+		clear_fullscreen(category, animate, dead_mob)
 
 /datum/hud/proc/reload_fullscreen()
 	if(mymob && mymob.client && mymob.stat != DEAD)
@@ -89,6 +91,7 @@
 	var/anim_state
 	var/clear_after_length // also doubles as the length of the animation
 	var/scaling = 1
+	var/keep_on_death = 0 //prevents deletion by clear_fullscreens() when it gets called from death()
 
 /obj/abstract/screen/fullscreen/Destroy()
 	severity = 0
@@ -97,10 +100,12 @@
 /obj/abstract/screen/fullscreen/brute
 	icon_state = "brutedamageoverlay"
 	layer = DAMAGE_HUD_LAYER
+	keep_on_death = 1
 
 /obj/abstract/screen/fullscreen/oxy
 	icon_state = "oxydamageoverlay"
 	layer = DAMAGE_HUD_LAYER
+	keep_on_death = 1
 
 /obj/abstract/screen/fullscreen/numb
 	icon_state = "numboverlay"
@@ -117,6 +122,7 @@
 /obj/abstract/screen/fullscreen/impaired
 	icon_state = "impairedoverlay"
 	layer = IMPAIRED_LAYER
+	keep_on_death = 1
 
 /obj/abstract/screen/fullscreen/blurry
 	icon = 'icons/mob/screen1.dmi'

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -16,7 +16,7 @@
 	layer = HUD_BASE_LAYER
 	var/obj/master = null	//A reference to the object in the slot. Grabs or items, generally.
 	var/gun_click_time = -100 //I'm lazy.
-	var/globalscreen = 0 //This screen object is not unique to one screen, can be seen by many
+	var/globalscreen = 0 //This screen object is not unique to one screen, can be seen by many, prevents deletion by reset_screen()
 	appearance_flags = NO_CLIENT_COLOR
 	plane = HUD_PLANE
 

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -48,7 +48,7 @@ var/global/list/blood_list = list()
 	update_plane()
 
 /obj/effect/decal/cleanable/blood/proc/update_plane()
-	if(basecolor == "#FF0000" || basecolor == DEFAULT_BLOOD) // no dirty dumb vox scum allowed
+	if((basecolor == "#FF0000") || (basecolor == DEFAULT_BLOOD) || (basecolor == "#a10808ff")) // no dirty dumb vox scum allowed
 		plane = NOIR_BLOOD_PLANE
 	else
 		plane = ABOVE_TURF_PLANE

--- a/code/game/objects/effects/decals/Cleanable/tracks.dm
+++ b/code/game/objects/effects/decals/Cleanable/tracks.dm
@@ -185,7 +185,7 @@
 		var/state=coming_state
 		truedir=track.direction
 		if(truedir>15) // Check if we're in the GOING block
-			state = state || going_state
+			state = going_state || state
 			truedir=truedir>>4
 		if (isfloor(loc))
 			var/turf/T = loc
@@ -210,7 +210,7 @@
 				lum_add.plane = LIGHTING_PLANE
 				lum_add.blend_mode = BLEND_ADD
 				overlays += lum_add
-		if(track.basecolor == "#FF0000"||track.basecolor == DEFAULT_BLOOD) // no dirty dumb vox scum allowed
+		if((track.basecolor == "#FF0000") || (track.basecolor == DEFAULT_BLOOD) || (track.basecolor == "#a10808ff")) // no dirty dumb vox scum allowed
 			plane = NOIR_BLOOD_PLANE
 		else
 			plane = ABOVE_TURF_PLANE

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -68,8 +68,8 @@
 
 			if (bloodDNA)
 				AddTracks(H.get_footprint_type(),bloodDNA,H.dir,0,bloodcolor,H.luminous_feet()) // Coming
-				var/turf/simulated/from = get_step(H,opposite_dirs[H.dir])
-				if(istype(from) && from)
+				if(istype(OL, /turf/simulated) && Adjacent(OL))
+					var/turf/simulated/from = OL
 					from.AddTracks(H.get_footprint_type(),bloodDNA,0,H.dir,bloodcolor,H.luminous_feet()) // Going
 
 			bloodDNA = null

--- a/code/modules/dna/genes/vg_powers.dm
+++ b/code/modules/dna/genes/vg_powers.dm
@@ -172,7 +172,7 @@ Obviously, requires DNA2.
 	if(..())
 		M.update_colour(NOIR_ANIM_TIME)
 		if(M.client)
-			M.client.screen -= noir_master
+			M.disable_noir()
 
 //CHARGE
 

--- a/code/modules/mob/dead/observer/login.dm
+++ b/code/modules/mob/dead/observer/login.dm
@@ -2,9 +2,6 @@
 	..()
 	observers += src
 
-	var/obj/abstract/screen/fullscreen/impaired_screen = screens["impaired_crit"]
-	impaired_screen.alpha = 0
-
 	client.show_popup_menus = TRUE
 
 	if(src.check_rights(R_ADMIN|R_FUN))

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -145,7 +145,7 @@
 				if(31 to INFINITY)
 					emp_damage = 30//Let's not overdo it
 				if(21 to 30)//High level of EMP damage, unable to see, hear, or speak
-					eye_blind = 1
+					eye_blind = 11
 					blinded = 1
 					ear_deaf = 1
 					silent = 1

--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -1,6 +1,10 @@
 
 /mob/living/Login()
 	..()
+
+	init_perception_filters()//nearsightedness, blurriness, etc
+	login_perception_filters_update()//apply the effects instantly without animate()
+
 	standard_damage_overlay_updates()
 
 	//Mind updates
@@ -27,7 +31,7 @@
 
 		if (hasFactionIcons(src))
 			update_faction_icons()
-	
+
 	if(virus2.len)
 		for(var/ID in virus2)
 			var/datum/disease2/disease/V = virus2[ID]

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -79,8 +79,6 @@
 
 	create_orphan_planemasters()
 	list_perception_planemasters()
-	init_perception_filters()
-	login_perception_filters_update()
 
 	regular_hud_updates()
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1958,7 +1958,7 @@ Use this proc preferably at the end of an equipment loadout
 	var/init_deaf = ear_deaf
 	overlay_fullscreen("blind", /obj/abstract/screen/fullscreen/blind)
 	blinded = 1
-	eye_blind = 1
+	eye_blind = 11
 	ear_deaf = 1
 
 	..()

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -80,7 +80,7 @@
 	if(!colour_to_apply)
 		colour_to_apply = get_screen_colour()
 	if((M_NOIR in mutations) && client)
-		client.screen += noir_master
+		enable_noir()
 	// We can't compare client.color directly because Byond will force set client.color to null
 	// when assigning the default_colour_matrix to it
 	var/list/colour_initial = (client.color ? client.color : default_colour_matrix)


### PR DESCRIPTION
Fixes #38878
Fixes #38887

before fix:
<img width="282" height="107" alt="image" src="https://github.com/user-attachments/assets/bd70d916-fbf8-4aa2-b436-85d70772678c" />

after fix:
<img width="316" height="153" alt="image" src="https://github.com/user-attachments/assets/f7934a81-7b16-48b4-b778-96fec1ec74dd" />


<img width="615" height="390" alt="image" src="https://github.com/user-attachments/assets/a85b8321-c813-45e6-a927-304042c0b735" />

backend:
* Noir has been reworked from a global planemaster shared by everyone to a perception filter orphan planemaster, allowing its plane to be affected by other filter effets

:cl:
* bugfix: Fixed players with bloody feet not adding footprints when leaving a tile, only when arriving on one, resulting in only half the expected footprints showing up (this bug has been around for 4 years, thanks for the fix Exxion).
* bugfix: Fixed bloody footprints sometimes not appearing red when the Noir gene is enabled despite being red.
* bugfix: Fixed some blood splatters not being affected by blurriness/nearsightedness
* bugfix: Fixed the blindness overlay sometimes going away and causing runtimes (namely when someone dies then gets defib'd)
* bugfix: Fixed observers being unable to properly zoom in