### PR TITLE
Window RCD and buildmode sprite hotfix

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -611,6 +611,7 @@ var/list/one_way_windows
 /obj/structure/window/change_dir(new_dir, changer)
 	update_nearby_tiles() //Compel updates before
 	. = ..()
+	relativewall()
 	update_nearby_tiles()
 
 /obj/structure/window/Destroy()


### PR DESCRIPTION
[bugfix][hotfix]

## What this does
Closes #33602.
Closes #38418.
Closes #38335.
Closes #33784.
Closes #33620.

## How it was tested
Buildmoding windows, placing them with an admin RCD.

## Changelog
:cl:
 * bugfix: Buildmode and RCD windows now have proper sprites.