### PR TITLE
makes it so that XGM_GAS_NOTEWORTHY is actually used how it should be

### DIFF
--- a/code/game/machinery/ATMOSPHERICS/components/binary_devices/MSGS.dm
+++ b/code/game/machinery/ATMOSPHERICS/components/binary_devices/MSGS.dm
@@ -91,7 +91,7 @@
 	data["targetPressure"] = target_pressure
 	data["gases"] = list()
 	var/static/list/display_gases = list()
-	for(var/gas_id in XGM.gases)
+	for(var/gas_id in XGM.noteworthy_gases)
 		var/datum/gas/gas_datum = XGM.gases[gas_id]
 		display_gases[gas_id] = gas_datum.name
 	var/total_moles = air.total_moles

--- a/code/game/machinery/ATMOSPHERICS/components/trinary_devices/filter.dm
+++ b/code/game/machinery/ATMOSPHERICS/components/trinary_devices/filter.dm
@@ -116,7 +116,7 @@
 			<b>Filtering: </b>[current_filter_name]<br><HR>
 			<h4>Set Filter Type:</h4>"}
 
-	for(var/gas_ID in XGM.gases)
+	for(var/gas_ID in XGM.noteworthy_gases)
 		var/datum/gas/gas_datum = XGM.gases[gas_ID]
 		dat += "<A href='?src=\ref[src];filterset=" + gas_ID + "'>" + gas_datum.name + "</A><BR>"
 

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -952,7 +952,7 @@ var/global/list/air_alarms = list()
 	data["scrubbers"]=scrubbers
 
 	var/list/gas_datums=list()
-	for(var/gas_id in XGM.gases)
+	for(var/gas_id in XGM.noteworthy_gases)
 		var/datum/gas/gas_datum = XGM.gases[gas_id]
 		var/list/datum_data = list()
 		datum_data["id"] = gas_id

--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -40,7 +40,7 @@
 		<li>Monitor Pressure: <a href="?src=\ref[src];toggle_monitoring=pressure">[is_monitoring("pressure") ? "Yes" : "No"]</a>
 		<li>Monitor Temperature: <a href="?src=\ref[src];toggle_monitoring=temperature">[is_monitoring("temperature") ? "Yes" : "No"]</a>"}
 
-	for(var/gas_ID in XGM.gases)
+	for(var/gas_ID in XGM.noteworthy_gases)
 		var/datum/gas/gas_datum = XGM.gases[gas_ID]
 		dat += {"<li>Monitor [gas_datum.name] Concentration: <a href="?src=\ref[src];toggle_monitoring=[gas_ID]">[is_monitoring(gas_ID) ? "Yes" : "No"]</a>"}
 	dat += "</ul>"
@@ -159,7 +159,7 @@
 				if(data["temperature"])
 					sensor_part += "<tr><th>Temperature:</th><td>[data["temperature"]] K</td></tr>"
 				var/header_added = FALSE
-				for(var/gas_ID in XGM.gases)
+				for(var/gas_ID in XGM.noteworthy_gases)
 					if(data[gas_ID])
 						if(!header_added)
 							header_added = TRUE

--- a/code/game/machinery/atmoalter/meter.dm
+++ b/code/game/machinery/atmoalter/meter.dm
@@ -152,7 +152,7 @@
 		<li>Monitor Pressure: <a href="?src=\ref[src];toggle_monitoring=pressure">[is_monitoring("pressure") ? "Yes" : "No"]</a>
 		<li>Monitor Temperature: <a href="?src=\ref[src];toggle_monitoring=temperature">[is_monitoring("temperature") ? "Yes" : "No"]</a>"}
 
-	for(var/gas_ID in XGM.gases)
+	for(var/gas_ID in XGM.noteworthy_gases)
 		var/datum/gas/gas_datum = XGM.gases[gas_ID]
 		dat += {"<li>Monitor [gas_datum.name] Concentration: <a href="?src=\ref[src];toggle_monitoring=[gas_ID]">[is_monitoring(gas_ID) ? "Yes" : "No"]</a>"}
 	dat += "</ul>"

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -175,7 +175,7 @@
 	data["rate"] = round(volume_rate)
 	data["on"] = on ? 1 : 0
 	var/list/scrub_toggles = list()
