### PR TITLE
new drink: Jungle Juice

### DIFF
--- a/__DEFINES/reagents.dm
+++ b/__DEFINES/reagents.dm
@@ -215,6 +215,7 @@
 #define LIMEJUICE 			"limejuice"
 #define CARROTJUICE 			"carrotjuice"
 #define BERRYJUICE 			"berryjuice"
+#define BERRYJUICEJUNGLE 			"berryjuicejungle"
 #define POISONBERRYJUICE 			"poisonberryjuice"
 #define WATERMELONJUICE 			"watermelonjuice"
 #define APPLEJUICE 			"applejuice"
@@ -496,6 +497,8 @@
 #define BLOB_ESSENCE	"blob_essence"
 #define METHAMPHETAMINE "methamphetamine"
 #define GRUGZONE		"grugzone"
+#define JUNGLEJUICE		"junglejuice"
+#define FAKEJUNGLEJUICE		"fakejunglejuice"
 
 #define TUNGSTEN 			"tungsten"
 #define LITHIUMSODIUMTUNGSTATE 			"lithiumsodiumtungstate"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -4434,22 +4434,22 @@
 	name = "Jungle Juice"
 	id = JUNGLEJUICE
 	result = JUNGLEJUICE
-	required_reagents = list(BERRYJUICEJUNGLE = 3, SCREWDRIVERCOCKTAIL=3)
-	result_amount = 6
+	required_reagents = list(BERRYJUICEJUNGLE = 1, SCREWDRIVERCOCKTAIL=1)
+	result_amount = 2
 
 /datum/chemical_reaction/junglejuice_fake
 	name = "Jungle Juice"
 	id = FAKEJUNGLEJUICE
 	result = FAKEJUNGLEJUICE
-	required_reagents = list(BERRYJUICE = 3, SCREWDRIVERCOCKTAIL=3)
-	result_amount = 6
+	required_reagents = list(BERRYJUICE = 1, SCREWDRIVERCOCKTAIL=1)
+	result_amount = 2
 
 /datum/chemical_reaction/junglejuice_frompoison
 	name = "Jungle Juice"
 	id = "junglejuicepoison"
 	result = JUNGLEJUICE
-	required_reagents = list(POISONBERRYJUICE = 3, SCREWDRIVERCOCKTAIL=3)
-	result_amount = 6
+	required_reagents = list(POISONBERRYJUICE = 1, SCREWDRIVERCOCKTAIL=1)
+	result_amount = 2
 
 
 #undef ALERT_AMOUNT_ONLY

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -4434,21 +4434,21 @@
 	name = "Jungle Juice"
 	id = JUNGLEJUICE
 	result = JUNGLEJUICE
-	required_reagents = list(BERRYJUICEJUNGLE = 3, ORANGEJUICE=1, VODKA=2)
+	required_reagents = list(BERRYJUICEJUNGLE = 3, SCREWDRIVERCOCKTAIL=3)
 	result_amount = 6
 
 /datum/chemical_reaction/junglejuice_fake
 	name = "Jungle Juice"
 	id = FAKEJUNGLEJUICE
 	result = FAKEJUNGLEJUICE
-	required_reagents = list(BERRYJUICE = 3, ORANGEJUICE=1, VODKA=2)
+	required_reagents = list(BERRYJUICE = 3, SCREWDRIVERCOCKTAIL=3)
 	result_amount = 6
 
 /datum/chemical_reaction/junglejuice_frompoison
 	name = "Jungle Juice"
 	id = "junglejuicepoison"
 	result = JUNGLEJUICE
-	required_reagents = list(POISONBERRYJUICE = 3, ORANGEJUICE=1, VODKA=2)
+	required_reagents = list(POISONBERRYJUICE = 3, SCREWDRIVERCOCKTAIL=3)
 	result_amount = 6
 
 

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -3477,7 +3477,7 @@
 	name = "Sex on The Beach"
 	id = SEXONTHEBEACH
 	result = SEXONTHEBEACH
