### PR TITLE
Fixes some vlevel issues

### DIFF
--- a/code/game/machinery/computer/climate.dm
+++ b/code/game/machinery/computer/climate.dm
@@ -8,6 +8,7 @@ var/list/climatecomps = list()
 	moody_state = "overlay_climate-wall"
 	light_color = LIGHT_COLOR_CYAN
 	circuit = "/obj/item/weapon/circuitboard/labor"
+	var/datum/virtual_z/linked_vz
 
 /obj/machinery/computer/climate/wall
 	density = FALSE
@@ -16,10 +17,16 @@ var/list/climatecomps = list()
 /obj/machinery/computer/climate/New()
 	..()
 	climatecomps += src
+	link_climate()
 
 /obj/machinery/computer/climate/Destroy()
 	climatecomps -= src
 	..()
+
+/obj/machinery/computer/climate/proc/link_climate()
+	var/datum/vz = get_virtual_z()
+	if(vz)
+		linked_vz = vz
 
 /obj/machinery/computer/climate/attack_hand(var/mob/user as mob)
 	if(..())
@@ -28,7 +35,7 @@ var/list/climatecomps = list()
 	var/dat = list()
 	dat += "<center>"
 	dat += "<div class='modal'><div class='modal-content'><div class='line'><b>Weather Report</b></div><br>"
-	var/datum/climate/C = SSweather.get_climate_from_turf(get_turf(src))
+	var/datum/climate/C = SSweather.get_climate(linked_vz)
 	if(C?.current_weather)
 		var/datum/weather/W = C.current_weather
 		var/reported_temp = W.temperature - 273.15
@@ -48,3 +55,10 @@ var/list/climatecomps = list()
 	popup.set_content(dat)
 	popup.open()
 	onclose(user, "climate")
+
+/obj/machinery/computer/climate/long_range
+	name = "long-range climate monitoring console"
+	desc = "A computer designed to report on the weather conditions in a distant location."
+
+/obj/machinery/computer/climate/link_climate()
+	linked_vz = map.getVLevel(map.zMainStation)

--- a/code/modules/events/vox_trade_probe.dm
+++ b/code/modules/events/vox_trade_probe.dm
@@ -41,7 +41,7 @@
 /datum/event/tradeprobe/setup()
 	//Lock trade shuttle so that it can't crush the probe
 	trade_shuttle.lockdown = "The trade shuttle has been temporarily locked while a pod is in port. The pod will depart after 10 minutes."
-	load_dungeon(/datum/map_element/dungeon/tradeprobe, 0, TRUE)
+	load_dungeon(/datum/map_element/dungeon/tradeprobe, 0, TRUE, FALSE) //Don't spawn teleporters, since the probe will be moving to the station, not random locations
 	tradeprobe = new(starting_area = /area/shuttle/tradeprobe)
 	tradeprobe.initialize()
 	tradeprobe.move()

--- a/code/modules/randomMaps/dungeons.dm
+++ b/code/modules/randomMaps/dungeons.dm
@@ -14,7 +14,7 @@ var/list/existing_dungeons = list()
 
 //Returns list of loaded objects. If trying to load a duplicate dungeon (and it's forbidden), returns a reference to the "original" dungeon instead
 
-/proc/load_dungeon(dungeon_type, var/rotate = 0, var/hidden = FALSE)
+/proc/load_dungeon(dungeon_type, var/rotate = 0, var/hidden = FALSE, var/teleporters = TRUE)
 	var/datum/map_element/ME
 	if(ispath(dungeon_type, /datum/map_element))
 		ME = new dungeon_type
@@ -38,7 +38,8 @@ var/list/existing_dungeons = list()
 
 	var/result = ME.load(used_vz.x_min - 1, used_vz.y_min - 1, used_vz.parent_z.z, rotate)
 
-	for(var/turf/T in block_borders(locate(used_vz.x_min, used_vz.y_min,used_vz.parent_z.z), locate(used_vz.x_max, used_vz.y_max, used_vz.parent_z.z)))
-		new /obj/effect/step_trigger/teleporter/random/shuttle_transit(T)
+	if(teleporters)
+		for(var/turf/T in block_borders(locate(used_vz.x_min, used_vz.y_min,used_vz.parent_z.z), locate(used_vz.x_max, used_vz.y_max, used_vz.parent_z.z)))
+			new /obj/effect/step_trigger/teleporter/random/shuttle_transit(T)
 
 	return result

--- a/maps/snaxi.dm
+++ b/maps/snaxi.dm
@@ -130,6 +130,8 @@
 		for (var/y = center_y; y >= center_y - center_y/3; y = y - 10)
 			gaussian_geyser(x, y)
 			CHECK_TICK
+	for(var/obj/machinery/computer/climate/CC in climatecomps)
+		CC.link_climate()
 
 #define MIN_REGIONAL_VAULTS 2
 #define MAX_REGIONAL_VAULTS 4

--- a/maps/snaxi.dmm
+++ b/maps/snaxi.dmm
@@ -63745,7 +63745,7 @@
 	icon_state = "warning";
 	tag = "icon-warning (NORTH)"
 	},
-/obj/machinery/computer/climate,
+/obj/machinery/computer/climate/long_range,
 /turf/simulated/floor,
 /area/hallway/secondary/entry)
 "dpV" = (
@@ -65098,7 +65098,7 @@
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
-/obj/machinery/computer/climate,
+/obj/machinery/computer/climate/long_range,
 /turf/simulated/floor,
 /area/hallway/secondary/entry)
 "dtv" = (
@@ -66655,7 +66655,7 @@
 	name = "Outpost Mining Dock"
 	})
 "dwy" = (
-/obj/machinery/computer/climate,
+/obj/machinery/computer/climate/long_range,
 /turf/simulated/floor,
 /area/mine/eva{
 	name = "Outpost Mining Dock"


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
- Stops the Vox Trade Probe from teleporting players to deep space when they enter it
- Fixes the climate computers in the Snaxi space lounge not showing the surface's weather

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Bugs bad. Closes #38997 & closes #38998.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
- Fired the trade probe event, entered the probe successfully.
- Loaded Snaxi, confirmed both stationside and space climate computers worked.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed the Vox Trade Probe sending players to deep space when they enter it.
 * bugfix: Fixed the climate computers in the Snaxi space lounge not showing the surface's weather.