### PR TITLE
Jungle hotfix

### DIFF
--- a/code/datums/shuttle.dm
+++ b/code/datums/shuttle.dm
@@ -963,7 +963,7 @@
 		//Delete the old turf
 		var/replacing_turf_type = old_turf.get_underlying_turf()
 
-		if(D && istype(D))
+		if(D && istype(D) && D.base_turf_type)
 			replacing_turf_type = D.base_turf_type
 
 		old_turf.ChangeTurf(replacing_turf_type, allow = 1)

--- a/code/game/objects/structures/docking_port.dm
+++ b/code/game/objects/structures/docking_port.dm
@@ -154,7 +154,7 @@ var/global/list/all_docking_ports = list()
 	var/turf/origin_turf = null
 	var/list/disk_references = list() //List of shuttle destination disks that know about this docking port
 
-	var/base_turf_type			= /turf/space
+	var/base_turf_type			= null // was formerly /turf/space. undo this (and the change in shuttle.dm) if it causes stuff to mess up.
 	var/base_turf_icon			= null
 	var/base_turf_icon_state	= null
 	var/base_turf_override		= FALSE

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -283,11 +283,11 @@
 			if(v.transition_crosswrap_v && v.transition_crosswrap_v.len==4)
 				locked_to_current_v=TRUE //prevent shuffling z-level later in the code.
 				randomize_drift_position=FALSE
-				if(A.vy()>v.y_max - TRANSITIONEDGE) // NORTH
+				if(A.vy()>=v.y_max - TRANSITIONEDGE) // NORTH
 					move_to_v=v.transition_crosswrap_v[1]
 				else if(A.vy()<=TRANSITIONEDGE) // SOUTH
 					move_to_v=v.transition_crosswrap_v[2]
-				else if(A.vx()>v.x_max - TRANSITIONEDGE) // EAST
+				else if(A.vx()>=v.x_max - TRANSITIONEDGE) // EAST
 					move_to_v=v.transition_crosswrap_v[3]
 				else if(A.vx()<=TRANSITIONEDGE) // WEST
 					move_to_v=v.transition_crosswrap_v[4]

--- a/code/game/turfs/unsimulated/jungle.dm
+++ b/code/game/turfs/unsimulated/jungle.dm
@@ -104,6 +104,7 @@ var/list/foliage_replacments=list(
 	desc="A mixture of sediments, clays, and decomposed matter."
 	icon='icons/turf/floors.dmi'
 	icon_state = "ironsand1"
+	base_icon_state=null
 	temperature = T_JUNGLE
 	oxygen = MOLES_JUNGLE_O2_STD
 	nitrogen = MOLES_JUNGLE_N2_STD

--- a/code/modules/mob/living/complex_animal/jungle_mobs/crocodile.dm
+++ b/code/modules/mob/living/complex_animal/jungle_mobs/crocodile.dm
@@ -52,7 +52,7 @@
 			if(1)
 				emote("me", MESSAGE_HEAR, "growls.")
 			if(2)
-				if(loc.type==/turf/unsimulated/floor/planetary/water/jungle)
+				if(loc?.type==/turf/unsimulated/floor/planetary/water/jungle)
 					emote("me", MESSAGE_HEAR, "splashes.")
 				else
 					emote("me", MESSAGE_HEAR, "growls.")

--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -111,7 +111,7 @@
 		level.reset_base_turf(/turf/space,fast_base_turf)
 
 /datum/map/proc/linkVLevel(datum/zLevel/level)
-	var/datum/virtual_z/new_vz = new(level, ALLOCATION_FULL, ALLOCATION_FULL, 1, 1, skip_turf_setup = FALSE)
+	var/datum/virtual_z/new_vz = new(level, world.maxx, world.maxy, 1, 1, skip_turf_setup = FALSE)
 	new_vz.id = level.z
 	new_vz.name = level.name
 	if(level.z in daynight_z_lvls)
@@ -123,8 +123,7 @@
 	new_vz.movementChance = level.movementChance
 	new_vz.transitionLoops = level.transitionLoops
 	if(level.transition_crosswrap_z && level.transition_crosswrap_z.len == 4)
-		for(var/datum/zLevel/zl in level.transition_crosswrap_z)
-			new_vz.transition_crosswrap_v += zl.virtual_z_levels[1]
+		new_vz.transition_crosswrap_v = level.transition_crosswrap_z.Copy()
 	new_vz.update_settings()
 	vLevels |= new_vz
 	return new_vz
@@ -364,14 +363,12 @@ var/global/list/accessable_v_levels = list(
 	name = "jungle surface"
 	base_turf = /turf/unsimulated/floor/planetary/dirt/jungle
 	base_area = /area/surface/jungle/landing //hacky workaround.
-	movementJammed = TRUE
 	planetside = TRUE
 
 /datum/zLevel/jungleunderground
 	name = "jungle underground"
 	base_turf = /turf/unsimulated/floor/planetary/cave/jungle
 	base_area = /area/surface/jungle/underground
-	movementJammed = TRUE
 	planetside = TRUE
 
 /datum/zLevel/junglesurface/mining

--- a/maps/junglestation.dmm
+++ b/maps/junglestation.dmm
@@ -15538,7 +15538,8 @@
 /area/shuttle/escape/centcom)
 "fHC" = (
 /obj/docking_port/destination/escape/shuttle/station{
-	dir = 4
+	dir = 4;
+	base_turf_type = /turf/unsimulated/floor/planetary/concrete/jungle
 	},
 /obj/effect/decal/warning_stripes{
 	dir = 4;
@@ -18659,7 +18660,8 @@
 	req_access_txt = "48"
 	},
 /obj/docking_port/destination/mining/outpost{
-	dir = 8
+	dir = 8;
+	base_turf_type = /turf/unsimulated/floor/planetary/path/jungle
 	},
 /turf/simulated/floor,
 /area/mine/production)
@@ -19763,7 +19765,8 @@
 	icon_state = "warning"
 	},
 /obj/docking_port/destination/transport/station{
-	dir = 8
+	dir = 8;
+	base_turf_type = /turf/unsimulated/floor/planetary/concrete/jungle
 	},
 /turf/unsimulated/floor/planetary/concrete/jungle,
 /area/surface/jungle/landing)
