### PR TITLE
Fix Validhunt-DMIs CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Validhunt DMIs
         run: |
           pip install Pillow
-          echo "this is it, luigi"
+          echo "i wonder whats for dinner"
           python tools/dmi-validhunt/dmi-validhunt.py icons/ || true
       - name: Make sure test maps or vaults aren't ticked
         run: find -name '*.dme' -exec cat {} \; | awk '/maps\\test.*|\.dmm/ { exit 1 }'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Validhunt DMIs
         run: |
           pip install Pillow
+          echo "this is it, luigi"
           python tools/dmi-validhunt/dmi-validhunt.py icons/ || true
       - name: Make sure test maps or vaults aren't ticked
         run: find -name '*.dme' -exec cat {} \; | awk '/maps\\test.*|\.dmm/ { exit 1 }'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,6 @@ jobs:
       - name: Validhunt DMIs
         run: |
           pip install Pillow
-          echo "i wonder whats for dinner"
           python tools/dmi-validhunt/dmi-validhunt.py icons/ || true
       - name: Make sure test maps or vaults aren't ticked
         run: find -name '*.dme' -exec cat {} \; | awk '/maps\\test.*|\.dmm/ { exit 1 }'

--- a/tools/dmi-validhunt/dmi-validhunt.py
+++ b/tools/dmi-validhunt/dmi-validhunt.py
@@ -18,7 +18,7 @@ def file_contains_duplicate_icon_states(filename: str):
     except:
         print(f"{filename}: An error occurred opening this file.")
         return True # whatever, you get the point, something's wrong
-    desc = image.info["Description"]
+    desc = image.info.get("Description")
     if desc is None:
         print(f"{filename}: No Description metadata (invalid DMI?)")
         return False

--- a/tools/dmi-validhunt/dmi-validhunt.py
+++ b/tools/dmi-validhunt/dmi-validhunt.py
@@ -19,6 +19,9 @@ def file_contains_duplicate_icon_states(filename: str):
         print(f"{filename}: An error occurred opening this file.")
         return True # whatever, you get the point, something's wrong
     desc = image.info["Description"]
+    if desc is None:
+        print(f"{filename}: No Description metadata (invalid DMI?)")
+        return False
     states = set()
     output = False
     for line in desc.splitlines():


### PR DESCRIPTION
## What this does

Adds a null check to prevent the validhunt-DMIs thing giving up the moment it sees some fucked up DMI file:
```
Defaulting to user installation because normal site-packages is not writeable
Collecting Pillow
  Using cached pillow-12.1.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl.metadata (8.8 kB)
Using cached pillow-12.1.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (7.0 MB)
Installing collected packages: Pillow
Successfully installed Pillow-12.1.1
icons/lamprey.dmi: duplicate icon state: lampy
icons/barsigns.dmi: duplicate icon state: whiskeyimplant
Traceback (most recent call last):
  File "/home/runner/work/vgstation13/vgstation13/tools/dmi-validhunt/dmi-validhunt.py", line 58, in <module>
    main()
  File "/home/runner/work/vgstation13/vgstation13/tools/dmi-validhunt/dmi-validhunt.py", line 50, in main
    if file_contains_duplicate_icon_states(os.path.join(root, file)):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/vgstation13/vgstation13/tools/dmi-validhunt/dmi-validhunt.py", line 21, in file_contains_duplicate_icon_states
    desc = image.info["Description"]
           ~~~~~~~~~~^^^^^^^^^^^^^^^
KeyError: 'Description'
```

## Why it's good
python runtime bad

## How it was tested
open PR, look at actions

## Changelog
no user facing change
