### PR TITLE
Widens the destination tagger UI

### DIFF
--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -58,7 +58,7 @@ var/list/tagger_locations = list()
 	if(mode)
 		dat += "<a href='?src=\ref[src];new_dest=1'>Add destination</a>"
 
-	var/datum/browser/popup = new(user, "destTagger", name, 380, 350, src)
+	var/datum/browser/popup = new(user, "destTagger", name, 450, 350, src)
 	popup.add_stylesheet("shared", 'nano/css/shared.css')
 	popup.set_content(dat)
 	popup.open()


### PR DESCRIPTION
[UI]

## What this does
Closes #38960.

## How it was tested
Using the thing on box station.

## Changelog
:cl:
 * tweak: Destination tagger UIs are now wide enough to see all of its rows.