### PR TITLE
Adds Junglestation to map rotation

### DIFF
--- a/__DEFINES/__compile_options.dm
+++ b/__DEFINES/__compile_options.dm
@@ -46,6 +46,8 @@
 //#define MAP_OVERRIDE 16
 // tgstation-sec.dm
 //#define MAP_OVERRIDE 17
+// junglestation.dm
+//#define MAP_OVERRIDE 18
 
 // Toggles several features, explained in their respective comments.
 // You can turn those on and off manually if you prefer, instead of setting this

--- a/code/datums/next_map.dm
+++ b/code/datums/next_map.dm
@@ -182,11 +182,6 @@
 /datum/next_map/junglestation
 	name = "Jungle Station" //NT Colony Gamma-8 - the trve name.
 	path = "junglestation"
-	min_players=1 //placeholders - adjust later. Or don't. maybe it'll be fun in deadpop and highpop.
-	max_players=99
-//disabled voting. re-enable when jungle is good to run full time. should still be able to be bussed like this.
-/datum/next_map/junglestation/is_votable()
-	return FALSE
 
 /proc/get_votable_maps()
 	var/list/votable_maps = list()

--- a/maps/_map_override.dm
+++ b/maps/_map_override.dm
@@ -80,7 +80,7 @@
 		#define MAP_OVERRIDE 17
 	#elif MAP_OVERRIDE == 18
 		#undef MAP_OVERRIDE
-		#include "horizon.dm"
+		#include "junglestation.dm"
 		#define MAP_OVERRIDE 18
 	#endif
 #endif


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Adds Junglestation to the map rotation, allowing players to vote and play in the jungle.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Most of the code issues with this map have been addressed. Putting it into full rotation for ~1 month then holding a vote will decide if this is a permanent change.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
You, the beloved players, will test it.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * experiment: Added Junglestation to the map rotation.
