### PR TITLE
Fixes books from checkout spawning with wrong spine color

### DIFF
--- a/code/modules/library/computers/checkout.dm
+++ b/code/modules/library/computers/checkout.dm
@@ -669,6 +669,7 @@
 		else
 			B.icon_state = "book[rand(1,9)]"
 	B.item_state = B.icon_state
+	B.update_icon()
 	printbook(B, forceprint)
 
 #undef MAIN_MENU

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -418,6 +418,27 @@
 	else
 		..()
 
+/obj/item/weapon/book/update_icon()
+	switch(icon_state)
+		if("book1")
+			spine_color = "#888"
+		if("book2")
+			spine_color = "#800"
+		if("book3")
+			spine_color = "#880"
+		if("book4")
+			spine_color = "#088"
+		if("book5")
+			spine_color = "#080"
+		if("book6")
+			spine_color = "#808"
+		if("book7")
+			spine_color = "#fff"
+		if("book8")
+			spine_color = "#444"
+		if("book9")
+			spine_color = "#840"
+
 /*
  * Traitor Ooccult Books
  */
@@ -482,25 +503,7 @@
 	else
 		var/picked_num = rand(1,9)
 		icon_state = "book[picked_num]"
-		switch(picked_num)
-			if(1)
-				spine_color = "#888"
-			if(2)
-				spine_color = "#800"
-			if(3)
-				spine_color = "#880"
-			if(4)
-				spine_color = "#088"
-			if(5)
-				spine_color = "#080"
-			if(6)
-				spine_color = "#808"
-			if(7)
-				spine_color = "#fff"
-			if(8)
-				spine_color = "#444"
-			if(9)
-				spine_color = "#840"
+		update_icon()
 	item_state = icon_state
 
 /*


### PR DESCRIPTION
[bugfix]

## What this does
Stops them from all being grey spined, note that "cover" is a var for custom looks in book databases but goes completely unused, even in SQL, so this fix works for now.

## How it was tested
Spawning a book, changing icon_state to book4, calling update_icon()

## Changelog
:cl:
 * bugfix: Printed database books from checkout computers now have their proper spine colors for each icon state.