### PR TITLE
Window render fix

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -69,20 +69,19 @@ var/list/one_way_windows
 		return O.anchored && ..()
 
 /obj/structure/window/relativewall()
-	var/icon/I
 	if(anchored && density)
 		icon_state = "[base_state][..()]"
-		I = new('icons/obj/structures/window.dmi', icon_state, dir)
+		var/icon/I = new('icons/obj/structures/window.dmi', icon_state, dir)
 		if(!is_fulltile)
 			var/cmasknumber = findSmoothingOnTurf()
 			if(cmasknumber)
 				var/icon/mask = new('icons/obj/structures/window.dmi', "cmask[cmasknumber]", dir)
 				I.Blend(mask, ICON_OVERLAY)
 				I.SwapColor(rgb(0, 255, 0, 255), rgb(0, 0, 0, 0))
+		icon = I
 	else
 		icon_state = initial(icon_state)
-		I = new('icons/obj/structures/window.dmi', icon_state)
-	icon = I
+		icon = initial(icon)
 
 /obj/structure/window/proc/update_oneway_nearby_clients()
 	for(var/client/C in clients)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -71,14 +71,14 @@ var/list/one_way_windows
 /obj/structure/window/relativewall()
 	if(anchored && density)
 		icon_state = "[base_state][..()]"
-		var/icon/I = new('icons/obj/structures/window.dmi', icon_state, dir)
 		if(!is_fulltile)
+			var/icon/I = new('icons/obj/structures/window.dmi', icon_state, dir)
 			var/cmasknumber = findSmoothingOnTurf()
 			if(cmasknumber)
 				var/icon/mask = new('icons/obj/structures/window.dmi', "cmask[cmasknumber]", dir)
 				I.Blend(mask, ICON_OVERLAY)
 				I.SwapColor(rgb(0, 255, 0, 255), rgb(0, 0, 0, 0))
-		icon = I
+			icon = I
 	else
 		icon_state = initial(icon_state)
 		icon = initial(icon) // this just werks for some reason

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -69,14 +69,19 @@ var/list/one_way_windows
 		return O.anchored && ..()
 
 /obj/structure/window/relativewall()
-	icon_state = anchored && density ? "[base_state][..()]" : initial(icon_state)
-	var/icon/I = new('icons/obj/structures/window.dmi', icon_state, dir)
-	if(!is_fulltile)
-		var/cmasknumber = findSmoothingOnTurf()
-		if(cmasknumber)
-			var/icon/mask = new('icons/obj/structures/window.dmi', "cmask[cmasknumber]", dir)
-			I.Blend(mask, ICON_OVERLAY)
-			I.SwapColor(rgb(0, 255, 0, 255), rgb(0, 0, 0, 0))
+	var/icon/I
+	if(anchored && density)
+		icon_state = "[base_state][..()]"
+		I = new('icons/obj/structures/window.dmi', icon_state, dir)
+		if(!is_fulltile)
+			var/cmasknumber = findSmoothingOnTurf()
+			if(cmasknumber)
+				var/icon/mask = new('icons/obj/structures/window.dmi', "cmask[cmasknumber]", dir)
+				I.Blend(mask, ICON_OVERLAY)
+				I.SwapColor(rgb(0, 255, 0, 255), rgb(0, 0, 0, 0))
+	else
+		icon_state = initial(icon_state)
+		I = new('icons/obj/structures/window.dmi', icon_state)
 	icon = I
 
 /obj/structure/window/proc/update_oneway_nearby_clients()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -70,11 +70,11 @@ var/list/one_way_windows
 
 /obj/structure/window/relativewall()
 	icon_state = anchored && density ? "[base_state][..()]" : initial(icon_state)
-	var/icon/I = new('icons/obj/structures/window.dmi', icon_state)
+	var/icon/I = new('icons/obj/structures/window.dmi', icon_state, dir)
 	if(!is_fulltile)
 		var/cmasknumber = findSmoothingOnTurf()
 		if(cmasknumber)
-			var/icon/mask = new('icons/obj/structures/window.dmi', "cmask[cmasknumber]")
+			var/icon/mask = new('icons/obj/structures/window.dmi', "cmask[cmasknumber]", dir)
 			I.Blend(mask, ICON_OVERLAY)
 			I.SwapColor(rgb(0, 255, 0, 255), rgb(0, 0, 0, 0))
 	icon = I

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -81,7 +81,7 @@ var/list/one_way_windows
 		icon = I
 	else
 		icon_state = initial(icon_state)
-		icon = initial(icon)
+		icon = initial(icon) // this just werks for some reason
 
 /obj/structure/window/proc/update_oneway_nearby_clients()
 	for(var/client/C in clients)


### PR DESCRIPTION
[bugfix]

## What this does
Closes #33607.

## How it was tested
Securing and unsecuring windows, rotating them, taking a photo of them in both states and viewing the photos.

## Changelog
:cl:
 * bugfix: Windows now show up properly on cameras and similar image renderings again.