### PR TITLE
Hamster/gymrat wheel fixes

### DIFF
--- a/code/game/objects/structures/fitness.dm
+++ b/code/game/objects/structures/fitness.dm
@@ -154,8 +154,8 @@
 		var/image/W = image('icons/obj/fitness.dmi',"fitnessweight-w")
 		W.layer = MOB_LAYER + 0.1
 		overlays += W
-		var/bragmessage = pick("pushing it to the limit","going into overdrive","burning with determination","rising up to the challenge", "getting strong now","getting ripped")
 		if(user.client)
+			var/bragmessage = pick("pushing it to the limit","going into overdrive","burning with determination","rising up to the challenge", "getting strong now","getting ripped")
 			user.visible_message("<B>[user] is [bragmessage]!</B>")
 		user.pixel_y = 5 * PIXEL_MULTIPLIER
 		for(var/reps = 1 to 6)

--- a/code/game/objects/structures/fitness.dm
+++ b/code/game/objects/structures/fitness.dm
@@ -155,7 +155,8 @@
 		W.layer = MOB_LAYER + 0.1
 		overlays += W
 		var/bragmessage = pick("pushing it to the limit","going into overdrive","burning with determination","rising up to the challenge", "getting strong now","getting ripped")
-		user.visible_message("<B>[user] is [bragmessage]!</B>")
+		if(user.client)
+			user.visible_message("<B>[user] is [bragmessage]!</B>")
 		user.pixel_y = 5 * PIXEL_MULTIPLIER
 		for(var/reps = 1 to 6)
 			if (user.loc != loc)

--- a/code/modules/mob/living/simple_animal/hostile/gym_rats.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gym_rats.dm
@@ -41,6 +41,7 @@
 	var/obj/my_wheel
 	var/list/gym_equipments = list(/obj/structure/stacklifter, /obj/structure/punching_bag, /obj/structure/weightlifter, /obj/machinery/power/treadmill)
 	var/static/list/edibles = list(/obj/item/weapon/reagent_containers/food/snacks)
+	var/is_wheeling = FALSE
 
 	var/scalerate = 1
 	var/translaterate = 4.5 //it is multiplied by the current scalerate, and we want a final value of 9
@@ -173,29 +174,34 @@
 				wander = TRUE
 
 /mob/living/simple_animal/hostile/retaliate/gym_rat/proc/gymratwheel(var/repeat)
-	if(repeat < 1 || stat)
+	if(is_wheeling)
+		return
+	is_wheeling = TRUE
+	spawn(0)
+		while(repeat > 0 && !stat)
+			if(my_wheel)
+				if(istype(my_wheel, /obj/structure/stacklifter))
+					var/obj/structure/stacklifter/S = my_wheel
+					S.attack_hand(src, 0, S.Adjacent(src))
+				else if(istype(my_wheel, /obj/structure/punching_bag))
+					var/obj/structure/punching_bag/P = my_wheel
+					P.attack_hand(src, 0, P.Adjacent(src))
+				else if(istype(my_wheel, /obj/structure/weightlifter))
+					var/obj/structure/weightlifter/W = my_wheel
+					W.attack_hand(src, 0, W.Adjacent(src))
+				else if(istype(my_wheel, /obj/machinery/power/treadmill) && my_wheel.loc == loc)
+					step(src,my_wheel.dir)
+				step_towards(src,my_wheel)
+			else
+				wander = TRUE
+				break
+			delayNextMove(speed)
+			sleep(speed)
+			repeat--
+		sleep(20 * speed) //rest period
 		wander = TRUE
 		my_wheel = null
-		return
-	if(my_wheel)
-		if(istype(my_wheel, /obj/structure/stacklifter))
-			var/obj/structure/stacklifter/S = my_wheel
-			S.attack_hand(src, 0, S.Adjacent(src))
-		else if(istype(my_wheel, /obj/structure/punching_bag))
-			var/obj/structure/punching_bag/P = my_wheel
-			P.attack_hand(src, 0, P.Adjacent(src))
-		else if(istype(my_wheel, /obj/structure/weightlifter))
-			var/obj/structure/weightlifter/W = my_wheel
-			W.attack_hand(src, 0, W.Adjacent(src))
-		else if(istype(my_wheel, /obj/machinery/power/treadmill) && my_wheel.loc == loc)
-			step(src,my_wheel.dir)
-		step_towards(src,my_wheel)
-	else
-		wander = TRUE
-
-	delayNextMove(speed)
-	sleep(speed)
-	gymratwheel(repeat-1)
+		is_wheeling = FALSE
 
 /mob/living/simple_animal/hostile/retaliate/gym_rat/proc/Calm()
 	enemies.Cut()

--- a/code/modules/trader/crates/cloudnine.dm
+++ b/code/modules/trader/crates/cloudnine.dm
@@ -50,6 +50,7 @@ var/global/list/cloudnine_stuff = list(
 	speak_chance = 2
 	emote_hear = list("squeaks deeply")
 	var/obj/my_wheel
+	var/is_wheeling = FALSE
 
 /mob/living/simple_animal/hamster/Life()
 	if(!..())
@@ -65,16 +66,21 @@ var/global/list/cloudnine_stuff = list(
 		hamsterwheel(20)
 
 /mob/living/simple_animal/hamster/proc/hamsterwheel(var/repeat)
-	if(repeat < 1 || stat)
+	if(is_wheeling)
 		return
-	if(!my_wheel || my_wheel.loc != loc) //no longer share a tile with our wheel
-		wander = TRUE
-		my_wheel = null
-		return
-	step(src,my_wheel.dir)
-	delayNextMove(HAMSTER_MOVEDELAY)
-	sleep(HAMSTER_MOVEDELAY)
-	hamsterwheel(repeat-1)
+	is_wheeling = TRUE
+	spawn(0)
+		while(repeat > 0 && !stat)
+			if(!my_wheel || my_wheel.loc != loc) //no longer share a tile with our wheel
+				wander = TRUE
+				my_wheel = null
+				break
+			step(src,my_wheel.dir)
+			delayNextMove(HAMSTER_MOVEDELAY)
+			sleep(HAMSTER_MOVEDELAY)
+			repeat--
+		sleep(20 * HAMSTER_MOVEDELAY) //rest period
+		is_wheeling = FALSE
 
 /mob/living/simple_animal/hamster/attack_hand(mob/living/carbon/human/M)
 	. = ..()

--- a/code/modules/trader/crates/cloudnine.dm
+++ b/code/modules/trader/crates/cloudnine.dm
@@ -79,7 +79,6 @@ var/global/list/cloudnine_stuff = list(
 			delayNextMove(HAMSTER_MOVEDELAY)
 			sleep(HAMSTER_MOVEDELAY)
 			repeat--
-		sleep(20 * HAMSTER_MOVEDELAY) //rest period
 		is_wheeling = FALSE
 
 /mob/living/simple_animal/hamster/attack_hand(mob/living/carbon/human/M)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
- Adjusts gymratwheel() and hamsterwheel() to embed their sleep() calls within a spawn() to prevent sleeping the main mob tick() loop.
- Gym rats will now rest for a short time between sets.
- Removes the visible message when a gym rat uses the weightlifting equipment to prevent chat spam.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
The mob subsystem is very demanding; any bit of performance boost helps.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Placed a gym rat next to a weight machine and watched it get swole (with reasonable breaks).
Placed a hamster next to a treadmill and watched it get lean (with no breaks).

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Gym rats exercising will no longer spam chat.
