### PR TITLE
Fixes ghetto implant surgery

### DIFF
--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -172,7 +172,7 @@
 /datum/surgery_step/cavity/implant_removal
 	allowed_tools = list(
 		/obj/item/tool/hemostat = 100,
-		"wirecutters" = 75,
+		/obj/item/tool/wirecutters = 75,
 		/obj/item/weapon/talisman = 70,
 		/obj/item/weapon/kitchen/utensil/fork = 20,
 		)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
Fixes the type pathing on wirecutters so they can ghetto hemostat as intended
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## Why it's good
fixes intended behavior
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->

## How it was tested
Tested relevant surgery with wirecutters to check if it worked.
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed a bug where wirecutters could not be used for ghetto implant surgery.
