### PR TITLE
botany seed hotfix

### DIFF
--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -544,10 +544,12 @@
 /obj/item/seeds/flaxseed
 	name = "packet of flax seeds"
 	seed_type = "flax"
+	vending_cat = "flowers"
 
 /obj/item/seeds/mintseed
 	name = "packet of mint seeds"
-	seed_type = "weeds"
+	seed_type = "mint"
+	vending_cat = "weeds"
 
 // Chili plants/variants.
 /datum/seed/chili


### PR DESCRIPTION
## What this does
adds a missing vending_cat to flax seeds and fixes an oversight on the mint seed
:cl:
 * bugfix: Flax and mint should be organized properly on the seed vendor.