### PR TITLE
Build SpacemanDMM from source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,12 +50,17 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
+        uses: actions/cache@v3
         with:
-          cache-on-failure: true
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo
 
       - name: Build Dreamchecker from master
         id: build-dreamchecker
+        continue-on-error: true
         run: |
           git clone --depth 1 https://github.com/SpaceManiac/SpacemanDMM.git ~/SpacemanDMM
           cd ~/SpacemanDMM

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,11 @@ jobs:
 
       - name: Fallback if master build fails
         if: steps.build-dreamchecker.outcome == 'failure'
+        env:
+          SPACEMAN_DMM_VERSION: suite-1.11
         run: |
           echo "Dreamchecker master build failed, falling back to release version"
-          wget -O ~/dreamchecker "https://github.com/SpaceManiac/SpacemanDMM/releases/download/suite-1.11/dreamchecker"
+          wget -O ~/dreamchecker "https://github.com/SpaceManiac/SpacemanDMM/releases/download/$SPACEMAN_DMM_VERSION/dreamchecker"
           chmod +x ~/dreamchecker
 
       - name: Run dreamchecker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,9 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache SpacemanDMM
+      - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          workspaces: ${{ github.workspace }}/../SpacemanDMM -> target
           cache-on-failure: true
 
       - name: Build Dreamchecker from master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           cache-on-failure: true
 
       - name: Build Dreamchecker from master
-        if: build-dreamchecker
+        id: build-dreamchecker
         run: |
           git clone --depth 1 https://github.com/SpaceManiac/SpacemanDMM.git ~/SpacemanDMM
           cd ~/SpacemanDMM

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Cache SpacemanDMM
         uses: Swatinem/rust-cache@v2
         with:
-          workspaces: ~/SpacemanDMM -> target
+          workspaces: ${{ github.workspace }}/../SpacemanDMM -> target
           cache-on-failure: true
 
       - name: Build Dreamchecker from master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,25 @@ jobs:
         run: |
           tools/bootstrap/python -c ''
 
-        #TODO: Cache Dreamchecker install
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache SpacemanDMM
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ~/SpacemanDMM -> target
+          cache-on-failure: true
+
+      - name: Build Dreamchecker from master
+        run: |
+          git clone --depth 1 https://github.com/SpaceManiac/SpacemanDMM.git ~/SpacemanDMM
+          cd ~/SpacemanDMM
+          cargo build --release --bin dreamchecker
+
       - name: Run dreamchecker
         run: |
-          SPACEMAN_DMM_GIT_TAG="suite-1.11" tools/travis/install_spaceman_dmm.sh dreamchecker
-          ~/dreamchecker 2>&1 | bash tools/ci/annotate_dm.sh
+          ~/SpacemanDMM/target/release/dreamchecker --version
+          ~/SpacemanDMM/target/release/dreamchecker 2>&1 | bash tools/ci/annotate_dm.sh
 
       - name: Run map checker
         run: python tools/travis/check_map_files.py maps/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,15 +56,24 @@ jobs:
           cache-on-failure: true
 
       - name: Build Dreamchecker from master
+        if: build-dreamchecker
         run: |
           git clone --depth 1 https://github.com/SpaceManiac/SpacemanDMM.git ~/SpacemanDMM
           cd ~/SpacemanDMM
           cargo build --release --bin dreamchecker
+          cp target/release/dreamchecker ~/dreamchecker
+
+      - name: Fallback if master build fails
+        if: steps.build-dreamchecker.outcome == 'failure'
+        run: |
+          echo "Dreamchecker master build failed, falling back to release version"
+          wget -O ~/dreamchecker "https://github.com/SpaceManiac/SpacemanDMM/releases/download/suite-1.11/dreamchecker"
+          chmod +x ~/dreamchecker
 
       - name: Run dreamchecker
         run: |
-          ~/SpacemanDMM/target/release/dreamchecker --version
-          ~/SpacemanDMM/target/release/dreamchecker 2>&1 | bash tools/ci/annotate_dm.sh
+          ~/dreamchecker --version
+          ~/dreamchecker 2>&1 | bash tools/ci/annotate_dm.sh
 
       - name: Run map checker
         run: python tools/travis/check_map_files.py maps/

--- a/tools/travis/install_spaceman_dmm.sh
+++ b/tools/travis/install_spaceman_dmm.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-
-wget -O ~/$1 "https://github.com/SpaceManiac/SpacemanDMM/releases/download/$SPACEMAN_DMM_GIT_TAG/$1"
-chmod +x ~/$1
-~/$1 --version


### PR DESCRIPTION
## What this does

Sets SpacemanDMM to build from source in CI
Caches build dependencies (kind of a pain in the dick to cache the build output itself because rust caching is weird or something)
If the master build fails then it falls back to the (often old) stable release binary

Adds around 45 sec to the CI time

## Why it's good
We can enjoy the latest master version of SpacemanDMM without relying on releases that only happen once every several months if lucky


## How it was tested
make PR, look at actions run

## Changelog
no user facing change