-	for(var/gas_id in XGM.gases)
+	for(var/gas_id in XGM.noteworthy_gases)
 		var/datum/gas/gas_datum = XGM.gases[gas_id]
 		var/list/gas_info = list(list("name" = gas_datum.short_name || gas_datum.name, "id" = gas_id, "active" = scrubbed_gases[gas_datum.id]))
 		scrub_toggles += gas_info

--- a/code/game/machinery/computer/atmos_control.dm
+++ b/code/game/machinery/computer/atmos_control.dm
@@ -220,7 +220,7 @@ var/global/list/atmos_controllers = list()
 	data["aca_screen"] = screen //aca_screen so we don't conflict with air alarms, which already use screen
 
 	var/list/gas_datums=list()
-	for(var/gas_id in XGM.gases)
+	for(var/gas_id in XGM.noteworthy_gases)
 		var/datum/gas/gas_datum = XGM.gases[gas_id]
 		var/list/datum_data = list()
 		datum_data["id"] = gas_id

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -398,7 +398,9 @@ Subject's pulse: ??? BPM"})
 			var/moles = scanned[id]
 			var/concentration = moles / total_moles
 			var/datum/gas/gas = XGM.gases[id]
-
+			
+			if(!(gas.flags & XGM_GAS_NOTEWORTHY))
+				continue
 			if (concentration < 0.01)
 				continue
 

--- a/code/modules/atmos_automation/implementation/scrubbers.dm
+++ b/code/modules/atmos_automation/implementation/scrubbers.dm
@@ -122,7 +122,8 @@
 	var/txt = "Set Scrubber <a href=\"?src=\ref[src];set_scrubber=1\">[fmtString(scrubber)]</a> to scrub "
 	for(var/gas in gasses)
 		var/datum/gas/gas_datum = XGM.gases[gas]
-		txt += " [gas_datum.short_name || gas_datum.name] (<a href=\"?src=\ref[src];tog_gas=[gas]\">[gasses[gas] ? "on" : "off"]</a>),"
+		if(gas_datum.flags & XGM_GAS_NOTEWORTHY)
+			txt += " [gas_datum.short_name || gas_datum.name] (<a href=\"?src=\ref[src];tog_gas=[gas]\">[gasses[gas] ? "on" : "off"]</a>),"
 	return txt
 
 /datum/automation/set_scrubber_gasses/Topic(href,href_list)

--- a/code/modules/atmos_automation/implementation/sensors.dm
+++ b/code/modules/atmos_automation/implementation/sensors.dm
@@ -36,7 +36,7 @@
 
 	if(href_list["set_field"])
 		var/options = list("temperature", "pressure")
-		for(var/gas_ID in XGM.gases)
+		for(var/gas_ID in XGM.noteworthy_gases)
 			options += gas_ID
 		field = input("Select a sensor output:", "Sensor Data", field) as null | anything in options
 		parent.updateUsrDialog()


### PR DESCRIPTION
[oldcoders] [ui]


## What this does
makes it so that the `XGM_GAS_NOTEWORTHY` flag is actually used by code
closes #38731

## Why it's good
reduces UI clutter

## How it was tested
went in game and opened a variety of UIs
<img width="583" height="673" alt="1" src="https://github.com/user-attachments/assets/b1a09a09-bef6-4ec4-8438-4e072b6f8d46" />
<img width="588" height="366" alt="2" src="https://github.com/user-attachments/assets/688c01fd-3e9c-4b52-b234-8273d650314c" />
<img width="424" height="466" alt="3" src="https://github.com/user-attachments/assets/ea767e1b-2671-44f6-ae39-41a776265ac0" />
<img width="501" height="495" alt="4" src="https://github.com/user-attachments/assets/3767efe4-1159-4892-9431-5f2de2b688c4" />
<img width="402" height="434" alt="5" src="https://github.com/user-attachments/assets/8eca241c-715e-4453-bc01-60685fedb1fd" />



## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: air alarms and other atmos UIs will no longer show unimportant gasses
