### PR TITLE
minor jungle fixes

### DIFF
--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -4,8 +4,8 @@
 
 //Fence smashing sound downloaded from http://freesound.org/people/hintringer/sounds/274768/
 
-#define CUT_TIME (20 SECONDS)
-#define CLIMB_TIME (20 SECONDS)
+#define CUT_TIME (10 SECONDS)
+#define CLIMB_TIME (5 SECONDS)
 
 #define NO_HOLE 0 //section is intact
 #define SMALL_HOLE 1 //small hole in the section - can pass small items through.

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -25,6 +25,7 @@
 	var/cuttable = TRUE
 	var/hole_size= NO_HOLE
 	var/invulnerable = FALSE
+	var/rodsadded=FALSE
 
 /obj/structure/fence/New()
 	..()
@@ -105,6 +106,23 @@
 
 	if(hole_size >= SMALL_HOLE)
 		user.drop_item(W, get_turf(src))
+
+	if(rodsadded && iswelder(W))
+		var/obj/item/tool/weldingtool/WT = W
+		user.visible_message("<span class='notice'>[user] begins welding the rods in \the [src] to restore it.</span>", "<span class='notice'>You begin welding the rods in \the [src] to restore it.</span>")
+		if(WT.do_weld(user,src,3 SECONDS,0))
+			user.visible_message("<span class='notice'>[user] restores \the [src]'s structure.</span>", "<span class='notice'>You restore \the [src]'s structure.</span>")
+			hole_size=NO_HOLE
+			rodsadded=FALSE
+			update_cut_status()
+	if(!rodsadded && hole_size && istype(W, /obj/item/stack/rods))
+		var/obj/item/stack/rods/R = W
+		if(R.amount < hole_size)
+			to_chat(user, "<span class='info'>You'll need more rods to patch the hole!</span>")
+			return FALSE
+		user.visible_message("<span class='notice'>[user] inserts some rods into \the [src]'s structure.</span>", "<span class='notice'>You insert some rods into \the [src]'s structure.</span>")
+		R.use(hole_size)
+		rodsadded=TRUE
 
 /obj/structure/fence/attack_hand(mob/user)
 	if(user.a_intent == I_HURT)

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -104,8 +104,6 @@
 				update_cut_status()
 		return
 
-	if(hole_size >= SMALL_HOLE)
-		user.drop_item(W, get_turf(src))
 
 	if(rodsadded && iswelder(W))
 		var/obj/item/tool/weldingtool/WT = W
@@ -115,6 +113,8 @@
 			hole_size=NO_HOLE
 			rodsadded=FALSE
 			update_cut_status()
+			return TRUE
+		return FALSE
 	if(!rodsadded && hole_size && istype(W, /obj/item/stack/rods))
 		var/obj/item/stack/rods/R = W
 		if(R.amount < hole_size)
@@ -123,6 +123,10 @@
 		user.visible_message("<span class='notice'>[user] inserts some rods into \the [src]'s structure.</span>", "<span class='notice'>You insert some rods into \the [src]'s structure.</span>")
 		R.use(hole_size)
 		rodsadded=TRUE
+		return TRUE
+
+	if(hole_size >= SMALL_HOLE)
+		user.drop_item(W, get_turf(src))
 
 /obj/structure/fence/attack_hand(mob/user)
 	if(user.a_intent == I_HURT)

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -102,7 +102,7 @@
 
 				update_cut_status()
 		return
-	
+
 	if(hole_size >= SMALL_HOLE)
 		user.drop_item(W, get_turf(src))
 

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -25,7 +25,6 @@
 	var/cuttable = TRUE
 	var/hole_size= NO_HOLE
 	var/invulnerable = FALSE
-	var/rodsadded=FALSE
 
 /obj/structure/fence/New()
 	..()
@@ -104,29 +103,6 @@
 				update_cut_status()
 		return
 
