### PR TITLE
Plane Filter prefs + Pref Settings tab split

### DIFF
--- a/SQL/players2.sql
+++ b/SQL/players2.sql
@@ -113,6 +113,7 @@ CREATE TABLE client (
     space_parallax INTEGER,
     space_dust     INTEGER,
     parallax_speed INTEGER,
+    plane_filters  INTEGER,
     stumble        INTEGER,
     attack_animation INTEGER,
     pulltoggle     INTEGER,

--- a/__DEFINES/planes+masters.dm
+++ b/__DEFINES/planes+masters.dm
@@ -263,6 +263,38 @@ var/obj/abstract/screen/plane_master/overdark_planemaster_target/overdark_planem
 #define IMPAIRED_VISION_RADIUS_OUT_OF_VIEW 	512	//we go this high when impairment is at 0 to prevent it showing up for players with farsight, binoculars, etc
 #define IMPAIRED_VISION_RADIUS_START 		192 //the minimal radius blurriness starts at, when impairment is at least 1
 
+/mob/proc/disable_all_visual_filters()
+	//called only when disabling the toggling preferences. It'll let players see without hindrance for a Life() tick so better log it in case of abuse
+	log_admin("[key_name(src)] toggled their visual filter prefs.")
+
+	if (perception_filters.enabled_filters & P_FILTER_IMPAIRED_VISION)
+		perception_filters.enabled_filters &= ~P_FILTER_IMPAIRED_VISION
+
+		filter_update_delay++
+		spawn(filter_update_delay)
+			for (var/obj/planemaster in perception_filters.perception_planemasters)
+				var/F1 = planemaster.filters["nearsightedness_angular"]
+				animate(F1, size = 0.5, offset = IMPAIRED_VISION_RADIUS_OUT_OF_VIEW, time = 20)
+		filter_update_delay++
+		spawn(filter_update_delay)
+			for (var/obj/planemaster in perception_filters.perception_planemasters)
+				var/F2 = planemaster.filters["nearsightedness_radial"]
+				animate(F2, size = 0.01, offset = IMPAIRED_VISION_RADIUS_OUT_OF_VIEW, time = 20)
+
+	if (perception_filters.enabled_filters & P_FILTER_BLURRY_VISION)
+		perception_filters.enabled_filters &= ~P_FILTER_BLURRY_VISION
+
+		filter_update_delay++
+		spawn(filter_update_delay)
+			for (var/obj/planemaster in perception_filters.perception_planemasters)
+				var/F1 = planemaster.filters["blurriness_blur"]
+				animate(F1, size = 0, time = 60)
+		filter_update_delay++
+		spawn(filter_update_delay)
+			for (var/obj/planemaster in perception_filters.perception_planemasters)
+				var/F2 = planemaster.filters["blurriness_displace"]
+				animate(F2, size = 0, time = 60)
+
 var/static/impaired_scale = list(40, 40, 40, 20, 16, 12, 9, 6, 3, 1)
 
 /mob
@@ -280,36 +312,57 @@ var/static/impaired_scale = list(40, 40, 40, 20, 16, 12, 9, 6, 3, 1)
 		clear_fullscreen("blind")
 
 /mob/proc/enable_nearsightedness(var/_severity, var/_animate = TRUE)//actually handles blindess too
-	perception_filters.enabled_filters |= P_FILTER_IMPAIRED_VISION
+	if(client?.prefs.get_pref(/datum/preference_setting/toggle/plane_filters))
+		perception_filters.enabled_filters |= P_FILTER_IMPAIRED_VISION
 
-	var/_a = 9 - _severity
-	var/_nearsightedness_offset = 0
-	if (_a >= 0)
-		_nearsightedness_offset = min(IMPAIRED_VISION_RADIUS_START, 2 ** (_a))
+		var/_a = 9 - _severity
+		var/_nearsightedness_offset = 0
+		if (_a >= 0)
+			_nearsightedness_offset = min(IMPAIRED_VISION_RADIUS_START, 2 ** (_a))
 
 
-	if (_animate)
-		filter_update_delay++
-		spawn(filter_update_delay)
-			for (var/obj/planemaster in perception_filters.perception_planemasters)
-				var/F1 = planemaster.filters["nearsightedness_angular"]
-				animate(F1, size = 0.5, offset = _nearsightedness_offset, time = 20)
-		filter_update_delay++
-		spawn(filter_update_delay)
-			for (var/obj/planemaster in perception_filters.perception_planemasters)
-				var/F2 = planemaster.filters["nearsightedness_radial"]
-				animate(F2, size = 0.01, offset = _nearsightedness_offset, time = 20)
+		if (_animate)
+			filter_update_delay++
+			spawn(filter_update_delay)
+				for (var/obj/planemaster in perception_filters.perception_planemasters)
+					var/F1 = planemaster.filters["nearsightedness_angular"]
+					animate(F1, size = 0.5, offset = _nearsightedness_offset, time = 20)
+			filter_update_delay++
+			spawn(filter_update_delay)
+				for (var/obj/planemaster in perception_filters.perception_planemasters)
+					var/F2 = planemaster.filters["nearsightedness_radial"]
+					animate(F2, size = 0.01, offset = _nearsightedness_offset, time = 20)
+		else
+			filter_update_delay++
+			spawn(filter_update_delay)
+				for (var/obj/planemaster in perception_filters.perception_planemasters)
+					var/F1 = planemaster.filters["nearsightedness_angular"]
+					F1:offset = _nearsightedness_offset
+			filter_update_delay++
+			spawn(filter_update_delay)
+				for (var/obj/planemaster in perception_filters.perception_planemasters)
+					var/F2 = planemaster.filters["nearsightedness_radial"]
+					F2:offset = _nearsightedness_offset
+
 	else
-		filter_update_delay++
-		spawn(filter_update_delay)
-			for (var/obj/planemaster in perception_filters.perception_planemasters)
-				var/F1 = planemaster.filters["nearsightedness_angular"]
-				F1:offset = _nearsightedness_offset
-		filter_update_delay++
-		spawn(filter_update_delay)
-			for (var/obj/planemaster in perception_filters.perception_planemasters)
-				var/F2 = planemaster.filters["nearsightedness_radial"]
-				F2:offset = _nearsightedness_offset
+		var/_b = 10 - min(10, _severity * 2)
+		var/_nearsightedness_scale = 1
+		if (_b > 0)
+			_nearsightedness_scale = min(40, 3 * _b)
+
+
+		var/obj/abstract/screen/fullscreen/screen = screens["impaired_crit_alt"]
+
+		if (!istype(screen))//might need to re-create if clear_fullscreens() was called.
+			screen = overlay_fullscreen("impaired_crit_alt", /obj/abstract/screen/fullscreen/impaired_crit)
+
+		var/matrix/M = matrix()
+		M.Scale(_nearsightedness_scale, _nearsightedness_scale)
+		if (_animate)
+			animate(screen, transform = M, alpha = 200, time = 20)
+		else
+			screen.alpha = 200
+			screen.transform = M
 
 
 	var/_b = 10 - _severity
@@ -332,18 +385,29 @@ var/static/impaired_scale = list(40, 40, 40, 20, 16, 12, 9, 6, 3, 1)
 		screen.transform = M
 
 /mob/proc/disable_nearsightedness()
-	perception_filters.enabled_filters &= ~P_FILTER_IMPAIRED_VISION
+	if(client?.prefs.get_pref(/datum/preference_setting/toggle/plane_filters))
+		perception_filters.enabled_filters &= ~P_FILTER_IMPAIRED_VISION
 
-	filter_update_delay++
-	spawn(filter_update_delay)
-		for (var/obj/planemaster in perception_filters.perception_planemasters)
-			var/F1 = planemaster.filters["nearsightedness_angular"]
-			animate(F1, size = 0.5, offset = IMPAIRED_VISION_RADIUS_OUT_OF_VIEW, time = 20)
-	filter_update_delay++
-	spawn(filter_update_delay)
-		for (var/obj/planemaster in perception_filters.perception_planemasters)
-			var/F2 = planemaster.filters["nearsightedness_radial"]
-			animate(F2, size = 0.01, offset = IMPAIRED_VISION_RADIUS_OUT_OF_VIEW, time = 20)
+		filter_update_delay++
+		spawn(filter_update_delay)
+			for (var/obj/planemaster in perception_filters.perception_planemasters)
+				var/F1 = planemaster.filters["nearsightedness_angular"]
+				animate(F1, size = 0.5, offset = IMPAIRED_VISION_RADIUS_OUT_OF_VIEW, time = 20)
+		filter_update_delay++
+		spawn(filter_update_delay)
+			for (var/obj/planemaster in perception_filters.perception_planemasters)
+				var/F2 = planemaster.filters["nearsightedness_radial"]
+				animate(F2, size = 0.01, offset = IMPAIRED_VISION_RADIUS_OUT_OF_VIEW, time = 20)
+	else
+		var/obj/abstract/screen/fullscreen/screen = screens["impaired_crit_alt"]
+
+		if (!istype(screen))//might need to re-create if clear_fullscreens() was called.
+			screen = overlay_fullscreen("impaired_crit_alt", /obj/abstract/screen/fullscreen/impaired_crit)
+
+		var/matrix/M = matrix()
+		M.Scale(40, 40)
+		animate(screen, transform = M, alpha = 0, time = 20)
+
 
 	var/obj/abstract/screen/fullscreen/screen = screens["impaired_crit"]
 
@@ -360,35 +424,52 @@ var/static/impaired_scale = list(40, 40, 40, 20, 16, 12, 9, 6, 3, 1)
 //----------------------------------------------------------------------------------------------
 
 /mob/proc/enable_blurriness(var/_blurriness)
-	perception_filters.enabled_filters |= P_FILTER_BLURRY_VISION
+	if(client?.prefs.get_pref(/datum/preference_setting/toggle/plane_filters))
+		perception_filters.enabled_filters |= P_FILTER_BLURRY_VISION
 
-	filter_update_delay++
-	spawn(filter_update_delay)
-		for (var/obj/planemaster in perception_filters.perception_planemasters)
-			var/F1 = planemaster.filters["blurriness_blur"]
-			var/_blur_size = clamp(_blurriness / 10, 0.7, 1.1)
-			animate(F1, size = _blur_size, time = 10)
-	filter_update_delay++
-	spawn(filter_update_delay)//seems like it won't work here either unless we wait here
-		for (var/obj/planemaster in perception_filters.perception_planemasters)
-			var/F2 = planemaster.filters["blurriness_displace"]
-			animate(F2, size = 2, time = 5)//a subtle displacement of 2, barely noticeable
-			animate(size = -2, time = 10)
-			animate(size = 0, time = 5)
+		filter_update_delay++
+		spawn(filter_update_delay)
+			for (var/obj/planemaster in perception_filters.perception_planemasters)
+				var/F1 = planemaster.filters["blurriness_blur"]
+				var/_blur_size = clamp(_blurriness / 10, 0.7, 1.1)
+				animate(F1, size = _blur_size, time = 10)
+		filter_update_delay++
+		spawn(filter_update_delay)//seems like it won't work here either unless we wait here
+			for (var/obj/planemaster in perception_filters.perception_planemasters)
+				var/F2 = planemaster.filters["blurriness_displace"]
+				animate(F2, size = 2, time = 5)//a subtle displacement of 2, barely noticeable
+				animate(size = -2, time = 10)
+				animate(size = 0, time = 5)
+	else
+		var/obj/abstract/screen/fullscreen/screen = screens["blurry_alt"]
+
+		if (!istype(screen))//might need to re-create if clear_fullscreens() was called.
+			screen = overlay_fullscreen("blurry_alt", /obj/abstract/screen/fullscreen/blurry/alt)
+
+		animate(screen, alpha = 255, time = 20)
+
 
 /mob/proc/disable_blurriness()
-	perception_filters.enabled_filters &= ~P_FILTER_BLURRY_VISION
+	if(client?.prefs.get_pref(/datum/preference_setting/toggle/plane_filters))
+		perception_filters.enabled_filters &= ~P_FILTER_BLURRY_VISION
 
-	filter_update_delay++
-	spawn(filter_update_delay)
-		for (var/obj/planemaster in perception_filters.perception_planemasters)
-			var/F1 = planemaster.filters["blurriness_blur"]
-			animate(F1, size = 0, time = 60)
-	filter_update_delay++
-	spawn(filter_update_delay)
-		for (var/obj/planemaster in perception_filters.perception_planemasters)
-			var/F2 = planemaster.filters["blurriness_displace"]
-			animate(F2, size = 0, time = 60)
+		filter_update_delay++
+		spawn(filter_update_delay)
+			for (var/obj/planemaster in perception_filters.perception_planemasters)
+				var/F1 = planemaster.filters["blurriness_blur"]
+				animate(F1, size = 0, time = 60)
+		filter_update_delay++
+		spawn(filter_update_delay)
+			for (var/obj/planemaster in perception_filters.perception_planemasters)
+				var/F2 = planemaster.filters["blurriness_displace"]
+				animate(F2, size = 0, time = 60)
+	else
+		var/obj/abstract/screen/fullscreen/screen = screens["blurry_alt"]
+
+		if (!istype(screen))//might need to re-create if clear_fullscreens() was called.
+			screen = overlay_fullscreen("blurry_alt", /obj/abstract/screen/fullscreen/blurry/alt)
+
+		animate(screen, alpha = 0, time = 20)
 
 //----------------------------------------------------------------------------------------------
 //Everyone gets their own noir planemaster now instead of there being one shared by everyone.

--- a/__DEFINES/planes+masters.dm
+++ b/__DEFINES/planes+masters.dm
@@ -315,11 +315,12 @@ var/static/impaired_scale = list(40, 40, 40, 20, 16, 12, 9, 6, 3, 1)
 	if(client?.prefs.get_pref(/datum/preference_setting/toggle/plane_filters))
 		perception_filters.enabled_filters |= P_FILTER_IMPAIRED_VISION
 
-		var/_a = 9 - _severity
-		var/_nearsightedness_offset = 0
-		if (_a >= 0)
-			_nearsightedness_offset = min(IMPAIRED_VISION_RADIUS_START, 2 ** (_a))
+		var/_exponent = 9 - _severity
 
+		var/_nearsightedness_offset = 0
+
+		if (_exponent >= 0)
+			_nearsightedness_offset = min(IMPAIRED_VISION_RADIUS_START, 2 ** (_exponent))
 
 		if (_animate)
 			filter_update_delay++
@@ -345,10 +346,11 @@ var/static/impaired_scale = list(40, 40, 40, 20, 16, 12, 9, 6, 3, 1)
 					F2:offset = _nearsightedness_offset
 
 	else
-		var/_b = 10 - min(10, _severity * 2)
+		var/_inverse_severity = 10 - min(10, _severity * 2)
+
 		var/_nearsightedness_scale = 1
-		if (_b > 0)
-			_nearsightedness_scale = min(40, 3 * _b)
+		if (_inverse_severity > 0)
+			_nearsightedness_scale = min(40, 3 * _inverse_severity)
 
 
 		var/obj/abstract/screen/fullscreen/screen = screens["impaired_crit_alt"]
@@ -365,10 +367,10 @@ var/static/impaired_scale = list(40, 40, 40, 20, 16, 12, 9, 6, 3, 1)
 			screen.transform = M
 
 
-	var/_b = 10 - _severity
+	var/_inverse_severity = 10 - _severity
 	var/_nearsightedness_scale = 1
-	if (_b > 0)
-		_nearsightedness_scale = min(40, 3 * _b)
+	if (_inverse_severity > 0)
+		_nearsightedness_scale = min(40, 3 * _inverse_severity)
 
 
 	var/obj/abstract/screen/fullscreen/screen = screens["impaired_crit"]

--- a/__DEFINES/preferences.dm
+++ b/__DEFINES/preferences.dm
@@ -20,6 +20,10 @@
 #define HEADSET_SOUND_TRANSMIT 1
 #define HEADSET_SOUND_ALL 2
 
+// /datum/preferences/var/plane_filters
+#define PLANE_FILTERS_DISABLED 0
+#define PLANE_FILTERS_ENABLED  1
+
 // list("None", "White Briefs", "Green Briefs", "Blue Briefs", "Black Briefs", "Grey Briefs", "Mankini", "Love-Hearts Boxers", "Black Boxers", "Grey Boxers", "Stripey Boxers", "Kinky", "Freedom Boxers", "Tea Boxers", "Communist Boxers", "Cowprint Boxers", "Green Wifebeater", "White Wifebeater", "Black Wifebeater")
 // Curse whoever made male/female underwear different colours
 #define UNDERWEAR_MALE_NONE 1

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -130,6 +130,11 @@
 	icon_state = "blurry"
 	//alpha = 0//set to 255 by update_fullscreen_alpha(); //not anymore, currently only used when getting pie'd
 
+
+/obj/abstract/screen/fullscreen/blurry/alt
+	color = "#808080"
+	alpha = 0
+
 /obj/abstract/screen/fullscreen/nearsighted
 	icon = 'icons/mob/screen1_blindness.dmi'
 	icon_state = "eye"

--- a/code/modules/client/preferences/pref_datums_client.dm
+++ b/code/modules/client/preferences/pref_datums_client.dm
@@ -206,6 +206,21 @@
 	var/p_speed = input(user, "Enter a number between 0 and 5 included (default=2)","Parallax Speed Preferences",setting)
 	setting = clamp(p_speed, min_value, max_value)
 
+/datum/preference_setting/toggle/plane_filters
+	name = "Plane filters"
+	sql_name = "plane_filters"
+	sql_table = "client"
+	enabled = TRUE
+
+	default_setting = TRUE
+
+/datum/preference_setting/toggle/plane_filters/choose_setting(var/mob/user)
+	. = ..()
+	if(user && isliving(user) && user.client)
+		var/mob/living/L = user
+		if (!L.client.prefs.get_pref(/datum/preference_setting/toggle/plane_filters))
+			L.disable_all_visual_filters()
+
 /datum/preference_setting/enum/special_popup
 	name = "Special popup"
 	sql_name = "special" // HISTORICAL REASONS :tm:

--- a/code/modules/client/preferences/preferences.dm
+++ b/code/modules/client/preferences/preferences.dm
@@ -1,7 +1,10 @@
-#define CHARACTER_SETUP 0
-#define UI_SETUP 1
-#define GENERAL_SETUP 2
-#define SPECIAL_ROLES_SETUP 3
+#define CHARACTER_SETUP     0
+#define GRAPHICS_SETUP      1
+#define UI_SETUP            2
+#define AUDIO_SETUP         3
+#define GENERAL_SETUP       4
+#define SPECIAL_ROLES_SETUP 5
+#define ADMIN_SETUP         6
 
 var/list/preferences_datums = list()
 var/global/list/special_roles = list(

--- a/code/modules/client/preferences/preferences_ui.dm
+++ b/code/modules/client/preferences/preferences_ui.dm
@@ -129,46 +129,115 @@
 
 	return dat
 
+/datum/preferences/proc/setup_graphics(var/dat, var/user)
+
+
+	dat += {"
+	<h1>Parallax Settings</h1>
+
+		<b>Space Parallax:</b>
+		<a href='?_src_=prefs;preference=space_parallax;task=input'><b>[get_pref(/datum/preference_setting/toggle/space_parallax) ? "Enabled" : "Disabled"]</b></a><br>
+
+		<b>Parallax Speed:</b>
+		<a href='?_src_=prefs;preference=parallax_speed;task=input'><b>[get_pref(/datum/preference_setting/numerical/parallax_speed) ]</b></a><br>
+
+		<b>Space Dust:</b>
+		<a href='?_src_=prefs;preference=space_dust;task=input'><b>[get_pref(/datum/preference_setting/toggle/space_dust) ? "Yes" : "No"]</b></a><br>
+
+	<h1>Misc Graphics Settings</h1>
+
+		<b>Attack Animations:<b>
+		<a href='?_src_=prefs;preference=attack_animation;task=input'><b>[get_pref(/datum/preference_setting/enum/attack_animations) ? (get_pref(/datum/preference_setting/enum/attack_animations) == ITEM_ANIMATION? "Item Anim." : "Person Anim.") : "No"]</b></a><br>
+
+		<b>Fancy Visual Filters:<b>
+		<a href='?_src_=prefs;preference=plane_filters;task=input'><b>[get_pref(/datum/preference_setting/toggle/plane_filters) ? "Enabled" : "Disabled"]</b></a><br>
+	"}
+
+	return dat
+
 /datum/preferences/proc/setup_UI(var/dat, var/user)
 
 
-	dat += {"<b>UI Style:</b> <a href='?_src_=prefs;preference=UI_style;task=input'><b>[get_pref(/datum/preference_setting/string/UI_style)]</b></a><br>
-	<b>Custom UI</b>(recommended for White UI): <span style='border:1px solid #161616; background-color: #[get_pref(/datum/preference_setting/string/UI_style_color)];'>&nbsp;&nbsp;&nbsp;</span><br>Color: <a href='?_src_=prefs;preference=UI_style_color;task=input'><b>[get_pref(/datum/preference_setting/string/UI_style_color)]</b></a><br>
-	Alpha(transparency): <a href='?_src_=prefs;preference=UI_style_alpha;task=input'><b>[get_pref(/datum/preference_setting/numerical/UI_style_alpha)]</b></a><br>
+	dat += {"
+	<h1>HUD Settings</h1>
+
+		<b>UI Style:</b> <a href='?_src_=prefs;preference=UI_style;task=input'><b>[get_pref(/datum/preference_setting/string/UI_style)]</b></a><br>
+		<b>Custom UI</b>(recommended for White UI): <span style='border:1px solid #161616; background-color: #[get_pref(/datum/preference_setting/string/UI_style_color)];'>&nbsp;&nbsp;&nbsp;</span><br>Color: <a href='?_src_=prefs;preference=UI_style_color;task=input'><b>[get_pref(/datum/preference_setting/string/UI_style_color)]</b></a><br>
+		Alpha(transparency): <a href='?_src_=prefs;preference=UI_style_alpha;task=input'><b>[get_pref(/datum/preference_setting/numerical/UI_style_alpha)]</b></a><br>
+
+	<h1>Runechat Settings</h1>
+
+		<b>Mob messages visible on map:</b>
+		<a href='?_src_=prefs;preference=mob_chat_on_map;task=input'>[get_pref(/datum/preference_setting/toggle/mob_chat_on_map) ? "Enabled" : "Disabled"]</a><br>
+
+		<b>Object messages visible on map:</b>
+		<a href='?_src_=prefs;preference=obj_chat_on_map;task=input'>[get_pref(/datum/preference_setting/toggle/obj_chat_on_map)  ? "Enabled" : "Disabled"]</a><br>
+
+		<b>Message character limit on map:</b>
+		<a href='?_src_=prefs;preference=max_chat_length;task=input'>[get_pref(/datum/preference_setting/numerical/max_chat_length)]</a><br>
+
+	<h1>Misc UI Settings</h1>
+
+		<b>Hide object messages from chat window:</b>
+		<a href='?_src_=prefs;preference=no_goonchat_for_obj;task=input'>[get_pref(/datum/preference_setting/toggle/no_goonchat_for_obj) ? "Enabled" : "Disabled"]</a><br>
+
+		<b>Say bubbles:</b>
+		<a href='?_src_=prefs;preference=typing_indicator;task=input'><b>[get_pref(/datum/preference_setting/toggle/typing_indicator) ? "Active" : "Inactive"]</b></a><br>
+
+		<b>Progress Bars:</b>
+		<a href='?_src_=prefs;preference=progress_bars;task=input'><b>[get_pref(/datum/preference_setting/toggle/progress_bars) ? "Yes" : "No"]</b></a><br>
+
+		<b>Window Flashing</b>
+		<a href='?_src_=prefs;preference=window_flashing;task=input'><b>[get_pref(/datum/preference_setting/toggle/window_flashing) ? "Yes":"No"]</b></a><br>
+
+		<b>Fancy tgui:</b>
+		<a href='?_src_=prefs;preference=tgui_fancy;task=input'>[get_pref(/datum/preference_setting/toggle/tgui_fancy) ? "Enabled" : "Disabled"]</a><br>
+
+	"}
+
+	return dat
+
+/datum/preferences/proc/setup_audio(var/dat, var/user)
+	dat += {"
+		<b>Play admin midis:</b>
+		<a href='?_src_=prefs;preference=toggles;task=input;toggle=[SOUND_MIDI]'><b>[(get_pref(/datum/preference_setting/binary_flag/toggles) & SOUND_MIDI) ? "Yes" : "No"]</b></a><br>
+
+		<b>Play lobby music:</b>
+		<a href='?_src_=prefs;preference=toggles;task=input;toggle=[SOUND_LOBBY]'><b>[(get_pref(/datum/preference_setting/binary_flag/toggles) & SOUND_LOBBY) ? "Yes" : "No"]</b></a><br>
+
+		<b>Play Ambience:</b>
+		<a href='?_src_=prefs;preference=toggles;task=input;toggle=[SOUND_AMBIENCE]'><b>[(get_pref(/datum/preference_setting/binary_flag/toggles) & SOUND_AMBIENCE) ? "Yes" : "No"]</b></a><br>
+		[(get_pref(/datum/preference_setting/binary_flag/toggles) & SOUND_AMBIENCE)? \
+		"<b>Ambience Volume:</b><a href='?_src_=prefs;preference=ambience_volume;task=input'><b>[get_pref(/datum/preference_setting/numerical/ambience_volume)]</b></a><br>":""]
+
+		<b>Radio Headset Sounds:</b>
+		<a href='?_src_=prefs;preference=headset_sound;task=input'><b>[headset_sound_text2num[get_pref(/datum/preference_setting/numerical/headset_sound)+1]]</b></a><br>
+
+		<b>Hear streamed media:</b>
+		<a href='?_src_=prefs;preference=toggles;task=input;toggle=[SOUND_STREAMING]'><b>[(get_pref(/datum/preference_setting/binary_flag/toggles) & SOUND_STREAMING) ? "Yes" : "No"]</b></a><br>
+
+		<b>Streaming Program:</b>
+		<a href='?_src_=prefs;preference=usewmp;task=input'><b>[get_pref(/datum/preference_setting/toggle/usewmp) ? "WMP (compatibility)" : "VLC (requires plugin)"]</b></a><br>
+
+		<b>Streaming Volume</b>
+		<a href='?_src_=prefs;preference=volume;task=input'><b>[get_pref(/datum/preference_setting/numerical/volume) ]</b></a><br>
+
+		<b>Hear player voices</b>
+		<a href='?_src_=prefs;preference=hear_voicesound;task=input'><b>[(get_pref(/datum/preference_setting/toggle/hear_voicesound)) ? "Yes" : "No"]</b></a><br>
+
+		<b>Hear instruments</b>
+		<a href='?_src_=prefs;preference=hear_instruments;task=input'><b>[(get_pref(/datum/preference_setting/toggle/hear_instruments)) ? "Yes":"No"]</b></a><br>
+
+		<b>Server Shutdown Jingle <span title='These jingles will only play if credits don&#39;t roll for you that round. &#39;Classics&#39; will only play &#39;APC Destroyed&#39; and &#39;Banging Donk&#39;, &#39;All&#39; will play the previous plus retro videogame sounds.'>(?):</span><b>
+		<a href='?_src_=prefs;preference=jingle;task=input'><b>[get_pref(/datum/preference_setting/enum/jingle)]</b></a><br>
+		<b>Credits/Jingle Volume:</b>
+		<a href='?_src_=prefs;preference=credits_volume;task=input'><b>[get_pref(/datum/preference_setting/numerical/credits_volume)]</b></a><br>
+
 	"}
 
 	return dat
 
 /datum/preferences/proc/setup_special(var/dat, var/mob/user)
-	if(user.client.holder)
-		dat += {"
-		<h1><font color=red>Admin Only Settings</font></h1>
-
-	<div id="container" style="border:1px solid #000; width:96%; padding-left:2%; padding-right:2%; overflow:auto; padding-top:5px; padding-bottom:5px;">
-	  <div id="leftDiv" style="width:50%;height:100%;float:left;">
-		<b>Toggle Adminhelp Sound</b>
-		<a href='?_src_=prefs;preference=toggles;task=input;toggle=[SOUND_ADMINHELP]'><b>[get_pref(/datum/preference_setting/binary_flag/toggles) & SOUND_ADMINHELP ? "Enabled" : "Disabled"]</b></a><br>
-
-		<b>Toggle Prayers</b>
-		<a href='?_src_=prefs;preference=toggles;task=input;toggle=[CHAT_PRAYER]'><b>[get_pref(/datum/preference_setting/binary_flag/toggles) & CHAT_PRAYER ? "Enabled" : "Disabled"]</b></a><br>
-
-		<b>Toggle Hear Radio</b>
-		<a href='?_src_=prefs;preference=toggles;task=input;toggle=[CHAT_GHOSTRADIO]'><b>[get_pref(/datum/preference_setting/binary_flag/toggles) & CHAT_GHOSTRADIO ? "Enabled" : "Disabled"]</b></a><br>
-	  </div>
-
-	  <div id="rightDiv" style="width:50%;height:100%;float:right;">
-		<b>Toggle Attack Logs</b>
-		<a href='?_src_=prefs;preference=toggles;task=input;toggle=[CHAT_ATTACKLOGS]'><b>[get_pref(/datum/preference_setting/binary_flag/toggles) & CHAT_ATTACKLOGS ? "Enabled" : "Disabled"]</b></a><br>
-
-		<b>Toggle Debug Logs</b>
-		<a href='?_src_=prefs;preference=toggles;task=input;toggle=[CHAT_DEBUGLOGS]'><b>[get_pref(/datum/preference_setting/binary_flag/toggles) & CHAT_DEBUGLOGS ? "Enabled" : "Disabled"]</b></a><br>
-
-		<b>De-admin on login</b>
-		<a href='?_src_=prefs;preference=toggles;task=input;toggle=[AUTO_DEADMIN]'><b>[get_pref(/datum/preference_setting/binary_flag/toggles) & AUTO_DEADMIN ? "Enabled" : "Disabled"]</b></a><br>
-
-	  </div>
-	</div>"}
-
 	dat += {"
 	<h1>General Settings</h1>
 <div id="container" style="border:1px solid #000; width:96; padding-left:2%; padding-right:2%; overflow:auto; padding-top:5px; padding-bottom:5px;">
@@ -176,47 +245,6 @@
 
 	<b>FPS:</b>
 	<a href='?_src_=prefs;preference=fps;task=input'><b>[get_pref(/datum/preference_setting/numerical/fps)]</b></a><br>
-
-	<b>Space Parallax:</b>
-	<a href='?_src_=prefs;preference=space_parallax;task=input'><b>[get_pref(/datum/preference_setting/toggle/space_parallax) ? "Enabled" : "Disabled"]</b></a><br>
-
-	<b>Parallax Speed:</b>
-	<a href='?_src_=prefs;preference=parallax_speed;task=input'><b>[get_pref(/datum/preference_setting/numerical/parallax_speed) ]</b></a><br>
-
-	<b>Space Dust:</b>
-	<a href='?_src_=prefs;preference=space_dust;task=input'><b>[get_pref(/datum/preference_setting/toggle/space_dust) ? "Yes" : "No"]</b></a><br>
-
-	<b>Play admin midis:</b>
-	<a href='?_src_=prefs;preference=toggles;task=input;toggle=[SOUND_MIDI]'><b>[(get_pref(/datum/preference_setting/binary_flag/toggles) & SOUND_MIDI) ? "Yes" : "No"]</b></a><br>
-
-	<b>Play lobby music:</b>
-	<a href='?_src_=prefs;preference=toggles;task=input;toggle=[SOUND_LOBBY]'><b>[(get_pref(/datum/preference_setting/binary_flag/toggles) & SOUND_LOBBY) ? "Yes" : "No"]</b></a><br>
-
-	<b>Play Ambience:</b>
-	<a href='?_src_=prefs;preference=toggles;task=input;toggle=[SOUND_AMBIENCE]'><b>[(get_pref(/datum/preference_setting/binary_flag/toggles) & SOUND_AMBIENCE) ? "Yes" : "No"]</b></a><br>
-	[(get_pref(/datum/preference_setting/binary_flag/toggles) & SOUND_AMBIENCE)? \
-	"<b>Ambience Volume:</b><a href='?_src_=prefs;preference=ambience_volume;task=input'><b>[get_pref(/datum/preference_setting/numerical/ambience_volume)]</b></a><br>":""]
-
-	<b>Radio Headset Sounds:</b>
-	<a href='?_src_=prefs;preference=headset_sound;task=input'><b>[headset_sound_text2num[get_pref(/datum/preference_setting/numerical/headset_sound)+1]]</b></a><br>
-
-	<b>Hear streamed media:</b>
-	<a href='?_src_=prefs;preference=toggles;task=input;toggle=[SOUND_STREAMING]'><b>[(get_pref(/datum/preference_setting/binary_flag/toggles) & SOUND_STREAMING) ? "Yes" : "No"]</b></a><br>
-
-	<b>Streaming Program:</b>
-	<a href='?_src_=prefs;preference=usewmp;task=input'><b>[get_pref(/datum/preference_setting/toggle/usewmp) ? "WMP (compatibility)" : "VLC (requires plugin)"]</b></a><br>
-
-	<b>Streaming Volume</b>
-	<a href='?_src_=prefs;preference=volume;task=input'><b>[get_pref(/datum/preference_setting/numerical/volume) ]</b></a><br>
-
-	<b>Hear player voices</b>
-	<a href='?_src_=prefs;preference=hear_voicesound;task=input'><b>[(get_pref(/datum/preference_setting/toggle/hear_voicesound)) ? "Yes" : "No"]</b></a><br>
-
-	<b>Hear instruments</b>
-	<a href='?_src_=prefs;preference=hear_instruments;task=input'><b>[(get_pref(/datum/preference_setting/toggle/hear_instruments)) ? "Yes":"No"]</b></a><br>
-
-	<b>Progress Bars:</b>
-	<a href='?_src_=prefs;preference=progress_bars;task=input'><b>[get_pref(/datum/preference_setting/toggle/progress_bars) ? "Yes" : "No"]</b></a><br>
 
 	<b>Pause after first step:</b>
 	<a href='?_src_=prefs;preference=stumble;task=input'><b>[get_pref(/datum/preference_setting/toggle/stumble) ? "Yes" : "No"]</b></a><br>
@@ -226,9 +254,6 @@
 
 	<b>Solo Antag Objectives:</b>
 	<a href='?_src_=prefs;preference=antag_objectives;task=input'><b>[get_pref(/datum/preference_setting/toggle/antag_objectives) ? "Standard" : "Freeform"]</b></a><br>
-
-	<b>Say bubbles:</b>
-	<a href='?_src_=prefs;preference=typing_indicator;task=input'><b>[get_pref(/datum/preference_setting/toggle/typing_indicator) ? "Active" : "Inactive"]</b></a><br>
   </div>
 
   <div id="rightDiv" style="width:50%;height:100%;float:right;">
@@ -263,37 +288,12 @@
 	<b>Adminhelp Special Tab:</b>
 	<a href='?_src_=prefs;preference=special;task=input'><b>[special_popup_text2num[get_pref(/datum/preference_setting/enum/special_popup)+1]]</b></a><br>
 
-	<b>Attack Animations:<b>
-	<a href='?_src_=prefs;preference=attack_animation;task=input'><b>[get_pref(/datum/preference_setting/enum/attack_animations) ? (get_pref(/datum/preference_setting/enum/attack_animations) == ITEM_ANIMATION? "Item Anim." : "Person Anim.") : "No"]</b></a><br>
-
 	<b>Show Credits <span title='&#39;No Reruns&#39; will roll credits only if an admin customized something about this round&#39;s credits, or if a rare and exclusive episode name was selected thanks to something uncommon happening that round.'>(?):</span><b>
 	<a href='?_src_=prefs;preference=credits;task=input'><b>[get_pref(/datum/preference_setting/enum/credits)]</b></a><br>
 
-	<b>Server Shutdown Jingle <span title='These jingles will only play if credits don&#39;t roll for you that round. &#39;Classics&#39; will only play &#39;APC Destroyed&#39; and &#39;Banging Donk&#39;, &#39;All&#39; will play the previous plus retro videogame sounds.'>(?):</span><b>
-	<a href='?_src_=prefs;preference=jingle;task=input'><b>[get_pref(/datum/preference_setting/enum/jingle)]</b></a><br>
-	<b>Credits/Jingle Volume:</b>
 
-	<a href='?_src_=prefs;preference=credits_volume;task=input'><b>[get_pref(/datum/preference_setting/numerical/credits_volume)]</b></a><br>
 
-	<b>Window Flashing</b>
-	<a href='?_src_=prefs;preference=window_flashing;task=input'><b>[get_pref(/datum/preference_setting/toggle/window_flashing) ? "Yes":"No"]</b></a><br>
 
-	<b>Fancy tgui:</b>
-	<a href='?_src_=prefs;preference=tgui_fancy;task=input'>[get_pref(/datum/preference_setting/toggle/tgui_fancy) ? "Enabled" : "Disabled"]</a><br>
-
-	<center>Runechat prefererences</center>
-
-	<b>Chat on map for mobs:</b>
-	<a href='?_src_=prefs;preference=mob_chat_on_map;task=input'>[get_pref(/datum/preference_setting/toggle/mob_chat_on_map) ? "Enabled" : "Disabled"]</a><br>
-
-	<b>Chat on map for objects:</b>
-	<a href='?_src_=prefs;preference=obj_chat_on_map;task=input'>[get_pref(/datum/preference_setting/toggle/obj_chat_on_map)  ? "Enabled" : "Disabled"]</a><br>
-
-	<b>No goonchat messages for objects:</b>
-	<a href='?_src_=prefs;preference=no_goonchat_for_obj;task=input'>[get_pref(/datum/preference_setting/toggle/no_goonchat_for_obj) ? "Enabled" : "Disabled"]</a><br>
-
-	<b>Runechat message char limit:</b>
-	<a href='?_src_=prefs;preference=max_chat_length;task=input'>[get_pref(/datum/preference_setting/numerical/max_chat_length)]</a><br>
   </div>
 </div>"}
 
@@ -301,6 +301,38 @@
 		dat += "<b>OOC Notes:</b> <a href='?_src_=prefs;preference=metadata;task=input'> Edit </a><br>"
 
 	return dat
+
+/datum/preferences/proc/setup_admin(var/dat, var/mob/user)
+	if(user.client.holder)
+		dat += {"
+		<h1><font color=red>Admin Only Settings</font></h1>
+
+		<div id="container" style="border:1px solid #000; width:96%; padding-left:2%; padding-right:2%; overflow:auto; padding-top:5px; padding-bottom:5px;">
+		  <div id="leftDiv" style="width:50%;height:100%;float:left;">
+			<b>Toggle Adminhelp Sound</b>
+			<a href='?_src_=prefs;preference=toggles;task=input;toggle=[SOUND_ADMINHELP]'><b>[get_pref(/datum/preference_setting/binary_flag/toggles) & SOUND_ADMINHELP ? "Enabled" : "Disabled"]</b></a><br>
+
+			<b>Toggle Prayers</b>
+			<a href='?_src_=prefs;preference=toggles;task=input;toggle=[CHAT_PRAYER]'><b>[get_pref(/datum/preference_setting/binary_flag/toggles) & CHAT_PRAYER ? "Enabled" : "Disabled"]</b></a><br>
+
+			<b>Toggle Hear Radio</b>
+			<a href='?_src_=prefs;preference=toggles;task=input;toggle=[CHAT_GHOSTRADIO]'><b>[get_pref(/datum/preference_setting/binary_flag/toggles) & CHAT_GHOSTRADIO ? "Enabled" : "Disabled"]</b></a><br>
+		  </div>
+
+		  <div id="rightDiv" style="width:50%;height:100%;float:right;">
+			<b>Toggle Attack Logs</b>
+			<a href='?_src_=prefs;preference=toggles;task=input;toggle=[CHAT_ATTACKLOGS]'><b>[get_pref(/datum/preference_setting/binary_flag/toggles) & CHAT_ATTACKLOGS ? "Enabled" : "Disabled"]</b></a><br>
+
+			<b>Toggle Debug Logs</b>
+			<a href='?_src_=prefs;preference=toggles;task=input;toggle=[CHAT_DEBUGLOGS]'><b>[get_pref(/datum/preference_setting/binary_flag/toggles) & CHAT_DEBUGLOGS ? "Enabled" : "Disabled"]</b></a><br>
+
+			<b>De-admin on login</b>
+			<a href='?_src_=prefs;preference=toggles;task=input;toggle=[AUTO_DEADMIN]'><b>[get_pref(/datum/preference_setting/binary_flag/toggles) & AUTO_DEADMIN ? "Enabled" : "Disabled"]</b></a><br>
+
+		  </div>
+		</div>"}
+	return dat
+
 
 /datum/preferences/proc/getPrefLevelText(var/datum/job/job)
 	var/list/jobs = get_pref(/datum/preference_setting/assoc_list_setting/jobs)
@@ -472,9 +504,15 @@
 		dat += "Please create an account to save your preferences."
 
 	dat += "<center><a href='?_src_=prefs;action=tab;tab=0' [current_tab == CHARACTER_SETUP ? "class='linkOn'" : ""]>Character Settings</a> | "
-	dat += "<a href='?_src_=prefs;action=tab;tab=1' [current_tab == UI_SETUP ? "class='linkOn'" : ""]>UI Settings</a> | "
-	dat += "<a href='?_src_=prefs;action=tab;tab=2' [current_tab == GENERAL_SETUP ? "class='linkOn'" : ""]>General Settings</a> | "
-	dat += "<a href='?_src_=prefs;action=tab;tab=3' [current_tab == SPECIAL_ROLES_SETUP ? "class='linkOn'" : ""]>Special Roles</a></center><br>"
+	dat += "<a href='?_src_=prefs;action=tab;tab=1' [current_tab == GRAPHICS_SETUP ? "class='linkOn'" : ""]>Graphics Settings</a> | "
+	dat += "<a href='?_src_=prefs;action=tab;tab=2' [current_tab == UI_SETUP ? "class='linkOn'" : ""]>UI Settings</a> | "
+	dat += "<a href='?_src_=prefs;action=tab;tab=3' [current_tab == AUDIO_SETUP ? "class='linkOn'" : ""]>Audio Settings</a> | "
+	dat += "<a href='?_src_=prefs;action=tab;tab=4' [current_tab == GENERAL_SETUP ? "class='linkOn'" : ""]>General Settings</a> | "
+	dat += "<a href='?_src_=prefs;action=tab;tab=5' [current_tab == SPECIAL_ROLES_SETUP ? "class='linkOn'" : ""]>Special Roles</a>"
+	if(user.client.holder)
+		dat += " | <a href='?_src_=prefs;action=tab;tab=6' [current_tab == ADMIN_SETUP ? "class='linkOn'" : ""]>Admin-Only Settings</a>"
+
+	dat += "</center><br>"
 
 	if(appearance_isbanned(user))
 		dat += "<b>You are banned from using custom names and appearances. You can continue to adjust your characters, but you will be randomised once you join the game.</b><br>"
@@ -482,12 +520,18 @@
 	switch(current_tab)
 		if(CHARACTER_SETUP)
 			dat = setup_character_options(dat, user)
+		if(GRAPHICS_SETUP)
+			dat = setup_graphics(dat, user)
 		if(UI_SETUP)
 			dat = setup_UI(dat, user)
+		if(AUDIO_SETUP)
+			dat = setup_audio(dat, user)
 		if(GENERAL_SETUP)
 			dat = setup_special(dat, user)
 		if(SPECIAL_ROLES_SETUP)
 			dat = configure_special_roles(dat, user)
+		if(ADMIN_SETUP)
+			dat = setup_admin(dat, user)
 
 	dat += "<div style='float:none;'><br><hr><center>"
 

--- a/code/modules/migrations/SS13_Prefs/030-plane-filters.dm
+++ b/code/modules/migrations/SS13_Prefs/030-plane-filters.dm
@@ -1,0 +1,13 @@
+/datum/migration/sqlite/ss13_prefs/_030
+	id = 30
+	name = "Plane Filters"
+
+/datum/migration/sqlite/ss13_prefs/_030/up()
+	if(!hasColumn("client","plane_filters"))
+		return execute("ALTER TABLE `client` ADD COLUMN plane_filters INTEGER DEFAULT 1")
+	return TRUE
+
+/datum/migration/sqlite/ss13_prefs/_030/down()
+	if(hasColumn("client","plane_filters"))
+		return execute("ALTER TABLE `client` DROP COLUMN plane_filters")
+	return TRUE

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -697,28 +697,6 @@
 	else
 		clear_alert(SCREEN_ALARM_TEMPERATURE)
 
-	if(stat != DEAD)
-		var/impaired_vision = get_impaired_vision_range()
-		if(impaired_vision > 0)
-			enable_nearsightedness(impaired_vision)
-		else if (perception_filters.enabled_filters & P_FILTER_IMPAIRED_VISION)
-			disable_nearsightedness()
-
-		if(eye_blurry)
-			enable_blurriness(eye_blurry)
-		else if (perception_filters.enabled_filters & P_FILTER_BLURRY_VISION)
-			disable_blurriness()
-
-		if(druggy)
-			enable_druggy_overlays()
-		else
-			disable_druggy_overlays()
-	else
-		if (perception_filters.enabled_filters & P_FILTER_IMPAIRED_VISION)
-			disable_nearsightedness()
-		if (perception_filters.enabled_filters & P_FILTER_BLURRY_VISION)
-			disable_blurriness()
-
 	if (stat != 2)
 		if (machine)
 			if (!( machine.check_eye(src) ))

--- a/code/modules/mob/living/silicon/robot/robot_hud.dm
+++ b/code/modules/mob/living/silicon/robot/robot_hud.dm
@@ -49,6 +49,8 @@
 
 	update_pull_icon()
 
+	filter_update_delay = -1
+
 	var/impaired_vision = get_impaired_vision_range()
 	if(impaired_vision > 0)
 		enable_nearsightedness(impaired_vision)

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -1910,6 +1910,7 @@
 #include "code\modules\migrations\SS13_Prefs\027-refactor-jobs.dm"
 #include "code\modules\migrations\SS13_Prefs\028-headset-sounds.dm"
 #include "code\modules\migrations\SS13_Prefs\029-wage-ratio.dm"
+#include "code\modules\migrations\SS13_Prefs\030-plane-filters.dm"
 #include "code\modules\migrations\SS13_Prefs\_base.dm"
 #include "code\modules\mining\abandonedcrates.dm"
 #include "code\modules\mining\debug_shit.dm"


### PR DESCRIPTION
<img width="1936" height="949" alt="image" src="https://github.com/user-attachments/assets/73fd94c8-a256-46c6-9646-95fccc5dc5e3" />

<img width="553" height="875" alt="image" src="https://github.com/user-attachments/assets/12060f6c-7da3-4091-a53b-d68785db295b" />

:cl:
* experiment: The General Settings tab of the Character Setup window has been split into 4 tabs, including ones for Graphics, UI, and Audio settings.
* experiment: The new Graphics Settings tab has a new Fancy Visual Filters toggle to replace the new blurry and nearsightedness filters with alternatives that don't rely on Byond's built-in filter effects. For players who either don't like the filters, or who experience framedrops on their machine.