### PR TITLE
Makes browser datum windows use proper DPI settings

### DIFF
--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -102,6 +102,11 @@
 	if (width && height)
 		window_size = "size=[width]x[height];"
 	user << browse(get_content(), "window=[window_id];[window_size][window_options]")
+	if (width && height)
+		var/dpi = winget(user, window_id, "dpi")
+		if(!dpi)
+			dpi = 1
+		winset(user, window_id, "size=[width*dpi]x[height*dpi]")
 	if (use_onclose)
 		onclose(user, window_id, ref)
 

--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -98,10 +98,7 @@
 	"}
 
 /datum/browser/proc/open(var/use_onclose = 1)
-	var/window_size = ""
-	if (width && height)
-		window_size = "size=[width]x[height];"
-	user << browse(get_content(), "window=[window_id];[window_size][window_options]")
+	user << browse(get_content(), "window=[window_id];[window_options]")
 	if (width && height)
 		var/dpi = text2num(winget(user, window_id, "dpi")) || 1
 		winset(user, window_id, "size=[width*dpi]x[height*dpi]")

--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -103,9 +103,7 @@
 		window_size = "size=[width]x[height];"
 	user << browse(get_content(), "window=[window_id];[window_size][window_options]")
 	if (width && height)
-		var/dpi = winget(user, window_id, "dpi")
-		if(!dpi)
-			dpi = 1
+		var/dpi = text2num(winget(user, window_id, "dpi")) || 1
 		winset(user, window_id, "size=[width*dpi]x[height*dpi]")
 	if (use_onclose)
 		onclose(user, window_id, ref)


### PR DESCRIPTION
[UI]

## What this does
Makes use of this, added in BYOND 516.

## Why it's good
I do stuff in 4K now and the windows weren't looking right.

## How it was tested
The login menu, it using this.

## Changelog
:cl:
 * bugfix: Basic browser datum popups now account for DPI.