-
-	if(rodsadded && iswelder(W))
-		var/obj/item/tool/weldingtool/WT = W
-		user.visible_message("<span class='notice'>[user] begins welding the rods in \the [src] to restore it.</span>", "<span class='notice'>You begin welding the rods in \the [src] to restore it.</span>")
-		if(WT.do_weld(user,src,3 SECONDS,0))
-			user.visible_message("<span class='notice'>[user] restores \the [src]'s structure.</span>", "<span class='notice'>You restore \the [src]'s structure.</span>")
-			hole_size=NO_HOLE
-			rodsadded=FALSE
-			update_cut_status()
-			return TRUE
-		return FALSE
-	if(!rodsadded && hole_size && istype(W, /obj/item/stack/rods))
-		var/obj/item/stack/rods/R = W
-		if(R.amount < hole_size)
-			to_chat(user, "<span class='info'>You'll need more rods to patch the hole!</span>")
-			return FALSE
-		user.visible_message("<span class='notice'>[user] inserts some rods into \the [src]'s structure.</span>", "<span class='notice'>You insert some rods into \the [src]'s structure.</span>")
-		R.use(hole_size)
-		rodsadded=TRUE
-		return TRUE
-
-	if(hole_size >= SMALL_HOLE)
-		user.drop_item(W, get_turf(src))
 
 /obj/structure/fence/attack_hand(mob/user)
 	if(user.a_intent == I_HURT)

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -102,7 +102,9 @@
 
 				update_cut_status()
 		return
-
+	
+	if(hole_size >= SMALL_HOLE)
+		user.drop_item(W, get_turf(src))
 
 /obj/structure/fence/attack_hand(mob/user)
 	if(user.a_intent == I_HURT)

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -4,8 +4,8 @@
 
 //Fence smashing sound downloaded from http://freesound.org/people/hintringer/sounds/274768/
 
-#define CUT_TIME (10 SECONDS)
-#define CLIMB_TIME (5 SECONDS)
+#define CUT_TIME (20 SECONDS)
+#define CLIMB_TIME (20 SECONDS)
 
 #define NO_HOLE 0 //section is intact
 #define SMALL_HOLE 1 //small hole in the section - can pass small items through.

--- a/code/modules/mob/living/complex_animal/jungle_mobs/crocodile.dm
+++ b/code/modules/mob/living/complex_animal/jungle_mobs/crocodile.dm
@@ -71,6 +71,7 @@
 	maxHealth=120
 	armor=list(melee=35,bullet=15,laser=20,energy=0,bomb=10,bio=0,rad=0)
 	petable=TRUE
+	is_pet=TRUE
 
 /mob/living/simple_animal/complex/crocodile/schnapps/get_offspring_cost()
 	return 0 //no infinite schnapps.	

--- a/maps/junglestation.dmm
+++ b/maps/junglestation.dmm
@@ -24699,7 +24699,6 @@
 /obj/structure/table/woodentable,
 /obj/item/clothing/accessory/storage/bandolier,
 /obj/item/weapon/gun/projectile/shotgun/doublebarrel,
-/obj/machinery/reagentgrinder,
 /obj/item/stack/sheet/metal{
 	amount = 50
 	},
@@ -31312,15 +31311,12 @@
 /area/surface/jungle/vault)
 "lEP" = (
 /obj/structure/closet/secure_closet/freezer/meat,
-/obj/machinery/alarm{
-	pixel_y = 23
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/obj/structure/wc/sink/kitchen{
-	pixel_y = 28;
-	dir = 1
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
 	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
@@ -37978,6 +37974,10 @@
 	},
 /obj/machinery/camera{
 	dir = 6
+	},
+/obj/structure/wc/sink/kitchen{
+	pixel_y = 28;
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
@@ -47560,7 +47560,7 @@
 /obj/machinery/door_control{
 	id_tag = "kitchen";
 	name = "Kitchen Shutters Control";
-	pixel_y = -30;
+	pixel_y = -22;
 	req_access_txt = "28"
 	},
 /turf/unsimulated/floor/planetary/path/jungle_plated,


### PR DESCRIPTION
[jungle] [bugfix] [tweak]

## What this does
* closes #38966 by moving the sink and air alarm
* removes a duplicate grinder in jungle's bar
* schnapps counts as a station pet and will award points if rescued to the escape shuttle

## Why it's good
mapping improvements are good, right?

## How it was tested
went in game and verified that you can repair fences

## Changelog
:cl:
 * bugfix: jungle: removed a duplicate grinder in bar
 * bugfix: jungle: fixed overlapping sink and air alarm in kitchen