@@ -38042,7 +38045,8 @@
 /area/chapel/main)
 "oaG" = (
 /obj/docking_port/destination/mining/station{
-	dir = 8
+	dir = 8;
+	base_turf_type = /turf/unsimulated/floor/planetary/concrete/jungle
 	},
 /obj/effect/decal/warning_stripes{
 	dir = 8;
@@ -43366,7 +43370,8 @@
 /area/centcom/ert)
 "qdn" = (
 /obj/docking_port/destination/ert/station{
-	dir = 8
+	dir = 8;
+	base_turf_type = /turf/unsimulated/floor/planetary/concrete/jungle
 	},
 /obj/effect/decal/warning_stripes{
 	dir = 8;
@@ -43684,7 +43689,8 @@
 /area/centcom/control)
 "qjp" = (
 /obj/docking_port/destination/pod1/station{
-	dir = 4
+	dir = 4;
+	base_turf_type = /turf/unsimulated/floor/planetary/concrete/jungle
 	},
 /obj/effect/decal/warning_stripes{
 	dir = 4;
@@ -45924,7 +45930,8 @@
 	icon_state = "warning"
 	},
 /obj/docking_port/destination/pod2/station{
-	dir = 4
+	dir = 4;
+	base_turf_type = /turf/unsimulated/floor/planetary/concrete/jungle
 	},
 /turf/unsimulated/floor/planetary/concrete/jungle,
 /area/surface/jungle/zoned/roid_prep)
@@ -50785,7 +50792,8 @@
 	tag = "icon-warning (WEST)"
 	},
 /obj/docking_port/destination/supply/station{
-	dir = 8
+	dir = 8;
+	base_turf_type = /turf/unsimulated/floor/planetary/concrete/jungle
 	},
 /turf/unsimulated/floor/planetary/concrete/jungle,
 /area/surface/jungle/landing)
@@ -64685,7 +64693,9 @@
 /turf/unsimulated/floor/planetary/concrete/jungle,
 /area/surface/jungle/zoned/atmos_outside)
 "xPT" = (
-/obj/docking_port/destination/arrival/station,
+/obj/docking_port/destination/arrival/station{
+	base_turf_type = /turf/unsimulated/floor/planetary/concrete/jungle
+	},
 /obj/effect/decal/warning_stripes{
 	dir = 1;
 	icon_state = "warning";


### PR DESCRIPTION
[hotfix] [bugfix]



# THANKS WEST

## What this does
* fixes dirt icons being incorrect sometimes
* fixed shuttles making space tiles
* fixed crosswrap zlevel transitions not working sometimes

## Why it's good
fixes bugs

## How it was tested
went into game and moved across all 4 edges of the map. also verified that dirt's icon didn't change with new calls. also verified that shuttles didn't create space turfs. tested shuttles on box to verify they operate the same

## Changelog
:cl:
 * bugfix: fixed some bugs due to virtual z-levels on jungle