### PR TITLE
unsimmed turfs (like the roid) can now have footsteps

### DIFF
--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -680,8 +680,8 @@ var/global/mulebot_count = 0
 			else if(newdir == (EAST + WEST))
 				newdir = EAST
 			goingdir = newdir
-		if(bloodiness && istype(next,/turf/simulated) )
-			var/turf/simulated/n=next
+		if(bloodiness )
+			var/turf/n=next
 			n.AddTracks(/obj/effect/decal/cleanable/blood/tracks/wheels,list(),0,goingdir,currentBloodColor)
 			bloodiness--
 

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -30,11 +30,6 @@
 	if(flammable)
 		zone?.burnable_atoms |= src
 
-/turf/simulated/proc/AddTracks(var/typepath,var/bloodDNA,var/comingdir,var/goingdir,var/bloodcolor=DEFAULT_BLOOD,var/luminous=FALSE)
-	var/obj/effect/decal/cleanable/blood/tracks/tracks = locate(typepath) in src
-	if(!tracks)
-		tracks = new typepath(src)
-	tracks.AddTracks(bloodDNA,comingdir,goingdir,bloodcolor,luminous)
 
 /turf/simulated/Entered(atom/A, atom/OL)
 	if(movement_disabled && usr.ckey != movement_disabled_exception)
@@ -48,32 +43,6 @@
 			return ..()
 		if(istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M
-
-			// Tracking blood
-			var/list/bloodDNA = null
-			var/bloodcolor=""
-
-			// Do we have shoes?
-			if(H.shoes)
-				var/obj/item/clothing/shoes/S = H.shoes
-				if(S.track_blood && S.blood_DNA)
-					bloodDNA   = S.blood_DNA
-					bloodcolor = S.blood_color
-					S.track_blood = max(round(S.track_blood - 1, 1),0)
-			else
-				if(H.track_blood && H.feet_blood_DNA)
-					bloodDNA   = H.feet_blood_DNA
-					bloodcolor = H.feet_blood_color
-					H.track_blood = max(round(H.track_blood - 1, 1),0)
-
-			if (bloodDNA)
-				AddTracks(H.get_footprint_type(),bloodDNA,H.dir,0,bloodcolor,H.luminous_feet()) // Coming
-				if(istype(OL, /turf/simulated) && Adjacent(OL))
-					var/turf/simulated/from = OL
-					from.AddTracks(H.get_footprint_type(),bloodDNA,0,H.dir,bloodcolor,H.luminous_feet()) // Going
-
-			bloodDNA = null
-
 			// Floorlength braids?  Enjoy your tripping.
 			if(H.my_appearance.h_style && !H.check_hidden_head_flags(HIDEHEADHAIR))
 				var/datum/sprite_accessory/hair_style = hair_styles_list[H.my_appearance.h_style]

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -219,3 +219,6 @@
 		S.perform(user, 0, list(src))
 		return 1
 	return 0
+
+/turf/space/AddTracks(var/typepath,var/bloodDNA,var/comingdir,var/goingdir,var/bloodcolor=DEFAULT_BLOOD,var/luminous=FALSE)
+	return null

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -202,10 +202,53 @@
 	if(reagent_interaction_flags & TURF_REAGENT_ENTER)
 		GiveReagentsTo(mover)
 
+
+/turf/proc/AddTracks(var/typepath,var/bloodDNA,var/comingdir,var/goingdir,var/bloodcolor=DEFAULT_BLOOD,var/luminous=FALSE)
+	var/obj/effect/decal/cleanable/blood/tracks/tracks = locate(typepath) in src
+	if(!tracks)
+		tracks = new typepath(src)
+	tracks.AddTracks(bloodDNA,comingdir,goingdir,bloodcolor,luminous)
+
+
 /turf/Entered(atom/movable/A as mob|obj, atom/OldLoc)
 	if(movement_disabled)
 		to_chat(usr, "<span class='warning'>Movement is admin-disabled.</span>")//This is to identify lag problems
 		return
+
+	//footstep decal code
+	if (istype(A,/mob/living/carbon))
+		var/mob/living/carbon/M = A
+		if(!M.on_foot())
+			return ..()
+		if(istype(M, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = M
+
+			// Tracking blood
+			var/list/bloodDNA = null
+			var/bloodcolor=""
+
+			// Do we have shoes?
+			if(H.shoes)
+				var/obj/item/clothing/shoes/S = H.shoes
+				if(S.track_blood && S.blood_DNA)
+					bloodDNA   = S.blood_DNA
+					bloodcolor = S.blood_color
+					S.track_blood = max(round(S.track_blood - 1, 1),0)
+			else
+				if(H.track_blood && H.feet_blood_DNA)
+					bloodDNA   = H.feet_blood_DNA
+					bloodcolor = H.feet_blood_color
+					H.track_blood = max(round(H.track_blood - 1, 1),0)
+
+			if (bloodDNA)
+				AddTracks(H.get_footprint_type(),bloodDNA,H.dir,0,bloodcolor,H.luminous_feet()) // Coming
+				if(Adjacent(OldLoc) && istype(OldLoc,/turf))
+					var/turf/from = OldLoc
+					from.AddTracks(H.get_footprint_type(),bloodDNA,0,H.dir,bloodcolor,H.luminous_feet()) // Going
+
+			bloodDNA = null
+	//end footstep decal code
+
 
 	//THIS IS OLD TURF ENTERED CODE
 	var/loopsanity = 100


### PR DESCRIPTION
## What this does
see title. makes it so that any turf can, not just simmed
closes #38901
<img width="630" height="566" alt="Capture" src="https://github.com/user-attachments/assets/31ec96fa-9bf3-4dd8-947c-8ea439c65cdf" />

## Why it's good
adds flavor. long wanted by many. muh immulsions.

## How it was tested
went onto the roid and gibbed a body, then walked around in the blood.

## Changelog
:cl:
 * rscadd: Bloody footsteps (and other decals) can now appear on the asteroid (among other tiles). traitors beware!