### PR TITLE
Gives centcomm and admin IDs infinitely funded centcomm accounts

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -669,6 +669,8 @@ var/list/global/id_cards = list()
 
 /obj/item/weapon/card/id/admin/New()
 	access = get_absolutely_all_accesses()
+	if(station_account)
+		associated_account_number = station_account.account_number
 	..()
 
 /obj/item/weapon/card/id/centcom
@@ -680,6 +682,8 @@ var/list/global/id_cards = list()
 
 /obj/item/weapon/card/id/centcom/New()
 	access = get_all_centcom_access()
+	if(station_account)
+		associated_account_number = station_account.account_number
 	..()
 
 /obj/item/weapon/card/id/salvage_captain

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -669,8 +669,9 @@ var/list/global/id_cards = list()
 
 /obj/item/weapon/card/id/admin/New()
 	access = get_absolutely_all_accesses()
-	if(station_account)
-		associated_account_number = station_account.account_number
+	if(!centcomm_account)
+		centcomm_account = create_account("Centcomm Account", starting_funds = INFINITY, source_db=null, wage_payout=0, security_pref=1, ratio_pref=0, makehidden=TRUE, isStationAccount=FALSE)
+	associated_account_number = centcomm_account.account_number
 	..()
 
 /obj/item/weapon/card/id/centcom
@@ -682,8 +683,9 @@ var/list/global/id_cards = list()
 
 /obj/item/weapon/card/id/centcom/New()
 	access = get_all_centcom_access()
-	if(station_account)
-		associated_account_number = station_account.account_number
+	if(!centcomm_account)
+		centcomm_account = create_account("Centcomm Account", starting_funds = INFINITY, source_db=null, wage_payout=0, security_pref=1, ratio_pref=0, makehidden=TRUE, isStationAccount=FALSE)
+	associated_account_number = centcomm_account.account_number
 	..()
 
 /obj/item/weapon/card/id/salvage_captain

--- a/code/modules/Economy/Accounts.dm
+++ b/code/modules/Economy/Accounts.dm
@@ -12,6 +12,7 @@ var/datum/money_account/vendor_account
 var/list/all_money_accounts = list()
 var/list/all_station_accounts = list()
 var/datum/money_account/trader_account
+var/datum/money_account/centcomm_account
 
 var/station_allowance = 0//This is what Nanotrasen will send to the Station Account after every salary, as provision for the next salary.
 var/latejoiner_allowance = 0//Added to station_allowance and reset before every wage payout.


### PR DESCRIPTION
[administration]

## What this does
See title

## Why it's good
Lets test dummy spawned admins test cargo easier

## How it was tested
Loading test_tiny, spawning a dummy, buying stuff on the cargo console, deleting the dummy, spawning it again

## Changelog
:cl:
 * tweak: Admin test dummies and centcomm officials now have their own accounts on their IDs, with infinite funds.