### PR TITLE
adds drag

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -2013,6 +2013,7 @@ var/list/weekend_days = list("Friday", "Saturday", "Sunday")
 #define PS_SHADOW_SMOKE		"Shadow Smoke"
 #define PS_SHADOW_SMOKE2	"Shadow Smoke2"
 #define PS_GAS_VENT			"Gas Vent"
+#define PS_CIG_SMOKE		"Cig Smoke"
 
 //Particles variable defines
 #define PVAR_SPAWNING	"spawning"

--- a/code/game/objects/effects/particles_system.dm
+++ b/code/game/objects/effects/particles_system.dm
@@ -195,7 +195,8 @@ var/list/particle_string_to_type = list(
 	PS_BIBLE_PAGE = /particles/bible_page,
 	PS_SHADOW_SMOKE = /particles/cult_smoke,
 	PS_SHADOW_SMOKE2 = /particles/cult_smoke/alt,
-	PS_GAS_VENT = /particles/gas_vent
+	PS_GAS_VENT = /particles/gas_vent,
+	PS_CIG_SMOKE = /particles/cigsmoke,
 	)
 
 /particles
@@ -489,6 +490,23 @@ var/list/particle_string_to_type = list(
 	drift = generator("box", list(-0.5,-0.1), list(0.5,0.1))
 	scale = list(0.5, 0.5)
 	grow = list(0.08, 0.08)
+
+/particles/cigsmoke //copied from /steam, mostly.
+	width = 64
+	height = 64
+	count = 20
+	spawning = 1
+	lifespan = 1 SECONDS
+	fade = 1 SECONDS
+	icon = 'icons/effects/effects_particles.dmi'
+	icon_state = "steam"
+	color = "#FFFFFF99"
+	position = 0
+	velocity = 1
+	scale = list(0.3, 0.3)
+	grow = list(0.05, 0.05)
+	rotation = generator("num", 0,360)
+	pixel_y=10
 
 /turf
 	var/last_dust_time = 0

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -232,6 +232,7 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 	surgerysound = 'sound/items/cautery.ogg'
 	var/light_icon = "cig-light"
 	var/requires_oxygen = TRUE
+	var/dragon = 0.0 //world.time
 
 /obj/item/clothing/mask/cigarette/New()
 	base_name = name
@@ -506,7 +507,7 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 		try_hotspot_expose(source_temperature, SMALL_FLAME, -1)
 	//Oddly specific and snowflakey reagent transfer system below
 	if(reagents && reagents.total_volume)	//Check if it has any reagents at all
-		if(iscarbon(M) && ((src == M.wear_mask) || (loc == M.wear_mask))) //If it's in the human/monkey mouth, transfer reagents to the mob
+		if(iscarbon(M) && ((src == M.wear_mask) || (loc == M.wear_mask || dragon))) //If it's in the human/monkey mouth, transfer reagents to the mob
 			if(M.reagents.has_any_reagents(LEXORINS) || (M_NO_BREATH in M.mutations) || istype(M.loc, /obj/machinery/atmospherics/unary/cryo_cell))
 				reagents.remove_any(REAGENTS_METABOLISM)
 			else
@@ -519,13 +520,24 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 
 /obj/item/clothing/mask/cigarette/attack_self(mob/user as mob)
 	if(lit)
-		user.visible_message("<span class='notice'>[user] calmly drops and treads on the [name], putting it out.</span>")
-		var/turf/T = get_turf(src)
-		var/atom/new_butt = new type_butt(T)
-		transfer_fingerprints_to(new_butt)
-		lit = 0 //Needed for proper update
-		update_brightness()
-		qdel(src)
+		if(user.a_intent == I_DISARM || user.a_intent == I_HURT)
+			user.visible_message("<span class='notice'>[user] calmly drops and treads on the [name], putting it out.</span>")
+			var/turf/T = get_turf(src)
+			var/atom/new_butt = new type_butt(T)
+			transfer_fingerprints_to(new_butt)
+			lit = 0 //Needed for proper update
+			update_brightness()
+			qdel(src)
+		else if(dragon==0.0 && user.get_item_by_slot(slot_wear_mask)==null)
+			dragon=world.time //because the callback does not send how long do_after was being done for, so we have to do this instead. thanks, oldcoders
+			user.emote("me",MESSAGE_SEE,"begins to slowly inhale from \the [src].")
+			
+			var/callback/take_drag_do_after_callback/cb = new()
+			cb.cig=src
+			if(do_after(user,src,2 SECONDS,custom_checks=cb)) //failiure/partial messages are handled in the callback
+				user.emote("me",MESSAGE_SEE,"pulls \the [src] away and exhales a dense cloud of smoke.")
+			dragon=0.0
+			
 
 /obj/item/clothing/mask/cigarette/attack(mob/living/carbon/M, mob/living/carbon/user)
 	if(!istype(M))
@@ -549,6 +561,47 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 
 	else
 		return ..()
+
+
+/callback/take_drag_do_after_callback
+	var/obj/item/clothing/mask/cigarette/cig=null
+
+/callback/take_drag_do_after_callback/invoke(var/mob/user, var/turf/use_user_turf, var/user_original_location, var/atom/target, var/target_original_location, var/needhand, var/obj/item/originally_held_item)
+	var/adjective
+	var/timesmoked=(world.time-cig.dragon)
+	if (timesmoked > 1 SECONDS)
+		adjective="a cloud of smoke"
+	else
+		adjective="a puff of smoke"
+	
+	if(!user)
+		return FALSE
+	if(user.isStunned())
+		user.emote("me",MESSAGE_SEE,"lets out [adjective] as \the [cig] falls to the ground.")
+		return FALSE
+	
+	var/itemonfloor=istype(originally_held_item.loc,/turf) ? "lets out [adjective] and drops \the [cig]." : "lets out [adjective] and puts the \the [cig] away."
+	if(target.loc != target_original_location)
+		user.emote("me",MESSAGE_SEE,itemonfloor)
+		return FALSE
+		
+	var/mask_slot=user.get_item_by_slot(slot_wear_mask)
+	if(mask_slot)
+		if(mask_slot!=cig) //moving it to mask slot is a silent failure
+			user.emote("me",MESSAGE_SEE,"quickly lets out [adjective] before putting on \the [mask_slot].")
+		return FALSE	
+		
+	if(originally_held_item)
+		if(!user.is_holding_item(originally_held_item))
+			user.emote("me",MESSAGE_SEE,itemonfloor)
+			return FALSE
+	else
+		if(user.get_active_hand())
+			user.emote("me",MESSAGE_SEE,itemonfloor)
+			return FALSE
+	if(!cig.lit)
+		user.emote("me",MESSAGE_SEE,"slowly lets out [adjective] as \the [cig] fizzles out.")
+	return TRUE
 
 //////////////
 //FANCY CIGS//

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -530,7 +530,8 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 			qdel(src)
 		else if(dragon==0.0 && user.get_item_by_slot(slot_wear_mask)==null)
 			dragon=world.time //because the callback does not send how long do_after was being done for, so we have to do this instead. thanks, oldcoders
-			user.emote("me",MESSAGE_SEE,"begins to slowly inhale from \the [src].")
+			var/list/pmsg=list("slowly inhales from \the [src].","takes a drag from \the [src].","gently draws from \the [src].")
+			user.emote("me",MESSAGE_SEE,pick(pmsg))
 			
 			var/callback/take_drag_do_after_callback/cb = new()
 			cb.cig=src
@@ -541,7 +542,9 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 			user.adjust_particles(PVAR_PIXEL_Y,10,PS_STEAM)
 			user.adjust_particles(PVAR_SCALE,list(0.3,0.3),PS_STEAM)
 			spawn( 0.75*(world.time-dragon) )
-				user.remove_particles(PS_STEAM)
+				user.adjust_particles(PVAR_SPAWNING,FALSE,PS_STEAM)
+				spawn(0.5 SECONDS) //do this so that the particle effect will naturally decay instead of abruptly stopping. it looks much better like this.
+					user.remove_particles(PS_STEAM)
 			dragon=0.0
 			
 

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -537,14 +537,11 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 			cb.cig=src
 			
 			do_after(user,src,2 SECONDS,custom_checks=cb) //need callback for stuff like moving the item and mask covering, ect.
-			user.add_particles(PS_STEAM)	
-			user.adjust_particles(PVAR_SPAWNING,TRUE,PS_STEAM)
-			user.adjust_particles(PVAR_PIXEL_Y,10,PS_STEAM)
-			user.adjust_particles(PVAR_SCALE,list(0.3,0.3),PS_STEAM)
+			user.add_particles(PS_CIG_SMOKE)
 			spawn( 0.75*(world.time-dragon) )
-				user.adjust_particles(PVAR_SPAWNING,FALSE,PS_STEAM)
+				user.adjust_particles(PVAR_SPAWNING,FALSE,PS_CIG_SMOKE)
 				spawn(0.5 SECONDS) //do this so that the particle effect will naturally decay instead of abruptly stopping. it looks much better like this.
-					user.remove_particles(PS_STEAM)
+					user.remove_particles(PS_CIG_SMOKE)
 			dragon=0.0
 			
 

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -535,8 +535,7 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 			var/callback/take_drag_do_after_callback/cb = new()
 			cb.cig=src
 			
-			if(do_after(user,src,2 SECONDS,custom_checks=cb)) //failiure/partial messages are handled in the callback
-				user.emote("me",MESSAGE_SEE,"pulls \the [src] away and exhales a dense cloud of smoke.")
+			do_after(user,src,2 SECONDS,custom_checks=cb) //need callback for stuff like moving the item and mask covering, ect.
 			user.add_particles(PS_STEAM)	
 			user.adjust_particles(PVAR_SPAWNING,TRUE,PS_STEAM)
 			user.adjust_particles(PVAR_PIXEL_Y,10,PS_STEAM)
@@ -574,40 +573,25 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 	var/obj/item/clothing/mask/cigarette/cig=null
 
 /callback/take_drag_do_after_callback/invoke(var/mob/user, var/turf/use_user_turf, var/user_original_location, var/atom/target, var/target_original_location, var/needhand, var/obj/item/originally_held_item)
-	var/adjective
-	var/timesmoked=(world.time-cig.dragon)
-	if (timesmoked > 1 SECONDS)
-		adjective="a cloud of smoke"
-	else
-		adjective="a puff of smoke"
-	
 	if(!user)
 		return FALSE
 	if(user.isStunned())
-		user.emote("me",MESSAGE_SEE,"lets out [adjective] as \the [cig] falls to the ground.")
 		return FALSE
-	
-	var/itemonfloor=istype(originally_held_item.loc,/turf) ? "lets out [adjective] and drops \the [cig]." : "lets out [adjective] and puts the \the [cig] away."
 	if(target.loc != target_original_location)
-		user.emote("me",MESSAGE_SEE,itemonfloor)
 		return FALSE
 		
 	var/mask_slot=user.get_item_by_slot(slot_wear_mask)
 	if(mask_slot)
-		if(mask_slot!=cig) //moving it to mask slot is a silent failure
-			user.emote("me",MESSAGE_SEE,"quickly lets out [adjective] before putting on \the [mask_slot].")
 		return FALSE	
 		
 	if(originally_held_item)
 		if(!user.is_holding_item(originally_held_item))
-			user.emote("me",MESSAGE_SEE,itemonfloor)
 			return FALSE
 	else
 		if(user.get_active_hand())
-			user.emote("me",MESSAGE_SEE,itemonfloor)
 			return FALSE
 	if(!cig.lit)
-		user.emote("me",MESSAGE_SEE,"slowly lets out [adjective] as \the [cig] fizzles out.")
+		return FALSE
 	return TRUE
 
 //////////////

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -534,8 +534,15 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 			
 			var/callback/take_drag_do_after_callback/cb = new()
 			cb.cig=src
+			
 			if(do_after(user,src,2 SECONDS,custom_checks=cb)) //failiure/partial messages are handled in the callback
 				user.emote("me",MESSAGE_SEE,"pulls \the [src] away and exhales a dense cloud of smoke.")
+			user.add_particles(PS_STEAM)	
+			user.adjust_particles(PVAR_SPAWNING,TRUE,PS_STEAM)
+			user.adjust_particles(PVAR_PIXEL_Y,10,PS_STEAM)
+			user.adjust_particles(PVAR_SCALE,list(0.3,0.3),PS_STEAM)
+			spawn( 0.75*(world.time-dragon) )
+				user.remove_particles(PS_STEAM)
 			dragon=0.0
 			
 


### PR DESCRIPTION
[fluff] [immulsions]

https://github.com/user-attachments/assets/4644a566-a8f2-4df8-b5b9-d137d0552e48

<img width="1920" height="1080" alt="516750_20260209043640_1" src="https://github.com/user-attachments/assets/c6a96ab5-00e9-4b6d-8050-3d23e89358c5" />

## What this does
adds drag(ing on cigarettes)
do this by clicking on a lit cig in hand, with help or grab intent (flicking the butt is now done with harm/disarm intent)
this is mildly functional, as it will count for a tick of smoking while you do it.
you can move around and whatnot while doing it, and there's some flavour text for early cancelation

## Why it's good
adds some fluff that will add to muh immulsions
also smoking is cool, probably

## How it was tested
see attached video

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: you can now click on a lit cig in hand to smoke on it. help/grab intent only