-	required_reagents = list(SCREWDRIVERCOCKTAIL = 1, SCHNAPPS = 1, BERRYJUICE = 1)
+	required_reagents = list(FAKEJUNGLEJUICE = 2, SCHNAPPS = 1)
 	result_amount = 3
 
 /datum/chemical_reaction/americano

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -4430,5 +4430,27 @@
 	required_temp = T0C + 100 //closest we can get to a vacuum distilation with our ghetto ass systems
 	result_amount = 1
 
+/datum/chemical_reaction/junglejuice
+	name = "Jungle Juice"
+	id = JUNGLEJUICE
+	result = JUNGLEJUICE
+	required_reagents = list(BERRYJUICEJUNGLE = 3, ORANGEJUICE=1, VODKA=2)
+	result_amount = 6
+
+/datum/chemical_reaction/junglejuice_fake
+	name = "Jungle Juice"
+	id = FAKEJUNGLEJUICE
+	result = FAKEJUNGLEJUICE
+	required_reagents = list(BERRYJUICE = 3, ORANGEJUICE=1, VODKA=2)
+	result_amount = 6
+
+/datum/chemical_reaction/junglejuice_frompoison
+	name = "Jungle Juice"
+	id = "junglejuicepoison"
+	result = JUNGLEJUICE
+	required_reagents = list(POISONBERRYJUICE = 3, ORANGEJUICE=1, VODKA=2)
+	result_amount = 6
+
+
 #undef ALERT_AMOUNT_ONLY
 #undef ALERT_ALL_REAGENTS

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -4430,14 +4430,14 @@
 	required_temp = T0C + 100 //closest we can get to a vacuum distilation with our ghetto ass systems
 	result_amount = 1
 
-/datum/chemical_reaction/junglejuice
+/datum/chemical_reaction/junglejuice //the intended route for JJ, also from poison berries (see below).
 	name = "Jungle Juice"
 	id = JUNGLEJUICE
 	result = JUNGLEJUICE
 	required_reagents = list(BERRYJUICEJUNGLE = 1, SCREWDRIVERCOCKTAIL=1)
 	result_amount = 2
 
-/datum/chemical_reaction/junglejuice_fake
+/datum/chemical_reaction/junglejuice_fake //this exists to make JJ more accessible and reduce confusion about why some berries can't make it. that being said, this varient does not have the special effects, for better or worse.
 	name = "Jungle Juice"
 	id = FAKEJUNGLEJUICE
 	result = FAKEJUNGLEJUICE

