### PR TITLE
Updates the science values for Scientist's Sapience and Scientist's Serendipity.

### DIFF
--- a/code/modules/reagents/reagents/reagents_ethanol.dm
+++ b/code/modules/reagents/reagents/reagents_ethanol.dm
@@ -490,13 +490,13 @@
 		glass_icon_state = "scientists_serendipity"
 		glass_name = "\improper Scientist's Serendipity"
 		glass_desc = "Knock back a cold glass of R&D."
-		D.origin_tech = "materials=7;engineering=3;plasmatech=2;powerstorage=4;bluespace=6;combat=3;magnets=6;programming=3"
+		D.origin_tech = "materials=7;engineering=4;plasmatech=3;powerstorage=6;bluespace=7;combat=3;magnets=6;programming=5"
 
 	else
 		glass_icon_state = "scientists_serendipity"
 		glass_name = "\improper Scientist's Sapience"
 		glass_desc = "Why research what has already been catalogued?"
-		D.origin_tech = "materials=10;engineering=5;plasmatech=4;powerstorage=5;bluespace=10;biotech=6;combat=6;magnets=6;programming=5;syndicate=2" //Maxes everything but Illegal and Anomaly //the heck is illegal research...
+		D.origin_tech = "materials=10;engineering=6;plasmatech=5;powerstorage=10;bluespace=10;biotech=7;combat=7;magnets=7;programming=6;syndicate=2" //Maxes everything but Illegal and Anomaly
 
 /datum/reagent/ethanol/beepskyclassic
 	name = "Beepsky Classic"


### PR DESCRIPTION
## What this does
<img width="432" height="279" alt="image" src="https://github.com/user-attachments/assets/9b6f825b-b6f9-4e16-9f63-2c6544c01088" />

This screenshot was taken immediately after putting the first Scientist's Sapience glass in the machine.
Scientist's Sapience is supposed to be the ultimate research juice, maxing everything except illegal, anomaly and expedition, hence updating the values to match the true max.
Slightly buffs Scientist's Serendipity to match these new levels.
## Why it's good
It's been a long while since it was first added and a lot of new tech levels have been created, it's time to update this thing.

:cl:
 * tweak: Updates the tech levels in a full glass of Scientist's Sapience (50u) to match the current player-reachable maximum since it's supposed to be the ultimate science drink. It STILL does not max Illegal nor Anomaly (or Expedition, for that matter).
 * tweak: Buffs Scientist's Serendipity (<50u) slightly to account for the extra tech levels added throughout the years.