### PR TITLE
Fixes auto outfitters being unable to be screwed open and have its parts pried out

### DIFF
--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -1132,6 +1132,7 @@ var/list/tagger_locations = list()
 /obj/machinery/autoprocessor/outfit
 	name = "auto outfitter"
 	desc = "Automatically applies an outfit to people inside."
+	machine_flags = SCREWTOGGLE | CROWDESTROY
 	circuitpath = /obj/item/weapon/circuitboard/autoprocessor/outfit
 
 	var/outfit_type = /datum/outfit/assistant


### PR DESCRIPTION
[bugfix]

## What this does
Closes #38981.

## How it was tested
Using a screwdriver and then a crowbar on a prisoner outfitter.

## Changelog
:cl:
 * bugfix: Screwdrivers and crowbars now work on auto outfitters, allowing their panels to be opened and parts to be pried out.