--- a/code/modules/reagents/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/machinery/reagentgrinder.dm
@@ -3,6 +3,7 @@ var/global/list/juice_items = list (
 	/obj/item/weapon/reagent_containers/food/snacks/grown/carrot = list(CARROTJUICE = 0),
 	/obj/item/weapon/reagent_containers/food/snacks/grown/grapes = list(GRAPEJUICE = 0),
 	/obj/item/weapon/reagent_containers/food/snacks/grown/greengrapes = list(GGRAPEJUICE = 0),
+	/obj/item/weapon/reagent_containers/food/snacks/grown/berries/jungle = list(BERRYJUICEJUNGLE = 0),
 	/obj/item/weapon/reagent_containers/food/snacks/grown/berries = list(BERRYJUICE = 0),
 	/obj/item/weapon/reagent_containers/food/snacks/grown/banana = list(BANANA = 0),
 	/obj/item/weapon/reagent_containers/food/snacks/grown/potato = list(POTATO = 0),

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -1259,6 +1259,7 @@ var/list/strange_seed_product_blacklist = subtypesof(/obj/item/weapon/reagent_co
 	icon = 'icons/obj/hydroponics/berry.dmi'
 	icon_state = "produce2"
 	desc = "They taste like... burning."
+	plantname=null
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/berries/jungle/New(var/loc,var/mob/berry_picker=null)
 	..(loc)

--- a/code/modules/reagents/reagents/reagents_drink.dm
+++ b/code/modules/reagents/reagents/reagents_drink.dm
@@ -201,6 +201,15 @@
 	nutriment_factor = 2.5 * REAGENTS_METABOLISM
 	glass_desc = "Berry juice. Or maybe it's jam. Who cares?"
 
+/datum/reagent/drink/berryjuice/jungle
+	id = BERRYJUICEJUNGLE
+	nutriment_factor = 1.5 * REAGENTS_METABOLISM
+
+/datum/reagent/drink/berryjuice/jungle/on_mob_life(var/mob/living/M)
+	if(..())
+		return 1
+	M.adjustToxLoss(0.8)
+
 /datum/reagent/drink/poisonberryjuice
 	name = "Poison Berry Juice"
 	id = POISONBERRYJUICE

--- a/code/modules/reagents/reagents/reagents_ethanol.dm
+++ b/code/modules/reagents/reagents/reagents_ethanol.dm
@@ -2022,7 +2022,7 @@
 		H.vomit()
 
 
-/datum/reagent/ethanol/drink/junglejuice
+/datum/reagent/ethanol/drink/junglejuice //this only exists to reduce confusion about why some berry juice might not be able to make the drink. of course, because this is made from safe berries, you don't get the "cool" effect.
 	name = "Jungle Juice"
 	id = FAKEJUNGLEJUICE
 	description = "Booze mixed with blended up wild berries."
@@ -2032,7 +2032,7 @@
 	glass_desc = "It's quite tart, with earthy undertones."
 	nutriment_factor = 0.5 * REAGENTS_METABOLISM
 
-/datum/reagent/ethanol/drink/junglejuice/real
+/datum/reagent/ethanol/drink/junglejuice/real //the intended variant of jungle juice which you make from poisounous berries (or the ones found on jungle). this one includes the special effects, as well as higher nutriment content.
 	id = JUNGLEJUICE
 	glass_desc = "It's quite tart, with earthy undertones. Better hope the berries were safe."
 	nutriment_factor = 1.25 * REAGENTS_METABOLISM

--- a/code/modules/reagents/reagents/reagents_ethanol.dm
+++ b/code/modules/reagents/reagents/reagents_ethanol.dm
@@ -2041,6 +2041,6 @@
 	if(..())
 		return 1
 	if(M.toxloss<15)
-		M.toxloss=min(M.toxloss+2.5,10)
+		M.toxloss=min(M.toxloss+2.5,15)
 	else
-		M.toxloss = max(M.toxloss-1.5,10)
+		M.toxloss = max(M.toxloss-1.5,15)

--- a/code/modules/reagents/reagents/reagents_ethanol.dm
+++ b/code/modules/reagents/reagents/reagents_ethanol.dm
@@ -2020,3 +2020,27 @@
 	if(ishuman(M) && prob(5))
 		var/mob/living/carbon/human/H = M
 		H.vomit()
+
+
+/datum/reagent/ethanol/drink/junglejuice
+	name = "Jungle Juice"
+	id = FAKEJUNGLEJUICE
+	description = "Booze mixed with blended up wild berries."
+	reagent_state = REAGENT_STATE_LIQUID
+	color = "#660099"
+	alpha = 64
+	glass_desc = "It's quite tart, with earthy undertones."
+	nutriment_factor = 0.5 * REAGENTS_METABOLISM
+
+/datum/reagent/ethanol/drink/junglejuice/real
+	id = JUNGLEJUICE
+	glass_desc = "It's quite tart, with earthy undertones. Better hope the berries were safe."
+	nutriment_factor = 1.25 * REAGENTS_METABOLISM
+
+/datum/reagent/ethanol/drink/junglejuice/real/on_mob_life(var/mob/living/M)
+	if(..())
+		return 1
+	if(M.toxloss<15)
+		M.toxloss=min(M.toxloss+2.5,10)
+	else
+		M.toxloss = max(M.toxloss-1.5,10)


### PR DESCRIPTION
[content]

## What this does
adds Jungle Juice, made with 3 parts berry juice, 2 parts vodka, and 1 part orange juice.
if jungle berries or poison berries are used, you get the "true" version, which will rapidly give toxin damage, up to a point, until it begins to heal toxin damage.

this also patches jungle berries to not be able to be seed extracted, since they gave you normal berry seeds anyways.

## Why it's good
more content is good, right? adds a bit of a ghetto chem to help with severe toxin damage in an interesting way.

## How it was tested
went into game and made the drink and then drunk it. it drinks.

## Changelog
:cl:
 * rscadd: added a new drink made with berry juice, vodka, and orange juice