### PR TITLE
Buffs potent ham

### DIFF
--- a/code/modules/reagents/reagents/reagents_toxin.dm
+++ b/code/modules/reagents/reagents/reagents_toxin.dm
@@ -241,7 +241,7 @@
 	if(..())
 		return 1
 
-	empulse(get_turf(M), 1, 2, 1)
+	empulse(get_turf(M), 100, 200, 1)
 
 	return
 


### PR DESCRIPTION
## What this does
Makes the EMP pulse of a Potent Ham match the intensity of a supermatter delamination.
## Why it's good
The current EMP is extremely underwhelming compared to the effort involved in making the potent ham. Even a 30s danchocolate + metal sheet EMP is stronger. This feels like a good reward, and actually makes it usable, if anyone bothers.
:cl:
 * tweak: The EMP pulse caused by Potent Ham now matches the intensity of a Supermatter Delamination's EMP (without the explosion).