### PR TITLE
Stops alarmlocks slowing down roundstart object init

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -72,7 +72,7 @@ var/list/all_doors = list()
 	var/obj/item/clothing/shoes/S = kicker.shoes
 	if(istype(S))
 		S.on_kick_obj(kicker, src)
-		
+
 /obj/machinery/door/proc/attempt_slicing(mob/user)
 	being_cut = TRUE
 	user.visible_message("<span class='warning'>[user] begins slicing through \the [src]!</span>", \
@@ -291,23 +291,23 @@ var/list/all_doors = list()
 	if(!arcanetampered || !arcane_linked_door)
 		set_opacity(0)
 	door_animate("opening")
+	var/current_delay = animation_delay
 	if (animation_delay_predensity_opening)
-		sleep(animation_delay_predensity_opening)
-	else
-		sleep(animation_delay)
-	plane = open_plane
-	layer = open_layer
-	setDensity(FALSE)
-	update_nearby_tiles()
-	if (animation_delay_predensity_opening)
-		sleep(animation_delay - animation_delay_predensity_opening)
-	update_icon()
-	if(!arcane_linked_door)
-		set_opacity(0)
-	//update_freelook_sight()
+		current_delay = animation_delay_predensity_opening
+	spawn(current_delay)
+		plane = open_plane
+		layer = open_layer
+		setDensity(FALSE)
+		update_nearby_tiles()
+		if (animation_delay_predensity_opening)
+			sleep(animation_delay - animation_delay_predensity_opening)
+		update_icon()
+		if(!arcane_linked_door)
+			set_opacity(0)
+		//update_freelook_sight()
 
-	if(operating == 1)
-		operating = 0
+		if(operating == 1)
+			operating = 0
 
 	return 1
 


### PR DESCRIPTION
[performance]

## What this does
changes sleep() to spawn() in open() on doors, which airlock calls.

## How it was tested
loading the map with the grey themed hoboshack, bumping into doors and opening them, closing and then opening a firedoor

## Changelog
:cl:
 * bugfix: Alarm airlocks no longer slow down roundstart init by opening.