### PR TITLE
Fixes window offsets on all maps

### DIFF
--- a/maps/LampreyStation.dmm
+++ b/maps/LampreyStation.dmm
@@ -7915,16 +7915,6 @@
 	icon_state = "neutral"
 	},
 /area/lamprey/foreporthallways)
-"asL" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/lamprey/foreporthallways)
 "asM" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -8726,19 +8716,6 @@
 "auK" = (
 /turf/unsimulated/floor/asteroid,
 /area/lamprey/catchall)
-"auL" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/lamprey/mining)
 "auM" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -23946,14 +23923,6 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/lamprey/centralhallways)
-"bfq" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/lamprey/centralhallways)
 "bfr" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -27581,26 +27550,6 @@
 	icon_state = "floorgrime"
 	},
 /area/lamprey/permabrig)
-"bmZ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "Secure Gate";
-	name = "Security Blast Door";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/lamprey/security)
 "bna" = (
 /obj/structure/closet/secure_closet/brig,
 /turf/simulated/floor{
@@ -33963,14 +33912,6 @@
 	oxygen = 0.01
 	},
 /area/lamprey/originmaintenanceblob)
-"bBl" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/lamprey/originmaintenanceblob)
 "bBm" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -35600,27 +35541,6 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/lamprey/permabrig)
-"bEU" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/full/reinforced,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "Secure Gate";
-	name = "Security Blast Door";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
 /area/lamprey/permabrig)
 "bEV" = (
 /obj/structure/grille,
@@ -44373,19 +44293,6 @@
 /obj/structure/sign/directions/evac,
 /turf/simulated/wall,
 /area/lamprey/tinyroomzone)
-"bYZ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/lamprey/escape)
 "bZa" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -48014,16 +47921,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/researchwarehousemaintenanceblob)
-"chA" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/lamprey/researchwarehousemaintenanceblob)
 "chB" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -48122,19 +48019,6 @@
 /obj/effect/decal/warning_stripes{
 	dir = 4;
 	icon_state = "unloading"
-	},
-/turf/simulated/floor/plating,
-/area/lamprey/researchwarehousemaintenanceblob)
-"chN" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/researchwarehousemaintenanceblob)
@@ -61243,19 +61127,6 @@
 "cLT" = (
 /turf/unsimulated/wall/other,
 /area/lamprey/bridge)
-"cLU" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/lamprey/researchwarehousemaintenanceblob)
 "cLV" = (
 /obj/structure/wc/toilet{
 	desc = "The HT-451, a torque rotation-based, waste disposal unit for small matter. Oh god, this ancient thing has been festering in here for years.";
@@ -76806,14 +76677,6 @@
 	req_access_txt = "48"
 	},
 /turf/simulated/floor/plating,
-/area/lamprey/miniatureboxstationreplica)
-"drY" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "white"
-	},
 /area/lamprey/miniatureboxstationreplica)
 "drZ" = (
 /obj/machinery/door/airlock/glass_medical{
@@ -93816,19 +93679,6 @@
 "ebi" = (
 /obj/item/clothing/gloves/yellow,
 /obj/item/weapon/rack_parts,
-/turf/simulated/floor/plating,
-/area/lamprey/engineeringmaintenanceblob)
-"ebj" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /turf/simulated/floor/plating,
 /area/lamprey/engineeringmaintenanceblob)
 "ebk" = (
@@ -111316,14 +111166,6 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 8
-	},
-/turf/space,
-/area)
-"eMP" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
 	},
 /turf/space,
 /area)
@@ -141782,17 +141624,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/space,
 /area)
-"gdn" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/space,
-/area)
 "gdo" = (
 /obj/structure/grille,
 /obj/structure/disposalpipe/segment,
@@ -142584,25 +142415,6 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/space,
-/area)
-"gfh" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/space,
-/area)
-"gfi" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
 /turf/space,
 /area)
 "gfj" = (
@@ -171570,36 +171382,12 @@
 /obj/structure/table/reinforced,
 /turf/space,
 /area)
-"hhF" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/space,
-/area)
 "hhG" = (
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
 /obj/machinery/vending/groans,
-/turf/space,
-/area)
-"hhH" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /turf/space,
 /area)
 "hhI" = (
@@ -174520,20 +174308,6 @@
 /obj/item/weapon/pickaxe/shovel/spade,
 /obj/item/weapon/reagent_containers/glass/bucket,
 /obj/item/tool/wirecutters/clippers,
-/turf/space,
-/area)
-"hni" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /turf/space,
 /area)
 "hnj" = (
@@ -188189,13 +187963,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/combooutpost)
-"hPI" = (
-/obj/structure/lattice,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/space,
-/area)
 "hPJ" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -247836,7 +247603,7 @@ aaa
 aaa
 aaa
 aLU
-bmZ
+bvb
 boZ
 bjr
 bsE
@@ -252868,7 +252635,7 @@ acc
 acc
 bjr
 bjr
-bEU
+blj
 bmT
 boT
 bjr
@@ -265877,7 +265644,7 @@ aek
 ady
 asr
 atV
-auL
+afW
 avE
 axd
 ayn
@@ -266881,7 +266648,7 @@ ady
 ady
 asv
 ady
-auL
+afW
 avH
 axf
 ayr
@@ -267917,7 +267684,7 @@ aLU
 aLU
 acc
 aLU
-bmZ
+bvb
 brm
 brm
 brm
@@ -272464,7 +272231,7 @@ ccb
 bTB
 cct
 cgl
-chA
+cNy
 ciW
 ciW
 ciW
@@ -272486,7 +272253,7 @@ ciW
 ciW
 ccn
 cct
-cLU
+caI
 cNx
 apk
 acc
@@ -285957,7 +285724,7 @@ aqK
 apF
 asJ
 aug
-asL
+aXN
 awh
 acc
 acc
@@ -286458,7 +286225,7 @@ apF
 apF
 apD
 asK
-asL
+aXN
 asM
 acc
 acc
@@ -286959,7 +286726,7 @@ alS
 apI
 aqL
 art
-asL
+aXN
 asM
 acc
 aaa
@@ -287524,7 +287291,7 @@ ccv
 cct
 bYq
 cgv
-chN
+ctD
 cjc
 ckj
 clv
@@ -292114,7 +291881,7 @@ dJL
 dKM
 dZJ
 eas
-ebj
+dWq
 ebM
 acc
 aaa
@@ -302061,7 +301828,7 @@ bvF
 bxc
 byr
 bzF
-bBl
+bWY
 bCF
 bCF
 bCF
@@ -304069,7 +303836,7 @@ bvJ
 blP
 byr
 bzF
-bBl
+bWY
 bOM
 bBj
 bBj
@@ -304571,7 +304338,7 @@ bvK
 bkb
 bys
 bzG
-bBl
+bWY
 dfg
 bBj
 bFL
@@ -305073,7 +304840,7 @@ bvK
 blP
 byr
 bzF
-bBl
+bWY
 bCJ
 bBj
 bBj
@@ -305575,7 +305342,7 @@ bvF
 bkb
 bys
 bzG
-bBl
+bWY
 bCK
 bBj
 bFM
@@ -307583,7 +307350,7 @@ bvJ
 bkb
 bys
 bzG
-bBl
+bWY
 dgu
 dmz
 bFP
@@ -337187,7 +336954,7 @@ aYT
 auw
 bck
 bdS
-bfq
+brL
 bgO
 biw
 bkA
@@ -340276,7 +340043,7 @@ dkf
 dnj
 cSZ
 dqB
-drY
+dnl
 dkf
 dvm
 dwG
@@ -358801,7 +358568,7 @@ bsm
 bUR
 bUR
 bsm
-bYZ
+bKy
 bMl
 bMl
 bMl
@@ -636400,7 +636167,7 @@ aaa
 aaa
 aaa
 abQ
-eMP
+hzy
 eNb
 eNu
 aaY
@@ -636902,7 +636669,7 @@ aaa
 aaa
 aaa
 abQ
-eMP
+hzy
 eNb
 eNu
 aaY
@@ -637404,7 +637171,7 @@ aaa
 aaa
 aaa
 abQ
-eMP
+hzy
 eNb
 eNu
 aaY
@@ -757949,7 +757716,7 @@ gLq
 aae
 gMF
 gNn
-gdn
+hhy
 geV
 gAN
 gQv
@@ -758451,7 +758218,7 @@ gLr
 aae
 gMG
 aaa
-gfh
+hhz
 eQq
 gAN
 eRE
@@ -758953,7 +758720,7 @@ aab
 aae
 gMH
 aaa
-gfh
+hhz
 eQq
 gAN
 eRE
@@ -759455,11 +759222,11 @@ gLs
 gLW
 gHd
 aaa
-gfh
+hhz
 eQq
 gAN
 eRE
-gdn
+hhy
 gSl
 fZT
 gaz
@@ -759943,7 +759710,7 @@ gAG
 gBA
 gCe
 gCQ
-gdn
+hhy
 eNN
 gFg
 gFS
@@ -759957,11 +759724,11 @@ aaa
 gLX
 gHd
 aaa
-gfh
+hhz
 eQq
 gAN
 eRE
-gfi
+hhA
 gSm
 eRE
 aaa
@@ -760459,7 +760226,7 @@ gLt
 fXy
 gMI
 aaa
-gfi
+hhA
 eQq
 gAN
 fZT
@@ -761449,7 +761216,7 @@ aaa
 eOA
 aaa
 aaa
-gdn
+hhy
 eNN
 gAL
 gFU
@@ -761467,7 +761234,7 @@ gNS
 eQq
 gPn
 gQw
-gdn
+hhy
 aaa
 aaa
 aae
@@ -761965,11 +761732,11 @@ gLu
 gMa
 gMJ
 gNo
-gdn
+hhy
 eQq
 gPn
 gQw
-gfh
+hhz
 gSn
 aaa
 aae
@@ -763447,7 +763214,7 @@ grF
 eNa
 gty
 guB
-gdn
+hhy
 aaa
 gxp
 gyy
@@ -764953,11 +764720,11 @@ grI
 gsI
 eOA
 guD
-gdn
+hhy
 gwp
 gxs
 eQq
-gfh
+hhz
 aaa
 gAN
 gBG
@@ -764968,7 +764735,7 @@ aaa
 aaa
 aaa
 gGC
-gfh
+hhz
 gIi
 gJc
 gEu
@@ -765455,11 +765222,11 @@ grJ
 gsJ
 gtA
 guE
-gfh
+hhz
 gwp
 gxs
 eQq
-gfh
+hhz
 eOA
 gAO
 gBH
@@ -765470,7 +765237,7 @@ aaa
 aaa
 gAH
 gGD
-gfh
+hhz
 eRE
 gaV
 gEu
@@ -765957,11 +765724,11 @@ grK
 gsK
 gtB
 guF
-gfi
+hhA
 aaa
 gxs
 eQq
-gfh
+hhz
 aaa
 gAP
 gBI
@@ -765972,7 +765739,7 @@ aaa
 aaa
 aaa
 geV
-gfi
+hhA
 eRE
 geV
 gEu
@@ -766463,7 +766230,7 @@ aae
 gjY
 gxs
 eQq
-gfi
+hhA
 aaa
 gAQ
 aae
@@ -767478,7 +767245,7 @@ aaa
 aaa
 gAH
 gGD
-gfh
+hhz
 gIl
 aaa
 eNP
@@ -767980,7 +767747,7 @@ gEB
 aaa
 aaa
 gGC
-gfi
+hhA
 gIm
 gJe
 eNP
@@ -771993,7 +771760,7 @@ gCm
 aaa
 eQq
 gEH
-eMP
+hzy
 aaa
 gGI
 gHn
@@ -776968,7 +776735,7 @@ ePN
 eRH
 eSJ
 eQx
-eMP
+hzy
 eNb
 apQ
 aab
@@ -777470,7 +777237,7 @@ fZm
 eRE
 apQ
 eQq
-eMP
+hzy
 eNb
 apQ
 aab
@@ -777511,7 +777278,7 @@ gzr
 eRG
 gAW
 eQq
-eMP
+hzy
 gcz
 aaa
 gek
@@ -777972,7 +777739,7 @@ aab
 fZU
 apQ
 eQq
-eMP
+hzy
 eNb
 apQ
 aab
@@ -778013,7 +777780,7 @@ gwB
 gAm
 gAX
 eQq
-eMP
+hzy
 gDb
 eOA
 gek
@@ -778550,7 +778317,7 @@ hdq
 fYk
 gfK
 eQx
-hhF
+hnk
 ghL
 hjL
 hkI
@@ -779560,7 +779327,7 @@ eNi
 eNi
 aaa
 aaa
-hni
+gfU
 hoe
 gaq
 aaa
@@ -780021,7 +779788,7 @@ eWb
 geV
 gAW
 eQq
-eMP
+hzy
 gDc
 eQq
 eRE
@@ -783068,7 +782835,7 @@ aab
 eRE
 hfz
 eNP
-hhH
+gBL
 hiE
 gDa
 gzW
@@ -786094,7 +785861,7 @@ eOz
 hry
 aae
 aaa
-gfh
+hhz
 hus
 aaa
 aae
@@ -786596,7 +786363,7 @@ hqG
 hrz
 aae
 aaa
-gfh
+hhz
 hus
 aaa
 acE
@@ -787615,7 +787382,7 @@ aaa
 aaa
 hxT
 aaa
-gfh
+hhz
 aaa
 hzQ
 aaa
@@ -788058,7 +787825,7 @@ aaa
 aiW
 aaa
 acE
-eMP
+hzy
 gGM
 gHw
 gIw
@@ -788105,7 +787872,7 @@ hsX
 hsX
 huw
 aaa
-gfh
+hhz
 hvV
 aaa
 hvV
@@ -788560,7 +788327,7 @@ aaa
 aiW
 aaa
 acE
-eMP
+hzy
 gGM
 gHw
 gIw
@@ -789062,7 +788829,7 @@ acc
 gxN
 aaa
 acE
-eMP
+hzy
 gGM
 gHx
 gIx
@@ -789623,7 +789390,7 @@ htb
 aaa
 hyZ
 hzi
-gfh
+hhz
 aaa
 hzQ
 aaa
@@ -790627,7 +790394,7 @@ htb
 aaa
 aaa
 aaa
-gfh
+hhz
 aaa
 hzS
 hAf
@@ -791129,7 +790896,7 @@ htb
 aaa
 aaa
 aaa
-gfh
+hhz
 acE
 aae
 aae
@@ -791619,7 +791386,7 @@ hte
 htK
 huD
 hvf
-gfh
+hhz
 hux
 eRE
 aaa
@@ -791631,7 +791398,7 @@ htb
 aaa
 aaa
 hzk
-gfh
+hhz
 aaa
 hzQ
 aaa
@@ -792635,7 +792402,7 @@ htb
 aaa
 aaa
 aaa
-gfh
+hhz
 aaa
 hzS
 hAh
@@ -793078,7 +792845,7 @@ acc
 gxN
 aaa
 acE
-eMP
+hzy
 gGM
 gHv
 gIC
@@ -793137,7 +792904,7 @@ hyo
 aaa
 aaa
 aaa
-gfh
+hhz
 acE
 aae
 aae
@@ -793580,7 +793347,7 @@ aaa
 aiW
 aaa
 acE
-eMP
+hzy
 gGM
 gHw
 gID
@@ -793639,7 +793406,7 @@ hyp
 aaa
 aaa
 hzm
-gfh
+hhz
 aaa
 hzQ
 aaa
@@ -794082,7 +793849,7 @@ aaa
 aiW
 aaa
 acE
-eMP
+hzy
 gGM
 gHw
 gID
@@ -794612,7 +794379,7 @@ haT
 eRE
 hdz
 heF
-eMP
+hzy
 eWS
 aaa
 hiT
@@ -794643,7 +794410,7 @@ hyp
 aaa
 aaa
 gqH
-gfh
+hhz
 aaa
 hzS
 hAj
@@ -795114,7 +794881,7 @@ aaa
 eWb
 fXL
 heG
-eMP
+hzy
 gGx
 aaa
 hiU
@@ -795145,7 +794912,7 @@ hyp
 aaa
 aaa
 aaa
-gfh
+hhz
 acE
 aae
 aae
@@ -795616,7 +795383,7 @@ gYR
 fVH
 aaa
 heH
-eMP
+hzy
 eMR
 aaa
 eWb
@@ -795647,7 +795414,7 @@ hyp
 aaa
 aaa
 hzo
-gfh
+hhz
 aaa
 hzQ
 aaa
@@ -799053,7 +798820,7 @@ eVo
 eQx
 aaa
 gQl
-eMP
+hzy
 gaO
 fWs
 gcb
@@ -799547,7 +799314,7 @@ fVp
 fVS
 fWg
 fWA
-eMP
+hzy
 aaa
 aaa
 aaa
@@ -799555,7 +799322,7 @@ fXL
 eQq
 aaa
 gQl
-eMP
+hzy
 gaP
 aaa
 aab
@@ -799637,7 +799404,7 @@ eMQ
 eRE
 hlE
 eQq
-gfh
+hhz
 hlK
 hmA
 hbZ
@@ -800139,7 +799906,7 @@ gwI
 hhN
 hcA
 eQq
-gfh
+hhz
 hlL
 aaa
 aaa
@@ -801155,7 +800922,7 @@ hrS
 hrS
 hrS
 htT
-gfh
+hhz
 gOK
 aaa
 aaa
@@ -801187,7 +800954,7 @@ hCy
 hCF
 aaa
 aaa
-eMP
+hzy
 aaa
 aaa
 aiW
@@ -801689,7 +801456,7 @@ hCz
 hCG
 aaa
 aaa
-eMP
+hzy
 aaa
 aaa
 aiW
@@ -802191,7 +801958,7 @@ hCA
 hwz
 aaa
 aaa
-eMP
+hzy
 aaa
 aaa
 aiW
@@ -802693,7 +802460,7 @@ hCy
 hwz
 aaa
 aaa
-eMP
+hzy
 aaa
 aaa
 aiW
@@ -803195,7 +802962,7 @@ hCy
 htU
 aaa
 aaa
-eMP
+hzy
 aaa
 aaa
 aiW
@@ -805108,7 +804875,7 @@ aab
 eQq
 eNb
 eRE
-gfh
+hhz
 aaa
 eOA
 gtZ
@@ -805610,7 +805377,7 @@ aae
 eQq
 eNb
 eRE
-gfh
+hhz
 dle
 aaa
 aaa
@@ -806194,9 +805961,9 @@ aaa
 aaa
 aaa
 aaa
-eMP
+hzy
 hBj
-eMP
+hzy
 aaa
 aaa
 aaa
@@ -806696,9 +806463,9 @@ aaa
 aaa
 aaa
 aaa
-eMP
+hzy
 aaa
-eMP
+hzy
 aaa
 aaa
 aaa
@@ -810103,7 +809870,7 @@ eNb
 apQ
 gcB
 aaa
-gdn
+hhy
 apQ
 eRE
 eQq
@@ -813620,7 +813387,7 @@ aaa
 aaa
 aaa
 aaa
-gfh
+hhz
 gfN
 ggs
 aab
@@ -814122,7 +813889,7 @@ fYO
 aaa
 aaa
 aaa
-gfh
+hhz
 gfO
 gfO
 aab
@@ -814624,7 +814391,7 @@ aaa
 gdr
 aaa
 aaa
-gfh
+hhz
 gfO
 gfO
 aab
@@ -815126,7 +814893,7 @@ gdg
 aab
 gdZ
 geE
-gfh
+hhz
 gfO
 gfO
 aab
@@ -815628,7 +815395,7 @@ gdh
 aab
 gea
 gea
-gfi
+hhA
 gfP
 gfO
 aab
@@ -817157,7 +816924,7 @@ aaa
 gne
 gea
 eNb
-eMP
+hzy
 eRE
 gte
 gvg
@@ -819208,7 +818975,7 @@ gVe
 haq
 hbj
 hcK
-gdn
+hhy
 gek
 eNL
 hgU
@@ -819710,7 +819477,7 @@ gZg
 har
 hbk
 geG
-gfh
+hhz
 gen
 hga
 hgV
@@ -820212,7 +819979,7 @@ gZh
 har
 hbk
 hcL
-gfh
+hhz
 heX
 hgb
 hgW
@@ -820714,7 +820481,7 @@ eOA
 eNj
 hbl
 hcM
-gfi
+hhA
 gek
 eNP
 hgX
@@ -1101273,7 +1101040,7 @@ acc
 acc
 hPj
 hPr
-hPI
+hVd
 aaa
 aaa
 aaa
@@ -1101775,7 +1101542,7 @@ aaa
 acc
 hPj
 hPr
-hPI
+hVd
 aaa
 aaa
 aaa

--- a/maps/LampreyStation.dmm
+++ b/maps/LampreyStation.dmm
@@ -302,8 +302,7 @@
 /obj/structure/window/full/reinforced,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/arrivals)
@@ -312,8 +311,7 @@
 /obj/structure/window/full/reinforced,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/arrivals)
@@ -323,8 +321,7 @@
 /obj/structure/window/full/reinforced,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/arrivals)
@@ -332,8 +329,7 @@
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -425,8 +421,7 @@
 	icon_state = "2-4"
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/arrivals)
@@ -1037,8 +1032,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
@@ -1547,8 +1541,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/wall/r_wall,
 /area/lamprey/mining)
@@ -1584,8 +1577,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor{
@@ -2116,8 +2108,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/wall/r_wall,
@@ -2554,8 +2545,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/mining)
@@ -2948,8 +2938,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
@@ -6658,8 +6647,7 @@
 	},
 /obj/structure/window/full/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/warzonebar)
@@ -7933,8 +7921,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/foreporthallways)
@@ -12878,8 +12865,7 @@
 	},
 /obj/structure/window/full/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/warzonemaintenanceblob)
@@ -17860,8 +17846,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/bronxmaintenanceblob)
@@ -18001,8 +17986,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/item/weapon/shard{
 	icon_state = "small";
@@ -20691,8 +20675,7 @@
 "aXQ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/item/weapon/shard{
@@ -21037,8 +21020,7 @@
 	opacity = 0
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4;
@@ -21554,8 +21536,7 @@
 /area/lamprey/foreporthallways)
 "aZJ" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -22116,8 +22097,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/lamprey/darkfarm)
@@ -22781,8 +22761,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/warzonemaintenanceblob)
@@ -23560,8 +23539,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -26267,16 +26245,14 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/bronxmaintenanceblob)
 "bkg" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/item/weapon/shard{
 	icon_state = "medium"
@@ -26401,8 +26377,7 @@
 	opacity = 0
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating{
 	icon = 'icons/turf/new_snow.dmi';
@@ -26540,8 +26515,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -27071,8 +27045,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/bronxmaintenanceblob)
@@ -28005,8 +27978,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/bronxmaintenanceblob)
@@ -28138,8 +28110,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -28995,8 +28966,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/centralhallways)
@@ -29007,8 +28977,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/centralhallways)
@@ -29419,8 +29388,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
@@ -29798,8 +29766,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/centralhallways)
@@ -31232,8 +31199,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /obj/machinery/door/poddoor{
@@ -31275,8 +31241,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -33838,8 +33803,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced/tinted,
 /obj/item/weapon/shard{
@@ -34560,8 +34524,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/door/window,
@@ -35647,8 +35610,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /obj/machinery/door/poddoor{
@@ -35669,8 +35631,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /obj/machinery/door/poddoor{
@@ -36590,8 +36551,7 @@
 /area/lamprey/ghettosecuritymaintenanceblob)
 "bGX" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -36608,8 +36568,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/warning_stripes{
@@ -36630,8 +36589,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -39065,8 +39023,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/item/tape{
 	icon_state = "engineering_door"
@@ -40206,8 +40163,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
@@ -40219,8 +40175,7 @@
 /area/lamprey/centralhallways)
 "bPl" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -40235,8 +40190,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
@@ -40837,8 +40791,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/originmaintenanceblob)
@@ -42326,8 +42279,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -43636,8 +43588,7 @@
 "bWX" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -43648,8 +43599,7 @@
 "bWY" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -43660,8 +43610,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -44433,8 +44382,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/escape)
@@ -45300,8 +45248,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/toolstorage)
@@ -46557,8 +46504,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/porthallways)
@@ -47095,8 +47041,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/item/weapon/shard,
 /obj/item/stack/rods,
@@ -47130,8 +47075,7 @@
 "cfp" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/item/weapon/shard{
@@ -48086,8 +48030,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/item/weapon/shard,
 /obj/item/stack/rods,
@@ -48925,8 +48868,7 @@
 "cjw" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -48937,8 +48879,7 @@
 "cjx" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -49147,8 +49088,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -49316,8 +49256,7 @@
 /obj/structure/window/full/reinforced/tinted,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -49397,8 +49336,7 @@
 "ckv" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -49423,8 +49361,7 @@
 "ckx" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -49522,8 +49459,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/conveyor/auto,
 /mob/living/carbon/monkey/punpun,
@@ -49973,8 +49909,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/botaneva)
@@ -50416,8 +50351,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/hellmaintenanceblob)
@@ -50553,8 +50487,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
@@ -51168,8 +51101,7 @@
 "cop" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -51466,8 +51398,7 @@
 /area/lamprey/tinyroomzone)
 "cpe" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/conveyor/auto{
@@ -51477,8 +51408,7 @@
 /area/lamprey/tinyroomzone)
 "cpf" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/conveyor/auto{
 	dir = 4
@@ -51642,8 +51572,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -51664,8 +51593,7 @@
 "cpE" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -51681,8 +51609,7 @@
 "cpF" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -51731,8 +51658,7 @@
 "cpH" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -52090,8 +52016,7 @@
 "cqD" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/full/reinforced/tinted,
@@ -52395,8 +52320,7 @@
 	tag = "icon-loading_area (EAST)"
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -52912,8 +52836,7 @@
 "csv" = (
 /obj/machinery/vending/hydronutrients,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -53369,8 +53292,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/researchwarehousemaintenanceblob)
@@ -53558,8 +53480,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/botanymaintenanceblob)
@@ -53892,8 +53813,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/grille/invulnerable,
 /turf/simulated/floor/plating,
@@ -56006,8 +55926,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced/tinted,
 /turf/simulated/floor/plating{
@@ -58490,8 +58409,7 @@
 "cFu" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -58916,8 +58834,7 @@
 	},
 /obj/item/stack/rods,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -59579,8 +59496,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/item/weapon/shard{
 	icon_state = "medium"
@@ -60975,8 +60891,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/botaneva)
@@ -61337,8 +61252,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/researchwarehousemaintenanceblob)
@@ -61361,8 +61275,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor{
@@ -61456,8 +61369,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8;
@@ -61678,8 +61590,7 @@
 "cMC" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -61690,8 +61601,7 @@
 "cMD" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -62080,8 +61990,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/researchwarehousemaintenanceblob)
@@ -62102,8 +62011,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
@@ -62594,8 +62502,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/researchwarehousemaintenanceblob)
@@ -62616,8 +62523,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/item/weapon/soap/syndie,
 /turf/simulated/floor{
@@ -67347,8 +67253,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/lamprey/bottomrung)
@@ -69048,8 +68953,7 @@
 "ddy" = (
 /obj/machinery/vending/hatdispenser,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/lamprey/miniatureboxstationreplica)
@@ -69583,8 +69487,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -70626,8 +70529,7 @@
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -70749,8 +70651,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/aftstarboardhallways)
@@ -72268,8 +72169,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/engineering)
@@ -72393,8 +72293,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced/tinted,
 /turf/simulated/floor/plating,
@@ -74266,8 +74165,7 @@
 /area/lamprey/miniatureboxstationreplica)
 "dnl" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -76160,8 +76058,7 @@
 "dqC" = (
 /obj/machinery/r_n_d/server/robotics,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -82264,8 +82161,7 @@
 	req_one_access_txt = "140"
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /turf/simulated/floor/vox{
 	icon_state = "gold";
@@ -82280,8 +82176,7 @@
 	req_one_access_txt = "140"
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /turf/simulated/floor/vox{
 	icon_state = "diamond";
@@ -85413,8 +85308,7 @@
 	},
 /obj/item/stack/rods,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/item/weapon/shard,
 /turf/simulated/floor/plating,
@@ -85883,8 +85777,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/item/stack/rods,
 /obj/item/weapon/shard{
@@ -86076,8 +85969,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -86085,8 +85977,7 @@
 "dKD" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -86234,8 +86125,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -86657,8 +86547,7 @@
 	},
 /obj/item/weapon/reagent_containers/food/snacks/roach_eggs,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/engineeringmaintenanceblob)
@@ -87312,8 +87201,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/item/weapon/shard{
 	icon_state = "medium"
@@ -87488,8 +87376,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -88218,8 +88105,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/thebelt)
@@ -89391,8 +89277,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -89400,8 +89285,7 @@
 "dRc" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -89412,8 +89296,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -89425,8 +89308,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/item/weapon/shard,
 /obj/item/stack/rods,
@@ -89446,8 +89328,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -91688,8 +91569,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/painting/random{
 	pixel_x = 32
@@ -92205,8 +92085,7 @@
 "dWP" = (
 /obj/structure/girder,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -93948,8 +93827,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/engineeringmaintenanceblob)
@@ -94159,8 +94037,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/engineeringmaintenanceblob)
@@ -94423,8 +94300,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/engineeringmaintenanceblob)
@@ -94987,8 +94863,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/engineeringmaintenanceblob)
@@ -94998,8 +94873,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/full/reinforced/tinted,
@@ -95008,8 +94882,7 @@
 "edV" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/full/reinforced/tinted,
@@ -95021,8 +94894,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/full/reinforced/tinted,
@@ -95152,8 +95024,7 @@
 "eeu" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -95462,8 +95333,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/theater)
@@ -95714,8 +95584,7 @@
 /area/lamprey/deepresearch)
 "efS" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -95727,8 +95596,7 @@
 /area/lamprey/deepresearch)
 "efT" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/computer/fluff/starmap,
 /turf/simulated/floor{
@@ -95750,8 +95618,7 @@
 /area/lamprey/deepresearch)
 "efV" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/computer/fluff/communications,
 /turf/simulated/floor{
@@ -95760,8 +95627,7 @@
 /area/lamprey/deepresearch)
 "efW" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -96064,8 +95930,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/deepresearch)
@@ -96151,8 +96016,7 @@
 "egN" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -96434,8 +96298,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -96519,8 +96382,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/bridge)
@@ -96612,8 +96474,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -96621,8 +96482,7 @@
 "ehP" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -96633,8 +96493,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -97172,8 +97031,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
@@ -97186,8 +97044,7 @@
 "eiV" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
@@ -97203,8 +97060,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
@@ -107688,8 +107544,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/lamprey/arrivals)
@@ -107814,8 +107669,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -107882,8 +107736,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/item/weapon/shard,
 /obj/item/stack/rods,
@@ -108459,8 +108312,7 @@
 "eGI" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -109301,8 +109153,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/item/weapon/shard{
 	icon_state = "medium"
@@ -109328,8 +109179,7 @@
 "eIv" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/item/weapon/shard{
 	icon_state = "medium"
@@ -171665,8 +171515,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/space,
@@ -171674,8 +171523,7 @@
 "hhz" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/space,
@@ -171686,8 +171534,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/space,
@@ -171745,8 +171592,7 @@
 "hhH" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -172184,8 +172030,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -174224,8 +174069,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/space,
 /area)
@@ -174682,8 +174526,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -174700,8 +174543,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/space,
 /area)
@@ -174712,8 +174554,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/space,
 /area)
@@ -180855,8 +180696,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/space,
 /area)
@@ -181120,8 +180960,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/space,
 /area)
@@ -181129,8 +180968,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/sign/vacuum,
 /turf/space,
@@ -184736,8 +184574,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -185172,8 +185009,7 @@
 /obj/structure/window/reinforced,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -185195,8 +185031,7 @@
 /obj/structure/window/reinforced,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -185548,8 +185383,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /turf/simulated/floor/vox{
 	icon_state = "plating"
@@ -187052,8 +186886,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -188359,16 +188192,14 @@
 "hPI" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /turf/space,
 /area)
 "hPJ" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -190773,8 +190604,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/vox{
 	icon_state = "dark"
@@ -190782,8 +190612,7 @@
 /area/lamprey/combooutpost)
 "hUJ" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/vox{
@@ -190792,8 +190621,7 @@
 /area/lamprey/combooutpost)
 "hUK" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/door/window{
@@ -190805,8 +190633,7 @@
 /area/lamprey/combooutpost)
 "hUL" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/vox{
 	icon_state = "dark"
@@ -190814,8 +190641,7 @@
 /area/lamprey/combooutpost)
 "hUM" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -191004,16 +190830,14 @@
 	},
 /obj/structure/catwalk,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/space,
 /area)
 "hVd" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/space,
 /area)
@@ -192180,8 +192004,7 @@
 /area/lamprey/combooutpost)
 "hXo" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/catwalk,
 /turf/space,

--- a/maps/RoidStation.dmm
+++ b/maps/RoidStation.dmm
@@ -4234,8 +4234,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating/airless,
@@ -4639,8 +4638,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/abstract/map/spawner/assistant/materials,
 /turf/simulated/floor{
@@ -4661,8 +4659,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 8;
@@ -4738,8 +4735,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -4852,8 +4848,7 @@
 	name = "Tradeship Display Shutters"
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -5015,8 +5010,7 @@
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -6805,8 +6799,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
@@ -8722,8 +8715,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
@@ -14322,8 +14314,7 @@
 /area/maintenance/fpmaint)
 "aEh" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -14336,8 +14327,7 @@
 "aEi" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -14363,8 +14353,7 @@
 "aEl" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
@@ -14391,8 +14380,7 @@
 "aEo" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -20244,8 +20232,7 @@
 "aOH" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -22277,8 +22264,7 @@
 "aSm" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -23032,8 +23018,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
@@ -24640,8 +24625,7 @@
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -28424,8 +28408,7 @@
 "bdz" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -28686,8 +28669,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -34466,8 +34448,7 @@
 /area/supply/sorting)
 "boF" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/machinery/computer/ordercomp,
 /obj/machinery/door/poddoor/shutters{
@@ -39312,8 +39293,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/supply/office)
@@ -42175,9 +42155,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 2;
-	tag = ""
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
@@ -45902,9 +45880,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 2;
-	tag = ""
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/starboard)
@@ -48741,8 +48717,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/flora/rock,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -48753,8 +48728,7 @@
 "bOM" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/flora/rock,
 /obj/structure/flora/ausbushes/leafybush,
@@ -48793,8 +48767,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/flora/rock,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -49170,8 +49143,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/engineering/supermatter_room)
@@ -49179,8 +49151,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/hidden,
 /turf/simulated/floor/plating,
@@ -49213,8 +49184,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -49233,8 +49203,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -50641,8 +50610,7 @@
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/port)
@@ -50728,8 +50696,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_upload)
@@ -51947,8 +51914,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/sign/kiddieplaque{
 	pixel_x = -32
@@ -51992,9 +51958,7 @@
 	one_way = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 2;
-	tag = ""
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -52375,8 +52339,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/starboard)
@@ -52411,8 +52374,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/starboard)
@@ -52963,8 +52925,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
@@ -52972,8 +52933,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -53001,8 +52961,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -53018,8 +52977,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -53358,9 +53316,7 @@
 	icon_state = "2-8"
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 2;
-	tag = ""
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/bridge)
@@ -57845,8 +57801,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/storage/auxillary)
@@ -60300,9 +60255,7 @@
 	opacity = 0
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 2;
-	tag = ""
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -60453,8 +60406,7 @@
 "cjd" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -61896,8 +61848,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/central)
@@ -64020,8 +63971,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/bar)
@@ -64240,8 +64190,7 @@
 "cqn" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -68160,8 +68109,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/bed/chair/wood/wings{
 	dir = 4
@@ -71361,8 +71309,7 @@
 "cCO" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -74594,8 +74541,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep)
@@ -84888,8 +84834,7 @@
 "ddW" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -86928,8 +86873,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/hydroponics)
@@ -86939,13 +86883,10 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 2;
-	tag = ""
+	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
@@ -87240,9 +87181,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 2;
-	tag = ""
+	dir = 4
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating{
@@ -92859,9 +92798,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 2;
-	tag = ""
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/security/lobby)
@@ -92924,9 +92861,7 @@
 	icon_state = "0-8"
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 2;
-	tag = ""
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -94530,9 +94465,7 @@
 	opacity = 0
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 2;
-	tag = ""
+	dir = 4
 	},
 /obj/structure/cable/orange{
 	d2 = 2;
@@ -97489,8 +97422,7 @@
 	id_tag = "secdisposal"
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint2)
@@ -97522,8 +97454,7 @@
 	tag = ""
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint2)
@@ -99488,8 +99419,7 @@
 "dEp" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/security/warden)
@@ -99535,8 +99465,7 @@
 /obj/structure/table/reinforced,
 /obj/item/weapon/pen,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/item/weapon/stamp/warden,
 /obj/item/weapon/paper_bin/red{
@@ -99560,8 +99489,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -99588,8 +99516,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -99615,8 +99542,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -99626,8 +99552,7 @@
 "dEz" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/security/interrogation)
@@ -104533,8 +104458,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor/plating,
@@ -104551,8 +104475,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -121394,8 +121317,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape/centcom)
@@ -130019,9 +129941,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 2;
-	tag = ""
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 1;

--- a/maps/RoidStation.dmm
+++ b/maps/RoidStation.dmm
@@ -6793,16 +6793,6 @@
 	},
 /turf/simulated/floor/glass/plasma,
 /area/hallway/primary/starboard)
-"apn" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/hallway/secondary/exit)
 "apo" = (
 /obj/effect/decal/warning_stripes{
 	dir = 4;
@@ -8114,17 +8104,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/derelictparts/fore)
-"asu" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/hallway/secondary/exit)
 "asv" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -38488,15 +38467,6 @@
 	},
 /turf/simulated/floor,
 /area/engineering/supermatter_room)
-"bvU" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/insulated/hidden,
-/turf/simulated/floor/plating,
-/area/engineering/supermatter_room)
 "bvV" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -52367,14 +52337,6 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/hallway/primary/starboard)
-"bVv" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/starboard)
@@ -181744,7 +181706,7 @@ bdu
 bnq
 bqc
 bti
-bvU
+bPy
 byF
 bBr
 btj
@@ -182748,7 +182710,7 @@ bdu
 bnq
 bqi
 bti
-bvU
+bPy
 byJ
 bBx
 bvl
@@ -219353,12 +219315,12 @@ aaa
 aoo
 aoH
 aob
-apn
+aor
 apT
 aqr
 aoc
 aoc
-asu
+atA
 aob
 atA
 aoc
@@ -245006,7 +244968,7 @@ bMo
 bOA
 bQT
 bJW
-bVv
+bSY
 bXF
 bZO
 bXy

--- a/maps/bagelstation.dmm
+++ b/maps/bagelstation.dmm
@@ -52019,8 +52019,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/library)
@@ -53022,8 +53021,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/library)
@@ -53035,8 +53033,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/library)
@@ -56385,8 +56382,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -56446,8 +56442,7 @@
 "cdW" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -56582,8 +56577,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -57452,8 +57446,7 @@
 "cfL" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -57509,8 +57502,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -58306,8 +58298,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -61463,8 +61454,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/science/podbay)
@@ -62401,8 +62391,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/science/podbay)
@@ -62414,8 +62403,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -63064,8 +63052,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/science/podbay)
@@ -73515,8 +73502,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
@@ -73890,8 +73876,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area)
@@ -73899,8 +73884,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area)
@@ -73930,8 +73914,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/sign/vacuum,
 /turf/simulated/floor/plating,
@@ -109408,8 +109391,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id_tag = "TSdisplay";
@@ -110476,8 +110458,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -110687,8 +110668,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/full/reinforced,
@@ -110705,8 +110685,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/full/reinforced,
@@ -114388,8 +114367,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/library)

--- a/maps/defficiency.dmm
+++ b/maps/defficiency.dmm
@@ -39465,8 +39465,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -110646,8 +110645,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -2856,8 +2856,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -4647,8 +4646,7 @@
 	tag = "icon-warning (NORTHWEST)"
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/door/window{
 	base_state = "right";
@@ -8821,8 +8819,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -9236,8 +9233,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -16385,8 +16381,7 @@
 /area/maintenance/asmaint2)
 "aCB" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/bed/chair/comfy/couch/mid/red,
 /turf/simulated/floor/carpet,
@@ -16416,8 +16411,7 @@
 /area/hallway/primary/starboard)
 "aCE" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -16910,8 +16904,7 @@
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -17243,8 +17236,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -17788,8 +17780,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint2)
@@ -18317,8 +18308,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
@@ -19477,8 +19467,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -21738,8 +21727,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/science/robotics)
@@ -23754,8 +23742,7 @@
 	},
 /obj/structure/window/full/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area)
@@ -26567,8 +26554,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -26592,8 +26578,7 @@
 	},
 /obj/item/weapon/gun/projectile/automatic/vector,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -29186,8 +29171,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
@@ -41937,8 +41921,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
@@ -42013,8 +41996,7 @@
 "bCE" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/full/reinforced,
@@ -74968,8 +74950,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -78354,8 +78335,7 @@
 /area/medical/chemistry)
 "wPo" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8

--- a/maps/junglestation.dmm
+++ b/maps/junglestation.dmm
@@ -1008,9 +1008,7 @@
 	in_dir = 4;
 	out_dir = 8
 	},
-/obj/structure/window/reinforced{
-	pixel_y = 1
-	},
+/obj/structure/window/reinforced,
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "dark"
@@ -10866,8 +10864,7 @@
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/security/processing)
@@ -12243,9 +12240,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	pixel_y = 1
-	},
+/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -14260,9 +14255,7 @@
 /obj/machinery/optable{
 	name = "Robotics Operating Table"
 	},
-/obj/structure/window/reinforced{
-	pixel_y = 1
-	},
+/obj/structure/window/reinforced,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -54500,9 +54493,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	pixel_y = 1
-	},
+/obj/structure/window/reinforced,
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "dark"
@@ -57487,9 +57478,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	pixel_y = 1
-	},
+/obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/research_outpost/anomaly)
 "vjR" = (
@@ -62337,9 +62326,7 @@
 	name = "reinforced one-way window";
 	one_way = 1
 	},
-/obj/structure/window/reinforced{
-	pixel_y = 1
-	},
+/obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -63979,9 +63966,7 @@
 	dir = 4;
 	id_tag = "garbage"
 	},
-/obj/structure/window/reinforced{
-	pixel_y = 1
-	},
+/obj/structure/window/reinforced,
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "dark"

--- a/maps/line.dmm
+++ b/maps/line.dmm
@@ -3168,8 +3168,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fportsolar)
@@ -3177,8 +3176,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fportsolar)
@@ -3213,8 +3211,7 @@
 	tag = ""
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fportsolar)
@@ -3588,8 +3585,7 @@
 "aQz" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/security/warden)
@@ -3842,8 +3838,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fportsolar)
@@ -8943,8 +8938,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
@@ -24364,8 +24358,7 @@
 "dVc" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -51158,8 +51151,7 @@
 	tag = ""
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/security/lobby)
@@ -51887,8 +51879,7 @@
 	tag = ""
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -52732,8 +52723,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/science/lab)
@@ -54823,8 +54813,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/construction/hallway{
@@ -55229,8 +55218,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -55851,8 +55839,7 @@
 "iuI" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/security/interrogation)
@@ -59909,8 +59896,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/ghettomorgue{
@@ -62930,9 +62916,7 @@
 	icon_state = "0-8"
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 2;
-	tag = ""
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -64380,8 +64364,7 @@
 	tag = ""
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/ghettomorgue{
@@ -74040,8 +74023,7 @@
 	id_tag = "secdisposal"
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -76341,8 +76323,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -77910,9 +77891,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	pixel_y = -1
-	},
+/obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/medical/genetics)
 "occ" = (
@@ -81062,8 +81041,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -81522,8 +81500,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor/plating,
@@ -83938,9 +83915,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	pixel_y = -1
-	},
+/obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/medical/genetics)
 "pAt" = (
@@ -85102,8 +85077,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -86833,9 +86807,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 2;
-	tag = ""
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/security/lobby)
@@ -87703,8 +87675,7 @@
 	tag = ""
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/construction/hallway{
@@ -92948,8 +92919,7 @@
 /obj/structure/table/reinforced,
 /obj/item/weapon/pen,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/item/weapon/stamp/warden,
 /obj/item/weapon/paper_bin/red{
@@ -104746,8 +104716,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -104994,8 +104963,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -105012,8 +104980,7 @@
 	tag = ""
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/storage/tools)
@@ -105241,9 +105208,7 @@
 	opacity = 0
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 2;
-	tag = ""
+	dir = 4
 	},
 /obj/structure/cable/orange{
 	d2 = 2;
@@ -115188,8 +115153,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/security/lobby)
@@ -115300,8 +115264,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -116829,8 +116792,7 @@
 	tag = ""
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -117789,8 +117751,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -118624,8 +118585,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/bar)

--- a/maps/line.dmm
+++ b/maps/line.dmm
@@ -7654,14 +7654,6 @@
 /obj/abstract/map/spawner/maint/lowchance,
 /turf/simulated/floor/plating,
 /area/shuttle/salvage/derelict)
-"bZD" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fportsolar)
 "bZH" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -198421,7 +198413,7 @@ byz
 bMA
 bMA
 cjw
-bZD
+aLU
 aaj
 aaa
 aaa
@@ -198923,7 +198915,7 @@ dEt
 dEb
 dEb
 ckf
-bZD
+aLU
 aaj
 aaa
 aaa
@@ -199425,7 +199417,7 @@ byL
 dEb
 dEb
 ckG
-bZD
+aLU
 aaj
 aaa
 aaa
@@ -199927,7 +199919,7 @@ bzA
 bNn
 dEb
 cmm
-bZD
+aLU
 aaj
 aaa
 aaa
@@ -200929,7 +200921,7 @@ dEb
 bmc
 bAA
 bNF
-bZD
+aLU
 cno
 cyu
 aaj

--- a/maps/lowfatbagel.dmm
+++ b/maps/lowfatbagel.dmm
@@ -51149,19 +51149,6 @@
 	icon_state = "dark"
 	},
 /area/security/armory)
-"hCH" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/port)
 "hCL" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -204019,7 +204006,7 @@ dhk
 bMX
 dhk
 uhp
-hCH
+kpk
 umb
 pgh
 hkq

--- a/maps/lowfatbagel.dmm
+++ b/maps/lowfatbagel.dmm
@@ -1856,8 +1856,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/supply/storage)
@@ -1980,8 +1979,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -2156,8 +2154,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -2784,8 +2781,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/supply/storage)
@@ -2869,8 +2865,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating/vox,
@@ -2884,8 +2879,7 @@
 "agB" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -3827,8 +3821,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
@@ -4907,8 +4900,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -4958,8 +4950,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/arrival/station)
@@ -4999,8 +4990,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -5430,8 +5420,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/arrival/station)
@@ -5594,8 +5583,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -6807,8 +6795,7 @@
 "apU" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -8015,8 +8002,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -8267,8 +8253,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -9683,8 +9668,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -10158,8 +10142,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -10193,8 +10176,7 @@
 "aBR" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -10941,8 +10923,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -11143,8 +11124,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -15357,8 +15337,7 @@
 "aQa" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -19434,8 +19413,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -19532,8 +19510,7 @@
 "bbN" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -19667,8 +19644,7 @@
 "bca" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
@@ -20006,8 +19982,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -23542,8 +23517,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
@@ -23553,8 +23527,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
@@ -29564,8 +29537,7 @@
 /obj/structure/window/reinforced,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
@@ -30837,8 +30809,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
@@ -31498,8 +31469,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating/airless,
 /area/science/hallway)
@@ -36865,8 +36835,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
@@ -37120,8 +37089,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
@@ -40780,8 +40748,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating/vox,
@@ -43229,8 +43196,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/cable,
@@ -43988,8 +43954,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -45900,8 +45865,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/trade/start)
@@ -50238,8 +50202,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -55085,8 +55048,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -55575,8 +55537,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating/airless,
 /area/science/hallway)
@@ -56848,8 +56809,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -60344,8 +60304,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -60626,8 +60585,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -62698,8 +62656,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
@@ -63054,8 +63011,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id_tag = "TSdisplay";
@@ -66738,8 +66694,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -74282,8 +74237,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -76278,8 +76232,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/status_display,
 /turf/simulated/floor/plating,
@@ -77844,8 +77797,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -78913,8 +78865,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
@@ -79842,8 +79793,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
@@ -83278,8 +83228,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -83929,8 +83878,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
@@ -89359,8 +89307,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -92135,8 +92082,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -92759,8 +92705,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
@@ -94626,8 +94571,7 @@
 /obj/structure/window/full/reinforced,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -98907,8 +98851,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -99066,8 +99009,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -103229,8 +103171,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -108565,8 +108506,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)

--- a/maps/metaclub.dmm
+++ b/maps/metaclub.dmm
@@ -99533,15 +99533,6 @@
 	},
 /turf/space,
 /area)
-"dUd" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/space,
-/area)
 "dVb" = (
 /obj/effect/landmark/map_element/djsat,
 /turf/space,
@@ -117021,20 +117012,6 @@
 	},
 /obj/machinery/door/mineral/wood,
 /turf/simulated/floor/vox/wood,
-/area)
-"eLa" = (
-/obj/structure/window/full/reinforced,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating/vox,
 /area)
 "eLb" = (
 /obj/structure/window/full/reinforced,
@@ -283057,7 +283034,7 @@ bhm
 aTn
 bsH
 bNw
-dUd
+bmD
 aTg
 bhj
 aTg
@@ -292066,7 +292043,7 @@ abl
 abl
 aPX
 aRG
-dUd
+bmD
 aTg
 aTg
 aTg
@@ -1486448,10 +1486425,10 @@ eJe
 eKn
 eJe
 eJe
-eLa
+eGT
 eHn
 eLp
-eLa
+eGT
 eHn
 dOD
 dOD

--- a/maps/metaclub.dmm
+++ b/maps/metaclub.dmm
@@ -11016,8 +11016,7 @@
 /obj/structure/cable/yellow,
 /obj/structure/window/full/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
@@ -18050,8 +18049,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/table,
 /turf/simulated/floor,
@@ -18715,8 +18713,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -20557,8 +20554,7 @@
 	})
 "aQy" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/closet/crate/internals,
 /obj/effect/decal/warning_stripes{
@@ -23268,8 +23264,7 @@
 "aVj" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/machinery/disposal/deliveryChute{
 	dir = 4;
@@ -30302,8 +30297,7 @@
 /area)
 "bhk" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -30316,8 +30310,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -30665,8 +30658,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -31529,8 +31521,7 @@
 /area/turret_protected/ai)
 "bjr" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -33305,8 +33296,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/space,
 /area)
@@ -46506,8 +46496,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/lattice,
 /turf/space,
@@ -74050,8 +74039,7 @@
 /area/medical/genetics)
 "cEY" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
@@ -76178,8 +76166,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/machinery/light{
 	dir = 4
@@ -78419,8 +78406,7 @@
 	icon_state = "bot"
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -83171,8 +83157,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
@@ -83181,8 +83166,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -83190,8 +83174,7 @@
 "cUG" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -85664,8 +85647,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -85910,8 +85892,7 @@
 /obj/structure/window/full/reinforced,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -87842,8 +87823,7 @@
 	icon_state = "14"
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/supply)
@@ -87859,8 +87839,7 @@
 	icon_state = "17"
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/supply)
@@ -87870,8 +87849,7 @@
 	icon_state = "9"
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/supply)
@@ -90993,8 +90971,7 @@
 /obj/structure/window/full/reinforced,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -101533,8 +101510,7 @@
 "ecx" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -113572,8 +113548,7 @@
 /area/mine/living_quarters)
 "eAO" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/mine/living_quarters)
@@ -113582,8 +113557,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/mine/living_quarters)
@@ -115273,8 +115247,7 @@
 /area)
 "eGq" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating/vox,
@@ -115435,8 +115408,7 @@
 /obj/structure/window/full/reinforced,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -115802,8 +115774,7 @@
 /obj/structure/window/full/reinforced,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -115839,8 +115810,7 @@
 /obj/structure/window/full/reinforced,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{

--- a/maps/nervestation.dmm
+++ b/maps/nervestation.dmm
@@ -57470,8 +57470,7 @@
 "kFd" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -79956,8 +79955,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
@@ -84663,8 +84661,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -87238,8 +87235,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
@@ -104419,8 +104415,7 @@
 "xCU" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -105219,8 +105214,7 @@
 "xMg" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{

--- a/maps/packedstation.dmm
+++ b/maps/packedstation.dmm
@@ -103,8 +103,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -115,8 +114,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -130,8 +128,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -451,8 +448,7 @@
 "aaM" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -491,8 +487,7 @@
 "aaQ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -652,8 +647,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -690,8 +684,7 @@
 /area/maintenance/fsmaint)
 "abl" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -874,8 +867,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -1601,8 +1593,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -1892,8 +1883,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/ghettobar)
@@ -1901,8 +1891,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1913,8 +1902,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -2213,8 +2201,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -3196,8 +3183,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -4481,8 +4467,7 @@
 "ahO" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -4951,8 +4936,7 @@
 "aiG" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -4963,8 +4947,7 @@
 "aiH" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -5293,8 +5276,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -5305,8 +5287,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -5455,8 +5436,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -6192,8 +6172,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/camera/flawless{
 	name = "AI Upload"
@@ -6642,8 +6621,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/greengrid,
 /area/turret_protected/ai_upload)
@@ -9394,8 +9372,7 @@
 "apO" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -9475,8 +9452,7 @@
 "apR" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -10733,8 +10709,7 @@
 "arP" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -11258,8 +11233,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -11324,8 +11298,7 @@
 "asL" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -11896,8 +11869,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -12373,8 +12345,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -19671,8 +19642,7 @@
 	},
 /obj/structure/window/full/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/medical/genetics)
@@ -27282,8 +27252,7 @@
 "aUD" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -28662,8 +28631,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -28671,8 +28639,7 @@
 "aWY" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -28680,8 +28647,7 @@
 "aWZ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -28862,8 +28828,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating/airless,
@@ -33310,8 +33275,7 @@
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
@@ -33371,8 +33335,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -33385,8 +33348,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint3{
@@ -33413,8 +33375,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -33460,8 +33421,7 @@
 "beR" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -33473,8 +33433,7 @@
 "beS" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -35300,8 +35259,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -35309,8 +35267,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -35332,8 +35289,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -35678,8 +35634,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes{
 	dir = 8;
@@ -37145,8 +37100,7 @@
 "bkG" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -37160,8 +37114,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -37369,8 +37322,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating/airless,
 /area/maintenance/disposal)
@@ -37722,8 +37674,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -37734,8 +37685,7 @@
 "blF" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -38031,8 +37981,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
@@ -38728,8 +38677,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -38812,8 +38760,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -39346,8 +39293,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -40471,8 +40417,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -41543,8 +41488,7 @@
 "bsa" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -41555,8 +41499,7 @@
 "bsb" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/full/reinforced,
@@ -41568,8 +41511,7 @@
 "bsc" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -41580,8 +41522,7 @@
 "bsd" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/full/reinforced,
@@ -41602,8 +41543,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
@@ -42770,8 +42710,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
@@ -42789,8 +42728,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /obj/structure/window/reinforced,
@@ -43051,8 +42989,7 @@
 "buh" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -43067,8 +43004,7 @@
 "bui" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/full/reinforced,
@@ -54312,8 +54248,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /turf/unsimulated/floor{
@@ -54493,8 +54428,7 @@
 	},
 /obj/structure/window/full/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/centcom/evac)
@@ -59848,8 +59782,7 @@
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -60835,8 +60768,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -61028,8 +60960,7 @@
 	name = "Tradeship Display Shutters"
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -61224,8 +61155,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/abstract/map/spawner/assistant/materials,
 /turf/simulated/floor{
@@ -69975,8 +69905,7 @@
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -70380,8 +70309,7 @@
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -71886,8 +71814,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
@@ -71909,8 +71836,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 8;
@@ -72332,8 +72258,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,

--- a/maps/packedstation.dmm
+++ b/maps/packedstation.dmm
@@ -28644,14 +28644,6 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
-"aWZ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
 "aXa" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -215463,7 +215455,7 @@ aRG
 aTl
 aLJ
 aVZ
-aWZ
+aWY
 aYh
 aCS
 aCS

--- a/maps/randomvaults/black_site_prism.dmm
+++ b/maps/randomvaults/black_site_prism.dmm
@@ -773,14 +773,6 @@
 /obj/structure/grille/window_spawner/reinforced,
 /turf/simulated/floor/plating,
 /area/vault/black_site_prism)
-"hR" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/vault/black_site_prism)
 "hX" = (
 /obj/effect/decal/cleanable/blood/stattrack{
 	dir = 10
@@ -5250,8 +5242,8 @@ Mg
 SU
 zm
 iQ
-hR
-hR
+Yc
+Yc
 pm
 xP
 UJ

--- a/maps/randomvaults/black_site_prism.dmm
+++ b/maps/randomvaults/black_site_prism.dmm
@@ -412,9 +412,7 @@
 	one_way = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 2;
-	tag = ""
+	dir = 4
 	},
 /obj/item/ammo_storage/magazine/mc9mm,
 /obj/item/ammo_storage/magazine/mc9mm,
@@ -777,9 +775,7 @@
 /area/vault/black_site_prism)
 "hR" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 2;
-	tag = ""
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -1156,9 +1152,7 @@
 /area/vault/black_site_prism)
 "pm" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 2;
-	tag = ""
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	dir = 8;
@@ -1635,8 +1629,7 @@
 /area/vault/black_site_prism)
 "vB" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1817,13 +1810,10 @@
 /area/vault/black_site_prism)
 "xt" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 2;
-	tag = ""
+	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -3868,9 +3858,7 @@
 	one_way = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 2;
-	tag = ""
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"

--- a/maps/randomvaults/dungeons/habitation.dmm
+++ b/maps/randomvaults/dungeons/habitation.dmm
@@ -158,8 +158,7 @@
 /area/vault/mothership_lab/administration)
 "bp" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/photocopier,
 /obj/structure/window/reinforced{
@@ -1307,8 +1306,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/unsimulated/floor,
 /area/vault/mothership_lab/habitation)
@@ -1621,8 +1619,7 @@
 /obj/item/weapon/paper_bin/yellow,
 /obj/item/weapon/pen,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/unsimulated/floor/ayy/maint,
 /area/vault/mothership_lab/habitation)
@@ -1952,8 +1949,7 @@
 	tag = "icon-warning (EAST)"
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/item/clothing/mask/gas/mothership,
 /turf/unsimulated/floor/ayy/fancy,
@@ -2474,8 +2470,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/item/weapon/paper_bin/yellow,
 /obj/item/weapon/pen,
@@ -2749,8 +2744,7 @@
 	tag = "icon-warning (EAST)"
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -2904,8 +2898,7 @@
 "yR" = (
 /obj/structure/closet/emcloset,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -3117,8 +3110,7 @@
 	tag = "icon-warning (WEST)"
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -3631,8 +3623,7 @@
 "FS" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/item/weapon/paper_bin/yellow,
 /obj/item/weapon/pen,
@@ -5509,8 +5500,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/item/weapon/storage/firstaid/regular,
 /obj/item/weapon/storage/firstaid/regular,

--- a/maps/randomvaults/dungeons/research.dmm
+++ b/maps/randomvaults/dungeons/research.dmm
@@ -13,8 +13,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/computer/med_data/laptop,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/unsimulated/floor/lab_sterile,
 /area/vault/mothership_lab/research)
@@ -3213,8 +3212,7 @@
 /area/vault/mothership_lab/maintenance)
 "IC" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/unsimulated/floor/ayy,
 /area/vault/mothership_lab/research)
@@ -4066,8 +4064,7 @@
 /area/vault/mothership_lab/armory)
 "QF" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/camera{
 	dir = 8;
@@ -4461,8 +4458,7 @@
 /obj/item/weapon/paper_bin/green,
 /obj/item/weapon/pen,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/unsimulated/floor/lab_sterile,
 /area/vault/mothership_lab/research)
@@ -4825,8 +4821,7 @@
 /area/vault/mothership_lab/maintenance)
 "Yr" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4

--- a/maps/randomvaults/forsakenreactor.dmm
+++ b/maps/randomvaults/forsakenreactor.dmm
@@ -70,8 +70,7 @@
 	one_way = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/vault/forsakenreactor)
@@ -311,8 +310,7 @@
 /area/vault/forsakenreactor)
 "eK" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	one_way = 1
@@ -384,8 +382,7 @@
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/vault/forsakenreactor)
@@ -517,8 +514,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	one_way = 1
@@ -663,8 +659,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -779,8 +774,7 @@
 /area/vault/forsakenreactor)
 "jX" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	one_way = 1
@@ -1191,8 +1185,7 @@
 	one_way = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/vault/forsakenreactor)
@@ -1313,8 +1306,7 @@
 	one_way = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1426,8 +1418,7 @@
 	one_way = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1606,8 +1597,7 @@
 /area/vault/forsakenreactor)
 "vn" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	one_way = 1
@@ -1813,8 +1803,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -2174,8 +2163,7 @@
 /area/vault/forsakenreactor)
 "EX" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/grille/broken,
 /obj/item/stack/rods,
@@ -2244,8 +2232,7 @@
 "Gl" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "dark brown stripe";
@@ -2763,8 +2750,7 @@
 	one_way = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/vault/forsakenreactor)
@@ -3161,8 +3147,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	one_way = 1

--- a/maps/randomvaults/forsakenreactor.dmm
+++ b/maps/randomvaults/forsakenreactor.dmm
@@ -1179,16 +1179,6 @@
 	icon_state = "dark"
 	},
 /area/vault/forsakenreactor)
-"pf" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	one_way = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/vault/forsakenreactor)
 "pp" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor{
@@ -4134,7 +4124,7 @@ EX
 kA
 eW
 nH
-pf
+ws
 rS
 Nf
 no
@@ -4394,11 +4384,11 @@ lm
 bB
 kA
 sa
-pf
+ws
 xP
 xQ
 ga
-pf
+ws
 eW
 sa
 Th

--- a/maps/snaxi.dmm
+++ b/maps/snaxi.dmm
@@ -1859,8 +1859,7 @@
 /area/surface/forest/north)
 "afV" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/full/reinforced,
@@ -1875,8 +1874,7 @@
 	})
 "afW" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1890,8 +1888,7 @@
 	})
 "agb" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/full/reinforced,
@@ -1905,8 +1902,7 @@
 	})
 "agc" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -2052,8 +2048,7 @@
 	})
 "agt" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -2070,8 +2065,7 @@
 	})
 "agu" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -2243,8 +2237,7 @@
 /obj/structure/window/full/reinforced,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal{
@@ -3093,8 +3086,7 @@
 /obj/structure/window/full/reinforced,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/filtering/visible{
 	dir = 4
@@ -7301,8 +7293,7 @@
 /obj/structure/window/full/reinforced,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/surface/icecore)
@@ -17333,8 +17324,7 @@
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port{
@@ -22346,8 +22336,7 @@
 "aZk" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /obj/structure/grille,
@@ -22359,8 +22348,7 @@
 "aZm" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /obj/structure/grille,
@@ -22550,8 +22538,7 @@
 /area/medical/chemistry)
 "aZT" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -24215,8 +24202,7 @@
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/garage)
@@ -24229,8 +24215,7 @@
 /area/station/garage)
 "bdT" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes{
 	dir = 8;
@@ -30199,8 +30184,7 @@
 "bsH" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /obj/structure/grille,
@@ -44777,8 +44761,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -45887,8 +45870,7 @@
 "bUA" = (
 /obj/structure/closet/coffin,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/chapel/office)
@@ -45899,8 +45881,7 @@
 "bUC" = (
 /obj/structure/closet/coffin,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -47658,8 +47639,7 @@
 	icon_state = "0-2"
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -49905,8 +49885,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -49973,8 +49952,7 @@
 	one_way = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -50025,8 +50003,7 @@
 	icon_state = "0-2"
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -50230,8 +50207,7 @@
 	icon_state = "0-2"
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -50304,8 +50280,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
@@ -50334,8 +50309,7 @@
 /obj/structure/cable,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
@@ -50362,8 +50336,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
@@ -50386,8 +50359,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /obj/structure/cable{
@@ -50414,8 +50386,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /obj/structure/cable{
@@ -70461,9 +70432,7 @@
 "dDx" = (
 /obj/machinery/botany/extractor,
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 2;
-	tag = ""
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -70509,9 +70478,7 @@
 /obj/structure/table,
 /obj/item/weapon/storage/lockbox/diskettebox/large/open/botanydisk,
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 2;
-	tag = ""
+	dir = 4
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor{
@@ -75509,8 +75476,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating/airless,
@@ -75677,9 +75643,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 2;
-	tag = ""
+	dir = 4
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 2;
@@ -76408,8 +76372,7 @@
 "eBd" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -81139,8 +81102,7 @@
 "ljU" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /obj/structure/grille,
@@ -83218,8 +83180,7 @@
 "nSP" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /obj/structure/grille,
@@ -85576,9 +85537,7 @@
 "rqN" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 2;
-	tag = ""
+	dir = 4
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor{

--- a/maps/synergy.dmm
+++ b/maps/synergy.dmm
@@ -278,8 +278,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fportsolar)
@@ -287,8 +286,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fportsolar)
@@ -300,8 +298,7 @@
 	tag = ""
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fportsolar)
@@ -367,8 +364,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fportsolar)
@@ -1600,8 +1596,7 @@
 "adm" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
@@ -1640,8 +1635,7 @@
 	tag = ""
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
@@ -1848,8 +1842,7 @@
 	tag = ""
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -2903,8 +2896,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/air,
@@ -2936,8 +2928,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/air,
@@ -5200,8 +5191,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/barricade/full/block,
 /turf/simulated/floor/plating,
@@ -5214,8 +5204,7 @@
 	tag = ""
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/sign/pox,
 /turf/simulated/floor/plating,
@@ -5249,8 +5238,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/barricade/full/block,
 /obj/structure/sign/pox,
@@ -5260,8 +5248,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/ghettobar)
@@ -5273,8 +5260,7 @@
 	tag = ""
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/barricade/full/block,
 /turf/simulated/floor/plating,
@@ -5343,8 +5329,7 @@
 	tag = ""
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -8753,8 +8738,7 @@
 	tag = "icon-warning (EAST)"
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -8928,8 +8912,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/construction/hallway{
@@ -8943,8 +8926,7 @@
 	tag = ""
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/construction/hallway{
@@ -9565,8 +9547,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/structure/window/reinforced{
@@ -9578,8 +9559,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/engineering/supermatter_room)
@@ -9587,8 +9567,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -9600,8 +9579,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -9618,8 +9596,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/construction/mommi_nest)
@@ -12747,8 +12724,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/construction/mommi_nest)
@@ -12756,8 +12732,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/construction/mommi_nest)
@@ -12769,8 +12744,7 @@
 	tag = ""
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/construction/mommi_nest)
@@ -12903,8 +12877,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor/plating,
@@ -12917,8 +12890,7 @@
 	tag = ""
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/storage/tools)
@@ -19028,8 +19000,7 @@
 "aIi" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -22522,8 +22493,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -22539,8 +22509,7 @@
 	tag = ""
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor/plating,
@@ -24795,8 +24764,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -24821,8 +24789,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor/plating,
@@ -24845,8 +24812,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos_control)
@@ -24872,8 +24838,7 @@
 	tag = ""
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos_control)
@@ -26249,8 +26214,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
@@ -26258,8 +26222,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
@@ -26271,8 +26234,7 @@
 	tag = ""
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
@@ -26324,8 +26286,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -26361,8 +26322,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -26403,8 +26363,7 @@
 	tag = ""
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -27754,8 +27713,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -27994,8 +27952,7 @@
 	opacity = 0
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -28725,8 +28682,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/grille,
@@ -37249,8 +37205,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/disposaloutlet,
 /obj/structure/window/reinforced{
@@ -38067,8 +38022,7 @@
 /area/supply/sorting)
 "bov" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4

--- a/maps/synergy.dmm
+++ b/maps/synergy.dmm
@@ -282,14 +282,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fportsolar)
-"aaG" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fportsolar)
 "aaH" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -5242,14 +5234,6 @@
 	},
 /obj/structure/window/barricade/full/block,
 /obj/structure/sign/pox,
-/turf/simulated/floor/plating,
-/area/maintenance/ghettobar)
-"akE" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/ghettobar)
 "akF" = (
@@ -12675,17 +12659,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/engineering/supermatter_room)
-"axj" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	tag = ""
 	},
 /turf/simulated/floor/plating,
 /area/engineering/supermatter_room)
@@ -184763,7 +184736,7 @@ arK
 atb
 auD
 avP
-axj
+aIi
 ays
 azJ
 aBa
@@ -198777,7 +198750,7 @@ aaa
 aaa
 aac
 aaa
-aaG
+abD
 aaL
 aaT
 aaY
@@ -203326,7 +203299,7 @@ aeK
 ahG
 aeK
 ajD
-akE
+adT
 alH
 aeV
 anx

--- a/maps/tgstation-sec.dmm
+++ b/maps/tgstation-sec.dmm
@@ -42474,25 +42474,6 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
-"bHl" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
-"bHm" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
 "bHn" = (
 /turf/simulated/floor/shuttle,
 /area/shuttle/mining/station)
@@ -45579,9 +45560,6 @@
 	name = "blobstart"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
-"bNe" = (
-/turf/simulated/floor/plating/damaged/broken,
 /area/maintenance/aft)
 "bNf" = (
 /obj/effect/decal/cleanable/ash,
@@ -73194,11 +73172,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/unsimulated/wall,
 /area/prison/solitary)
-"cOB" = (
-/turf/unsimulated/floor/broken{
-	icon_state = "plating"
-	},
-/area/prison/solitary)
 "cOC" = (
 /turf/unsimulated/floor{
 	name = "plating"
@@ -73209,10 +73182,6 @@
 /turf/unsimulated/floor{
 	name = "plating"
 	},
-/area/prison/solitary)
-"cOE" = (
-/obj/structure/bed,
-/turf/unsimulated/floor/scorched,
 /area/prison/solitary)
 "cOF" = (
 /obj/effect/decal/cleanable/blood,
@@ -73620,9 +73589,6 @@
 	icon_state = "dark neutral stripe"
 	},
 /area/centcom/suppy)
-"cPM" = (
-/turf/unsimulated/floor/scorched,
-/area/prison/solitary)
 "cPN" = (
 /turf/unsimulated/floor/scorched,
 /area/prison/solitary)
@@ -85945,15 +85911,6 @@
 	},
 /turf/simulated/floor,
 /area/derelict/bridge)
-"dyO" = (
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/singularity_engine)
-"dyP" = (
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/singularity_engine)
-"dyQ" = (
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/singularity_engine)
 "dyR" = (
 /obj/item/stack/cable_coil/cut,
 /obj/machinery/light/small{
@@ -85998,18 +85955,10 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/damaged/airless/broken,
 /area/derelict/singularity_engine)
-"dzb" = (
-/obj/structure/window/reinforced,
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/singularity_engine)
 "dzc" = (
 /obj/structure/window/reinforced,
 /obj/item/weapon/table_parts/reinforced,
 /obj/item/weapon/table_parts/reinforced,
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/singularity_engine)
-"dzd" = (
-/obj/structure/window/reinforced,
 /turf/simulated/floor/damaged/airless/broken,
 /area/derelict/singularity_engine)
 "dze" = (
@@ -86233,10 +86182,6 @@
 /obj/item/stack/rods,
 /turf/simulated/floor/plating/airless,
 /area/derelict/singularity_engine)
-"dzM" = (
-/obj/item/weapon/shard,
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/singularity_engine)
 "dzN" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating/airless,
@@ -86286,12 +86231,6 @@
 /obj/item/weapon/stamp/denied,
 /turf/simulated/floor,
 /area/derelict/bridge)
-"dzV" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/singularity_engine)
 "dzW" = (
 /obj/item/clothing/head/helmet/tactical/swat,
 /turf/simulated/floor/plating/airless,
@@ -86360,10 +86299,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/airless,
-/area/derelict/singularity_engine)
-"dAg" = (
-/obj/item/stack/cable_coil/cut,
-/turf/simulated/floor/damaged/airless/broken,
 /area/derelict/singularity_engine)
 "dAh" = (
 /turf/simulated/floor/airless,
@@ -86456,14 +86391,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/derelict/bridge/access)
-"dAu" = (
-/obj/item/stack/cable_coil/cut,
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/singularity_engine)
-"dAv" = (
-/obj/item/stack/cable_coil/cut,
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/singularity_engine)
 "dAw" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -86499,12 +86426,6 @@
 /area/derelict/singularity_engine)
 "dAC" = (
 /obj/structure/grille,
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/singularity_engine)
-"dAD" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /turf/simulated/floor/damaged/airless/broken,
 /area/derelict/singularity_engine)
 "dAE" = (
@@ -86604,21 +86525,12 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/derelict/hallway/primary)
-"dAX" = (
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/hallway/primary)
 "dAY" = (
 /obj/structure/window{
 	dir = 4
 	},
 /turf/simulated/floor/airless,
 /area/derelict/hallway/primary)
-"dAZ" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/singularity_engine)
 "dBa" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -86686,9 +86598,6 @@
 "dBi" = (
 /turf/simulated/floor/damaged/airless/burnt,
 /area)
-"dBj" = (
-/turf/simulated/floor/damaged/airless/broken,
-/area)
 "dBk" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -86705,15 +86614,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/derelict/hallway/primary)
-"dBm" = (
-/turf/simulated/floor/damaged/airless/burnt,
-/area)
-"dBn" = (
-/obj/item/weapon/shard{
-	icon_state = "medium"
-	},
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/singularity_engine)
 "dBo" = (
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating/airless,
@@ -86908,9 +86808,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area)
-"dCb" = (
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/hallway/primary)
 "dCc" = (
 /obj/machinery/door/window{
 	dir = 8
@@ -86929,9 +86826,6 @@
 	},
 /area/derelict/medical)
 "dCf" = (
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/medical)
-"dCg" = (
 /turf/simulated/floor/damaged/airless/broken,
 /area/derelict/medical)
 "dCh" = (
@@ -86991,9 +86885,6 @@
 	icon_state = "white"
 	},
 /area/derelict/medical)
-"dCq" = (
-/turf/simulated/floor/damaged/airless/broken,
-/area)
 "dCr" = (
 /obj/structure/table,
 /obj/structure/window/reinforced{
@@ -87020,9 +86911,6 @@
 "dCv" = (
 /obj/item/weapon/disk/data/demo,
 /turf/simulated/floor/plating/airless,
-/area)
-"dCw" = (
-/turf/simulated/floor/damaged/airless/broken,
 /area)
 "dCx" = (
 /obj/structure/bed/chair{
@@ -87073,14 +86961,6 @@
 	icon_state = "white"
 	},
 /area)
-"dCE" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/hallway/primary)
 "dCF" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -88055,9 +87935,6 @@
 /obj/structure/closet/wardrobe,
 /turf/simulated/floor,
 /area/derelict/arrival)
-"dFk" = (
-/turf/simulated/floor/damaged/airless/burnt,
-/area/derelict/hallway/primary)
 "dFl" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -88096,9 +87973,6 @@
 /turf/simulated/floor/airless{
 	icon_state = "floorgrime"
 	},
-/area/derelict/hallway/primary)
-"dFr" = (
-/turf/simulated/floor/damaged/airless/broken,
 /area/derelict/hallway/primary)
 "dFs" = (
 /obj/structure/table,
@@ -88884,9 +88758,6 @@
 	maxcharge = 15000
 	},
 /turf/simulated/floor/airless,
-/area/derelict/teleporter)
-"dHD" = (
-/turf/simulated/floor/damaged/airless/broken,
 /area/derelict/teleporter)
 "dHE" = (
 /obj/machinery/power/apc{
@@ -216607,7 +216478,7 @@ bGf
 bGf
 bGf
 bLE
-bNe
+bWY
 bOa
 bPl
 bPl
@@ -265798,7 +265669,7 @@ bwx
 aak
 aaa
 aaa
-bHl
+bVQ
 bEy
 bEy
 bEy
@@ -266300,7 +266171,7 @@ bwz
 aak
 aaa
 aaa
-bHm
+bVR
 bEy
 bEy
 bEy
@@ -398413,7 +398284,7 @@ cOx
 cOW
 cOm
 cOF
-cPM
+cPN
 cOm
 aaa
 aaa
@@ -401421,11 +401292,11 @@ aaa
 aaa
 aaa
 cOm
-cOB
+cPE
 cOW
 cOm
 cOW
-cOB
+cPE
 cOm
 aaa
 cQf
@@ -402930,7 +402801,7 @@ cOm
 cOC
 cOF
 cOm
-cOB
+cPE
 cOC
 cOm
 aaa
@@ -404436,7 +404307,7 @@ cOm
 cOD
 cOz
 cOm
-cOB
+cPE
 cOC
 cOm
 aaa
@@ -405437,7 +405308,7 @@ aaa
 aaa
 aaa
 cOm
-cOE
+cOw
 cOV
 cOm
 cPG
@@ -407446,7 +407317,7 @@ aaa
 aaa
 cOm
 cOC
-cOB
+cPE
 cOm
 cOF
 cPN
@@ -915521,7 +915392,7 @@ dHt
 dHu
 dHv
 dHv
-dHD
+dHw
 dHv
 dHt
 aaa
@@ -932538,7 +932409,7 @@ dAN
 dAN
 dAN
 dAQ
-dFk
+dBf
 dBq
 aaa
 aak
@@ -933039,7 +932910,7 @@ dAN
 dEK
 dEV
 dAN
-dFk
+dBf
 dFq
 dBq
 dBq
@@ -933543,7 +933414,7 @@ dAQ
 dAN
 dBq
 dAQ
-dFk
+dBf
 dBq
 aak
 aak
@@ -934027,7 +933898,7 @@ aak
 aaa
 aaa
 dBX
-dCg
+dCf
 dCf
 dCf
 dCd
@@ -934043,8 +933914,8 @@ dEC
 dAQ
 dEV
 dAN
-dFk
-dFr
+dBf
+dAP
 dAQ
 dBq
 dBq
@@ -934519,8 +934390,8 @@ aak
 dyu
 dyu
 dzp
-dyO
-dyQ
+dzp
+dzp
 dzp
 dAE
 dyu
@@ -934530,8 +934401,8 @@ aaa
 dBK
 dBY
 dBY
-dCg
-dCg
+dCf
+dCf
 dCf
 dCK
 dCT
@@ -935020,11 +934891,11 @@ dyu
 dyu
 dyu
 dyu
-dAu
+dzv
 dAo
 dAH
 dAH
-dAZ
+dAH
 dyu
 dyu
 dyu
@@ -935034,7 +934905,7 @@ dBZ
 dBY
 dBY
 dBY
-dCg
+dCf
 dCf
 dCd
 dDf
@@ -935522,7 +935393,7 @@ dyu
 dyu
 dyu
 dyu
-dAv
+dzv
 dzP
 dAf
 dAf
@@ -936020,18 +935891,18 @@ dyZ
 dzl
 dyS
 dzp
-dyO
 dzp
 dzp
 dzp
 dzp
 dzp
-dyP
 dzp
-dyO
 dzp
-dyO
-dyQ
+dzp
+dzp
+dzp
+dzp
+dzp
 dyS
 dyS
 dCa
@@ -936039,7 +935910,7 @@ aak
 dBY
 dBY
 dBY
-dCg
+dCf
 dCf
 dDi
 dDA
@@ -936057,8 +935928,8 @@ dEV
 dFe
 dAQ
 dAN
-dCb
-dAX
+dAP
+dAP
 dBq
 dBq
 dBq
@@ -936521,19 +936392,19 @@ dyu
 dza
 dzl
 dzp
-dyP
-dyQ
-dyO
 dzp
 dzp
 dzp
-dyP
-dyP
-dyQ
-dyP
 dzp
-dBn
-dyP
+dzp
+dzp
+dzp
+dzp
+dzp
+dzp
+dzp
+dAB
+dzp
 dyT
 dBL
 aak
@@ -936542,8 +936413,8 @@ dBY
 dBY
 dBY
 dBY
-dCg
-dCg
+dCf
+dCf
 dCd
 dDQ
 dAQ
@@ -937019,18 +936890,18 @@ dnI
 dyo
 dyu
 dyu
-dyO
-dzb
+dzp
+dza
 dzl
 dzp
-dyQ
-dyO
+dzp
+dzp
 dzI
 dAc
 dAc
 dAw
 dzp
-dyP
+dzp
 dzL
 dBa
 dAc
@@ -937045,7 +936916,7 @@ aaa
 aaa
 dBY
 dBY
-dCg
+dCf
 dBU
 dAN
 dAQ
@@ -937066,9 +936937,9 @@ dAQ
 dBq
 dAQ
 dAN
-dAX
+dAP
 dBq
-dAX
+dAP
 dFA
 dFR
 dFR
@@ -937521,18 +937392,18 @@ aaa
 aak
 dyu
 dyu
-dyP
+dzp
 dzc
 dzl
 dzp
-dyO
+dzp
 dzI
-dzV
+dAx
 dAd
-dzV
+dAx
 dAx
 dyS
-dyQ
+dzp
 dAS
 dAU
 dyS
@@ -937547,7 +937418,7 @@ aak
 aaa
 dCM
 dBY
-dCg
+dCf
 dBU
 dAN
 dAQ
@@ -937563,10 +937434,10 @@ dAQ
 dAQ
 dAQ
 dAN
-dFr
+dAP
 dAQ
 dAQ
-dAX
+dAP
 dAN
 dAQ
 dAP
@@ -938023,22 +937894,22 @@ aaa
 aak
 dyu
 dyz
-dyQ
-dzb
+dzp
+dza
 dzm
 dzu
 dzB
 dzJ
 dzW
-dyP
-dyP
+dzp
+dzp
 dyS
 dyS
 dyS
 dyS
 dyS
 dyS
-dyO
+dzp
 dyS
 dBo
 dyS
@@ -938526,10 +938397,10 @@ dyo
 dyu
 dyu
 dyR
-dyO
+dzp
 dyS
-dyP
-dyO
+dzp
+dzp
 dzK
 dzX
 dyS
@@ -938539,9 +938410,9 @@ dyS
 dyS
 dyS
 dyS
-dyO
-dyQ
-dyO
+dzp
+dzp
+dzp
 dzN
 dBM
 dzp
@@ -939027,11 +938898,11 @@ aaZ
 aaZ
 aaZ
 dyA
-dyO
-dzd
+dzp
+dza
 dzn
-dyO
-dyQ
+dzp
+dzp
 dzL
 dyS
 dyS
@@ -939046,7 +938917,7 @@ dyS
 dBv
 dAf
 dzp
-dyO
+dzp
 dzp
 dyu
 dyu
@@ -939533,22 +939404,22 @@ dyC
 dyB
 dyu
 dzv
-dyO
-dyS
-dyS
-dyS
-dyS
-aaa
-aaa
-aaa
-aaa
-aaa
-dyS
-dyS
-dyO
 dzp
-dyO
-dyP
+dyS
+dyS
+dyS
+dyS
+aaa
+aaa
+aaa
+aaa
+aaa
+dyS
+dyS
+dzp
+dzp
+dzp
+dzp
 dCi
 dyu
 dCu
@@ -940036,7 +939907,7 @@ dyS
 dyT
 dzp
 dyS
-dzM
+dBM
 dyS
 dyS
 dyS
@@ -940047,11 +939918,11 @@ aaa
 aaa
 dyS
 dyS
-dyP
 dzp
-dyO
-dyP
-dyQ
+dzp
+dzp
+dzp
+dzp
 dyS
 dyS
 dyu
@@ -940548,12 +940419,12 @@ aaa
 aaa
 aaa
 dyS
-dyP
-dyQ
+dzp
+dzp
 dzp
 dAK
-dyP
-dyO
+dzp
+dzp
 dyu
 dyS
 dyu
@@ -941050,11 +940921,11 @@ aaa
 aaa
 aaa
 dyS
-dyO
-dzb
+dzp
+dza
 dBA
 dzp
-dyO
+dzp
 dzp
 dyu
 dyu
@@ -941062,7 +940933,7 @@ dyu
 aak
 aaZ
 aaZ
-dBj
+dBt
 dAN
 dAN
 dAN
@@ -941541,7 +941412,7 @@ dyS
 dze
 dyS
 dzp
-dyO
+dzp
 dzN
 dzY
 dyS
@@ -941553,7 +941424,7 @@ dyS
 dyS
 dyS
 dyS
-dzd
+dza
 dzl
 dzp
 dzp
@@ -942039,11 +941910,11 @@ aak
 aak
 dyu
 dyu
-dyO
-dyO
 dzp
-dyO
-dyO
+dzp
+dzp
+dzp
+dzp
 dzO
 dzY
 dyS
@@ -942055,9 +941926,9 @@ dyS
 dyS
 dyS
 dyS
-dzb
+dza
 dzl
-dyO
+dzp
 dzp
 dyu
 dyu
@@ -942067,7 +941938,7 @@ aak
 aak
 dDl
 aaZ
-dBj
+dBt
 dAN
 dAN
 dDZ
@@ -942541,11 +942412,11 @@ aaa
 aak
 dyu
 dyu
-dyQ
-dyO
-dyQ
-dyP
-dyO
+dzp
+dzp
+dzp
+dzp
+dzp
 dzP
 dzZ
 dAe
@@ -942559,8 +942430,8 @@ dyS
 dBp
 dBv
 dzm
-dyP
-dyO
+dzp
+dzp
 dyu
 dyu
 aak
@@ -942568,7 +942439,7 @@ aaa
 aaa
 aak
 aaZ
-dBj
+dBt
 dDn
 dAN
 dAN
@@ -943043,11 +942914,11 @@ dnI
 dyo
 dyu
 dyu
-dyO
-dyO
 dzp
-dyP
-dyO
+dzp
+dzp
+dzp
+dzp
 dzp
 dzP
 dAf
@@ -943060,9 +942931,9 @@ dBb
 dBk
 dBk
 dBw
-dyO
-dyQ
-dyP
+dzp
+dzp
+dzp
 dyu
 dyu
 aak
@@ -943549,20 +943420,20 @@ dyu
 dzf
 dzp
 dzp
-dyQ
-dyP
-dyO
 dzp
-dyS
-dyS
+dzp
 dzp
 dzp
 dyS
+dyS
 dzp
-dyP
-dyQ
-dyP
-dyO
+dzp
+dyS
+dzp
+dzp
+dzp
+dzp
+dzp
 dzp
 dyu
 dyu
@@ -944051,19 +943922,19 @@ dyu
 dzg
 dyS
 dzp
-dyO
-dyQ
-dyP
-dAg
+dzp
+dzp
+dzp
+dzv
 dzp
 dzp
 dAB
 dAK
 dzp
 dzp
-dyP
 dzp
-dyP
+dzp
+dzp
 dzp
 dzp
 dyu
@@ -944075,7 +943946,7 @@ aaa
 aaa
 dDm
 dBt
-dBj
+dBt
 dAN
 dAQ
 dDS
@@ -944558,10 +944429,10 @@ dyu
 dyu
 dyu
 dyu
-dyO
+dzp
 dAC
 dAL
-dyO
+dzp
 dzN
 dyu
 dyu
@@ -945061,8 +944932,8 @@ dnI
 dnI
 dyu
 dzp
-dAD
-dAD
+dAx
+dAx
 dAU
 dAx
 dyu
@@ -945563,9 +945434,9 @@ aak
 dnI
 dyu
 dyS
-dyO
-dyO
-dyQ
+dzp
+dzp
+dzp
 dzp
 dyu
 dyu
@@ -945575,7 +945446,7 @@ aaa
 aaa
 dBq
 dBq
-dAX
+dAP
 dAP
 dAN
 dAQ
@@ -946078,8 +945949,8 @@ dAW
 dAW
 dAO
 dAO
-dCE
-dCE
+dAO
+dAO
 dCV
 dCV
 dCV
@@ -946576,8 +946447,8 @@ aak
 dBc
 dBx
 dBq
-dAX
-dAX
+dAP
+dAP
 dAP
 dAP
 dAP
@@ -947076,8 +946947,8 @@ dBc
 dAW
 dAW
 dBx
-dAX
-dAX
+dAP
+dAP
 dAP
 dAP
 dAP
@@ -948577,7 +948448,7 @@ dAq
 dAh
 dAF
 dAP
-dAX
+dAP
 dBf
 dAN
 dBq
@@ -950593,12 +950464,12 @@ dAQ
 dAQ
 dAN
 dBf
-dCb
+dAP
 dAV
 dBt
 dBi
 dBi
-dCw
+dBt
 dAV
 dAQ
 dDS
@@ -951098,8 +950969,8 @@ dBf
 dBf
 dAV
 dBi
-dCw
-dCq
+dBt
+dBt
 dBi
 dAV
 dAV
@@ -951596,7 +951467,7 @@ dBs
 dAN
 dAN
 dAN
-dCb
+dAP
 dBq
 dAV
 dBt
@@ -952101,7 +951972,7 @@ dAN
 dBf
 dCj
 dAV
-dCw
+dBt
 dBi
 aaa
 aaa
@@ -955614,7 +955485,7 @@ dBz
 dBO
 dBP
 dBy
-dCq
+dBt
 aaa
 aaa
 aaa
@@ -956116,7 +955987,7 @@ dBz
 dBO
 dBO
 dBy
-dBj
+dBt
 aaa
 aaa
 aaa
@@ -956618,8 +956489,8 @@ dBz
 dBP
 dBQ
 dBy
-dCq
-dCq
+dBt
+dBt
 aaa
 aaa
 aaa
@@ -957122,7 +956993,7 @@ dBQ
 dBy
 aaZ
 aak
-dCw
+dBt
 aaa
 aaa
 aak
@@ -957623,7 +957494,7 @@ dBQ
 dBP
 dBy
 dyn
-dCw
+dBt
 aak
 dBt
 dBy
@@ -958619,7 +958490,7 @@ aaa
 aaa
 aaZ
 aaZ
-dBj
+dBt
 cCT
 dBy
 dBD
@@ -959623,8 +959494,8 @@ aaZ
 aaZ
 aaZ
 aaZ
-dBm
-dBj
+dBi
+dBt
 dBy
 dBF
 dBD
@@ -961630,7 +961501,7 @@ aaa
 aaZ
 aaZ
 aaZ
-dBj
+dBt
 cCT
 cCT
 dBz
@@ -1487687,7 +1487558,7 @@ aaa
 aaa
 aaY
 evD
-dBm
+dBi
 evJ
 aaY
 aaY
@@ -1488189,8 +1488060,8 @@ aaa
 aaa
 aaY
 evE
-dBj
-dBm
+dBt
+dBi
 dnH
 aaZ
 aak

--- a/maps/tgstation-sec.dmm
+++ b/maps/tgstation-sec.dmm
@@ -12606,8 +12606,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -26896,8 +26895,7 @@
 	},
 /obj/structure/catwalk,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/space,
 /area)
@@ -30334,8 +30332,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/medical/genetics)
@@ -30760,8 +30757,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/medical/genetics)
@@ -36303,8 +36299,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/science/lab)
@@ -42482,8 +42477,7 @@
 "bHl" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -42491,8 +42485,7 @@
 "bHm" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -46068,8 +46061,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -62502,8 +62494,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -62563,8 +62554,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
@@ -89270,8 +89260,7 @@
 "dIM" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{

--- a/maps/tgstation-snow.dmm
+++ b/maps/tgstation-snow.dmm
@@ -18644,8 +18644,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -18690,8 +18689,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
@@ -31552,8 +31550,7 @@
 "bYy" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -32241,8 +32238,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating/airless,
@@ -37916,8 +37912,7 @@
 "cwT" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -60747,8 +60742,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 8;
@@ -68793,8 +68787,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/science/lab)
@@ -69101,8 +69094,7 @@
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -78709,8 +78701,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -90180,8 +90171,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/abstract/map/spawner/assistant/materials,
 /turf/simulated/floor/shuttle{
@@ -94086,8 +94076,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -94403,8 +94392,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
@@ -104769,8 +104757,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
@@ -108337,8 +108324,7 @@
 	name = "Tradeship Display Shutters"
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8

--- a/maps/tgstation-snow.dmm
+++ b/maps/tgstation-snow.dmm
@@ -31547,17 +31547,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
-"bYy" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
 "bYA" = (
 /obj/structure/bed,
 /obj/item/weapon/bedsheet/red,
@@ -37909,14 +37898,6 @@
 	tag = "icon-checker (NORTHEAST)"
 	},
 /area/science/rd)
-"cwT" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
 "cwY" = (
 /obj/effect/decal/warning_stripes{
 	dir = 5;
@@ -44245,10 +44226,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/prison)
-"daZ" = (
-/obj/structure/bed,
-/turf/unsimulated/floor/scorched,
-/area/prison/solitary)
 "dba" = (
 /obj/effect/decal/cleanable/blood,
 /turf/unsimulated/floor{
@@ -44476,11 +44453,6 @@
 	icon_state = "plating"
 	},
 /area/prison/solitary)
-"dbE" = (
-/turf/unsimulated/floor/broken{
-	icon_state = "plating"
-	},
-/area/prison/solitary)
 "dbF" = (
 /obj/structure/shuttle/diag_wall/black{
 	dir = 1
@@ -44524,9 +44496,6 @@
 	},
 /area/centcom/living)
 "dbL" = (
-/turf/unsimulated/floor/scorched,
-/area/prison/solitary)
-"dbM" = (
 /turf/unsimulated/floor/scorched,
 /area/prison/solitary)
 "dbN" = (
@@ -56513,10 +56482,6 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
-"eci" = (
-/obj/structure/window/reinforced,
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/singularity_engine)
 "ecj" = (
 /obj/structure/girder,
 /obj/structure/window/full/reinforced/tinted,
@@ -64399,9 +64364,6 @@
 	icon_state = "red"
 	},
 /area/security/lobby)
-"eNM" = (
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/singularity_engine)
 "eOa" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	default_scrubbed_gases = list("plasma");
@@ -66685,9 +66647,6 @@
 	},
 /turf/unsimulated/floor/snow,
 /area/surface/snow)
-"fEr" = (
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/hallway/primary)
 "fEA" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -73549,9 +73508,6 @@
 /obj/machinery/space_heater/air_conditioner,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
-"hXh" = (
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/singularity_engine)
 "hXu" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 4;
@@ -76469,12 +76425,6 @@
 	icon_state = "carpetnoconnect"
 	},
 /area/crew_quarters/sleep)
-"iYL" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/singularity_engine)
 "iYS" = (
 /obj/machinery/computer/arcade,
 /turf/simulated/floor/wood,
@@ -80392,9 +80342,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
-"kuo" = (
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/singularity_engine)
 "kuv" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1;
@@ -81671,9 +81618,6 @@
 	},
 /turf/unsimulated/floor/noblizz_permafrost/icecore,
 /area/surface/icecore)
-"kOl" = (
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/hallway/primary)
 "kOn" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -82685,9 +82629,6 @@
 	icon_state = "white"
 	},
 /area/science/xenobiology)
-"lim" = (
-/turf/simulated/floor/damaged/airless/broken,
-/area/surface/snow)
 "lin" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -83667,9 +83608,6 @@
 	},
 /turf/simulated/floor,
 /area/engineering/break_room)
-"lzY" = (
-/turf/simulated/floor/damaged/airless/broken,
-/area/surface/snow)
 "lAi" = (
 /mob/living/simple_animal/mouse/Tom,
 /turf/simulated/floor/plating,
@@ -84816,9 +84754,6 @@
 	icon_state = "dark"
 	},
 /area/gateway)
-"lXt" = (
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/medical)
 "lXu" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -85510,10 +85445,6 @@
 	icon_state = "dark-markings"
 	},
 /area/gateway)
-"mnf" = (
-/obj/item/stack/cable_coil/cut,
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/singularity_engine)
 "mng" = (
 /obj/machinery/gateway,
 /obj/structure/cable{
@@ -87540,14 +87471,6 @@
 	},
 /turf/simulated/floor,
 /area/derelict/solar_control)
-"mYi" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/hallway/primary)
 "mYl" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -89754,12 +89677,6 @@
 	},
 /turf/simulated/floor,
 /area/science/xenobiology/specimen_5)
-"nOg" = (
-/obj/item/weapon/shard{
-	icon_state = "medium"
-	},
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/singularity_engine)
 "nOC" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -94538,10 +94455,6 @@
 	},
 /turf/unsimulated/floor/snow,
 /area/surface/snow)
-"prv" = (
-/obj/item/stack/cable_coil/cut,
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/singularity_engine)
 "prD" = (
 /obj/machinery/door/window{
 	base_state = "right";
@@ -98013,12 +97926,6 @@
 	},
 /turf/simulated/floor,
 /area/supply/qm)
-"qGy" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/singularity_engine)
 "qGB" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -99656,9 +99563,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
-"rmm" = (
-/turf/simulated/floor/damaged/airless/broken,
-/area/surface/snow)
 "rms" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
@@ -106293,9 +106197,6 @@
 	icon_state = "cult"
 	},
 /area/library)
-"tHN" = (
-/turf/simulated/floor/damaged/airless/burnt,
-/area/derelict/hallway/primary)
 "tIm" = (
 /obj/structure/cult_legacy/tome,
 /obj/item/clothing/under/suit_jacket/red,
@@ -106538,12 +106439,6 @@
 	icon_state = "whitegreen"
 	},
 /area/centcom/evac)
-"tLM" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/singularity_engine)
 "tLN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
@@ -106793,10 +106688,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/derelict/hallway/secondary)
-"tQd" = (
-/obj/structure/window/reinforced,
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/singularity_engine)
 "tQp" = (
 /obj/machinery/status_display{
 	pixel_y = 32
@@ -107573,10 +107464,6 @@
 	},
 /turf/simulated/floor,
 /area/hallway/secondary/entry)
-"ufs" = (
-/obj/item/weapon/shard,
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/singularity_engine)
 "ufD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -110443,9 +110330,6 @@
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry)
-"vlR" = (
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/teleporter)
 "vlY" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -112396,9 +112280,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/storage/tools)
-"vWe" = (
-/turf/simulated/floor/damaged/airless/burnt,
-/area/surface/snow)
 "vWg" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -115154,9 +115035,6 @@
 	},
 /turf/simulated/floor,
 /area/hallway/primary/starboard)
-"wQI" = (
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/hallway/primary)
 "wQT" = (
 /obj/machinery/door/airlock{
 	name = "Stall 3"
@@ -117292,10 +117170,6 @@
 /obj/item/weapon/storage/fancy/donut_box,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain)
-"xFW" = (
-/obj/item/stack/cable_coil/cut,
-/turf/simulated/floor/damaged/airless/broken,
-/area/derelict/singularity_engine)
 "xGg" = (
 /turf/unsimulated/floor{
 	icon = 'icons/turf/snow.dmi';
@@ -117313,9 +117187,6 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
-"xGD" = (
-/turf/simulated/floor/plating/damaged/broken,
-/area/maintenance/aft)
 "xGH" = (
 /obj/structure/catwalk,
 /obj/structure/railing/glass{
@@ -241224,7 +241095,7 @@ jeu
 rgO
 ttx
 dZg
-xGD
+oKY
 wvq
 skq
 egY
@@ -272014,7 +271885,7 @@ bZp
 bZp
 bZp
 bZp
-cwT
+hoK
 eoA
 eoA
 eoA
@@ -272316,7 +272187,7 @@ bZp
 bZp
 bZp
 bZp
-bYy
+ecg
 eoA
 eoA
 eoA
@@ -320092,7 +319963,7 @@ dri
 daS
 daV
 dri
-dbE
+daU
 daV
 dri
 dvd
@@ -323411,7 +323282,7 @@ dvd
 dvd
 dvd
 dri
-daZ
+daP
 dbn
 dri
 dbH
@@ -323717,7 +323588,7 @@ dba
 daV
 dri
 daV
-dbE
+daU
 dri
 dvd
 dvd
@@ -324623,7 +324494,7 @@ daV
 daU
 dri
 dba
-dbM
+dbL
 dri
 dvd
 dvd
@@ -430299,7 +430170,7 @@ eEX
 eEX
 aCK
 ndb
-vlR
+vwc
 mQc
 feB
 mQc
@@ -430906,7 +430777,7 @@ ndb
 ylE
 mQc
 hdb
-vlR
+vwc
 ndb
 ylE
 xsN
@@ -439613,7 +439484,7 @@ kQy
 kQy
 kQy
 nER
-tHN
+ipB
 vew
 bZp
 eEX
@@ -439914,7 +439785,7 @@ kQy
 tQE
 wFz
 kQy
-tHN
+ipB
 bFu
 vew
 vew
@@ -440218,7 +440089,7 @@ nER
 kQy
 vew
 nER
-tHN
+ipB
 vew
 eEX
 eEX
@@ -440502,7 +440373,7 @@ eEX
 bZp
 bZp
 rDD
-lXt
+qLP
 qLP
 qLP
 cDU
@@ -440518,8 +440389,8 @@ iaQ
 nER
 wFz
 kQy
-tHN
-fEr
+ipB
+eHX
 nER
 vew
 vew
@@ -440794,8 +440665,8 @@ eEX
 dDB
 dDB
 rRt
-hXh
-kuo
+rRt
+rRt
 rRt
 fFC
 dDB
@@ -440805,8 +440676,8 @@ bZp
 iQq
 cAw
 cAw
-lXt
-lXt
+qLP
+qLP
 qLP
 vqG
 lHb
@@ -441095,11 +440966,11 @@ dDB
 dDB
 dDB
 dDB
-prv
+cSU
 wOc
 aZe
 aZe
-tLM
+aZe
 dDB
 dDB
 dDB
@@ -441109,7 +440980,7 @@ fJF
 cAw
 cAw
 cAw
-lXt
+qLP
 qLP
 cDU
 ssW
@@ -441397,7 +441268,7 @@ dDB
 dDB
 dDB
 dDB
-xFW
+cSU
 vkt
 uMp
 uMp
@@ -441695,18 +441566,18 @@ wUT
 sDr
 wdq
 rRt
-hXh
 rRt
 rRt
 rRt
 rRt
 rRt
-eNM
 rRt
-hXh
 rRt
-hXh
-kuo
+rRt
+rRt
+rRt
+rRt
+rRt
 wdq
 wdq
 lgF
@@ -441714,7 +441585,7 @@ eEX
 cAw
 cAw
 cAw
-lXt
+qLP
 qLP
 iBc
 gyY
@@ -441733,7 +441604,7 @@ ufH
 nER
 kQy
 eHX
-kOl
+eHX
 vew
 vew
 vew
@@ -441993,22 +441864,22 @@ orp
 eEX
 dDB
 dDB
-eci
+uHz
 sDr
 rRt
-eNM
-kuo
-hXh
 rRt
 rRt
 rRt
-eNM
-eNM
-kuo
-eNM
+rRt
+rRt
+rRt
+rRt
+rRt
+rRt
+rRt
 rRt
 gwG
-eNM
+rRt
 iCB
 yfG
 eEX
@@ -442017,8 +441888,8 @@ cAw
 cAw
 cAw
 cAw
-lXt
-lXt
+qLP
+qLP
 cDU
 jKx
 nER
@@ -442034,12 +441905,12 @@ wFz
 ufH
 nER
 kQy
-wQI
+eHX
 vew
-wQI
+eHX
 nER
 kQy
-wQI
+eHX
 vew
 vew
 fOI
@@ -442294,18 +442165,18 @@ orp
 rLW
 dDB
 dDB
-hXh
-tQd
+rRt
+uHz
 sDr
 rRt
-kuo
-hXh
+rRt
+rRt
 flX
 wZQ
 wZQ
 plQ
 rRt
-eNM
+rRt
 fou
 oLw
 wZQ
@@ -442320,7 +442191,7 @@ bZp
 bZp
 cAw
 cAw
-lXt
+qLP
 yhf
 kQy
 nER
@@ -442341,9 +442212,9 @@ nER
 vew
 nER
 kQy
-kOl
+eHX
 vew
-kOl
+eHX
 fOI
 jZM
 jZM
@@ -442596,18 +442467,18 @@ bZp
 eEX
 dDB
 dDB
-eNM
+rRt
 ron
 sDr
 rRt
-hXh
+rRt
 flX
-qGy
+xOr
 tcm
-qGy
+xOr
 xOr
 wdq
-kuo
+rRt
 pHV
 ycg
 wdq
@@ -442622,7 +442493,7 @@ eEX
 bZp
 jPs
 cAw
-lXt
+qLP
 yhf
 kQy
 nER
@@ -442638,13 +442509,13 @@ nER
 nER
 nER
 kQy
-fEr
+eHX
 nER
 nER
-kOl
+eHX
 kQy
 nER
-wQI
+eHX
 nER
 iDN
 jZM
@@ -442898,22 +442769,22 @@ bZp
 eEX
 dDB
 pEh
-kuo
-tQd
+rRt
+uHz
 ntX
 lDh
 lLe
 gyL
 rSV
-eNM
-eNM
+rRt
+rRt
 wdq
 wdq
 wdq
 wdq
 wdq
 wdq
-hXh
+rRt
 wdq
 oEU
 wdq
@@ -443201,10 +443072,10 @@ rLW
 dDB
 dDB
 lDN
-hXh
+rRt
 wdq
-eNM
-hXh
+rRt
+rRt
 wCd
 nDv
 wdq
@@ -443214,9 +443085,9 @@ wdq
 wdq
 wdq
 wdq
-hXh
-kuo
-hXh
+rRt
+rRt
+rRt
 kRo
 hbw
 rRt
@@ -443502,11 +443373,11 @@ aCK
 aCK
 aCK
 pOZ
-hXh
+rRt
 uHz
 dKy
-hXh
-kuo
+rRt
+rRt
 fou
 wdq
 wdq
@@ -443521,7 +443392,7 @@ wdq
 uuR
 uMp
 rRt
-hXh
+rRt
 rRt
 dDB
 dDB
@@ -443807,30 +443678,30 @@ dDB
 jko
 pQC
 dDB
-mnf
-hXh
-wdq
-wdq
-wdq
-wdq
-bZp
-bZp
-bZp
-bZp
-bZp
-wdq
-wdq
-hXh
+cSU
 rRt
-hXh
-eNM
+wdq
+wdq
+wdq
+wdq
+bZp
+bZp
+bZp
+bZp
+bZp
+wdq
+wdq
+rRt
+rRt
+rRt
+rRt
 fSX
 dDB
 uIN
 dDB
 yhf
 aCK
-lim
+sFv
 hoV
 kQy
 nER
@@ -444111,7 +443982,7 @@ wdq
 iCB
 rRt
 wdq
-ufs
+hbw
 wdq
 wdq
 wdq
@@ -444122,11 +443993,11 @@ bZp
 bZp
 wdq
 wdq
-eNM
 rRt
-hXh
-eNM
-kuo
+rRt
+rRt
+rRt
+rRt
 wdq
 wdq
 dDB
@@ -444423,19 +444294,19 @@ bZp
 bZp
 bZp
 wdq
-eNM
-kuo
+rRt
+rRt
 rRt
 iIz
-eNM
-hXh
+rRt
+rRt
 dDB
 wdq
 dDB
 mOs
 aCK
 aCK
-lim
+sFv
 kQy
 nER
 nER
@@ -444725,11 +444596,11 @@ bZp
 bZp
 bZp
 wdq
-hXh
-tQd
+rRt
+uHz
 ohS
 rRt
-hXh
+rRt
 rRt
 dDB
 dDB
@@ -444737,7 +444608,7 @@ dDB
 eEX
 aCK
 aCK
-rmm
+sFv
 kQy
 kQy
 kQy
@@ -445016,7 +444887,7 @@ wdq
 hoE
 wdq
 rRt
-hXh
+rRt
 kRo
 tsn
 wdq
@@ -445314,11 +445185,11 @@ eEX
 eEX
 dDB
 dDB
-hXh
-hXh
 rRt
-hXh
-hXh
+rRt
+rRt
+rRt
+rRt
 iUo
 tsn
 wdq
@@ -445330,9 +445201,9 @@ wdq
 wdq
 wdq
 wdq
-tQd
+uHz
 sDr
-hXh
+rRt
 rRt
 dDB
 dDB
@@ -445342,7 +445213,7 @@ eEX
 eEX
 mxI
 aCK
-rmm
+sFv
 kQy
 kQy
 pwe
@@ -445616,11 +445487,11 @@ bZp
 eEX
 dDB
 dDB
-kuo
-hXh
-kuo
-eNM
-hXh
+rRt
+rRt
+rRt
+rRt
+rRt
 vkt
 jAC
 lyF
@@ -445634,8 +445505,8 @@ wdq
 ezk
 uuR
 ntX
-eNM
-hXh
+rRt
+rRt
 dDB
 dDB
 eEX
@@ -445643,7 +445514,7 @@ bZp
 bZp
 eEX
 aCK
-rmm
+sFv
 gjD
 kQy
 kQy
@@ -445918,11 +445789,11 @@ orp
 rLW
 dDB
 dDB
-hXh
-hXh
 rRt
-eNM
-hXh
+rRt
+rRt
+rRt
+rRt
 rRt
 vkt
 uMp
@@ -445935,9 +445806,9 @@ fLj
 eJH
 eJH
 lXu
-hXh
-kuo
-eNM
+rRt
+rRt
+rRt
 dDB
 dDB
 eEX
@@ -446224,20 +446095,20 @@ dDB
 gWU
 rRt
 rRt
-kuo
-eNM
-hXh
 rRt
-wdq
-wdq
+rRt
 rRt
 rRt
 wdq
+wdq
 rRt
-eNM
-kuo
-eNM
-hXh
+rRt
+wdq
+rRt
+rRt
+rRt
+rRt
+rRt
 rRt
 dDB
 dDB
@@ -446526,19 +446397,19 @@ dDB
 ned
 wdq
 rRt
-hXh
-kuo
-eNM
+rRt
+rRt
+rRt
 cSU
 rRt
 rRt
-nOg
+gwG
 iIz
 rRt
 rRt
-eNM
 rRt
-eNM
+rRt
+rRt
 rRt
 rRt
 dDB
@@ -446549,8 +446420,8 @@ lyK
 bZp
 bZp
 gTj
-lim
-rmm
+sFv
+sFv
 kQy
 nER
 vzx
@@ -446833,10 +446704,10 @@ dDB
 dDB
 dDB
 dDB
-hXh
+rRt
 gRf
 oJg
-hXh
+rRt
 kRo
 dDB
 dDB
@@ -447136,8 +447007,8 @@ orp
 orp
 dDB
 rRt
-iYL
-iYL
+xOr
+xOr
 ycg
 xOr
 dDB
@@ -447438,9 +447309,9 @@ eEX
 orp
 dDB
 wdq
-hXh
-hXh
-kuo
+rRt
+rRt
+rRt
 rRt
 dDB
 dDB
@@ -447450,8 +447321,8 @@ bZp
 bZp
 vew
 vew
-kOl
-wQI
+eHX
+eHX
 kQy
 nER
 nER
@@ -447751,8 +447622,8 @@ ngv
 igU
 igU
 igU
-mYi
-mYi
+qNd
+qNd
 qNd
 qNd
 dQJ
@@ -448051,12 +447922,12 @@ eEX
 ngv
 frr
 vew
-kOl
-kOl
-wQI
-wQI
-wQI
-wQI
+eHX
+eHX
+eHX
+eHX
+eHX
+eHX
 nER
 nER
 nER
@@ -448351,12 +448222,12 @@ ngv
 igU
 igU
 frr
-kOl
-kOl
-wQI
-wQI
-wQI
-wQI
+eHX
+eHX
+eHX
+eHX
+eHX
+eHX
 nER
 kQy
 nER
@@ -448394,7 +448265,7 @@ aCK
 eEX
 aCK
 aCK
-lim
+sFv
 pNn
 bZp
 bZp
@@ -448695,7 +448566,7 @@ bZp
 aCK
 aCK
 aCK
-lim
+sFv
 prD
 pNn
 crH
@@ -448949,12 +448820,12 @@ cTr
 iWC
 toR
 xpw
-mYi
+qNd
 igU
 dXM
 kQy
-wQI
-wQI
+eHX
+eHX
 nER
 kQy
 nER
@@ -449251,8 +449122,8 @@ cTr
 nUJ
 cTr
 lLP
-wQI
-kOl
+eHX
+eHX
 ipB
 kQy
 vew
@@ -449260,16 +449131,16 @@ vew
 nER
 kQy
 ipB
-wQI
-wQI
+eHX
+eHX
 kQy
 ipB
 nER
 nER
-wQI
+eHX
 nER
 vzx
-wQI
+eHX
 nER
 nER
 ruS
@@ -449553,26 +449424,26 @@ cTr
 nUJ
 cTr
 rSc
-wQI
-wQI
-wQI
+eHX
+eHX
+eHX
 qTS
 vew
-wQI
+eHX
 nER
 nER
-wQI
+eHX
 vew
-wQI
+eHX
 kQy
-wQI
+eHX
 vew
 nER
 nER
 nER
 xpu
 nER
-wQI
+eHX
 nER
 mEK
 kQy
@@ -449860,8 +449731,8 @@ nER
 nER
 kQy
 kQy
-wQI
-wQI
+eHX
+eHX
 kQy
 ipB
 ipB
@@ -449874,9 +449745,9 @@ rug
 vew
 vzx
 nER
-wQI
+eHX
 nER
-wQI
+eHX
 kQy
 mKa
 jHL
@@ -450470,7 +450341,7 @@ kQy
 ipB
 eHX
 ruS
-lim
+sFv
 fJP
 fJP
 sFv
@@ -450774,7 +450645,7 @@ ipB
 ruS
 fJP
 sFv
-lzY
+sFv
 fJP
 ruS
 ruS
@@ -451074,7 +450945,7 @@ kQy
 eHX
 vew
 ruS
-lim
+sFv
 fJP
 bZp
 bZp
@@ -453489,7 +453360,7 @@ kef
 sVk
 cni
 uPK
-lzY
+sFv
 bZp
 bZp
 bZp
@@ -453791,7 +453662,7 @@ kef
 sVk
 sVk
 uPK
-rmm
+sFv
 bZp
 bZp
 bZp
@@ -454093,8 +453964,8 @@ kef
 cni
 rDV
 uPK
-lzY
-lzY
+sFv
+sFv
 bZp
 bZp
 bZp
@@ -454700,7 +454571,7 @@ uPK
 vQG
 sFv
 eEX
-lim
+sFv
 uPK
 aCK
 bZp
@@ -455294,7 +455165,7 @@ bZp
 bZp
 aCK
 aCK
-rmm
+sFv
 pNn
 uPK
 hfw
@@ -455898,8 +455769,8 @@ aCK
 aCK
 aCK
 aCK
-vWe
-rmm
+fJP
+sFv
 uPK
 fYn
 hfw
@@ -456201,7 +456072,7 @@ aCK
 pNn
 fJP
 pNn
-lim
+sFv
 uPK
 quw
 fYn
@@ -457105,7 +456976,7 @@ bZp
 aCK
 aCK
 aCK
-rmm
+sFv
 pNn
 pNn
 kef

--- a/maps/tgstation.dmm
+++ b/maps/tgstation.dmm
@@ -17014,8 +17014,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -48703,8 +48702,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/science/lab)
@@ -49579,8 +49577,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/medical/genetics)
@@ -52476,8 +52473,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/medical/genetics)
@@ -55933,8 +55929,7 @@
 "cbc" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -55942,8 +55937,7 @@
 "cbd" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -59544,8 +59538,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -66165,8 +66158,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -75689,8 +75681,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
@@ -75716,8 +75707,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -95468,8 +95458,7 @@
 "dVc" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{

--- a/maps/tgstation.dmm
+++ b/maps/tgstation.dmm
@@ -63695,14 +63695,6 @@
 	icon_state = "whitegreen"
 	},
 /area/science/hallway)
-"cpI" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
 "cpJ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -63710,17 +63702,6 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
-"cpK" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -268245,7 +268226,7 @@ clc
 bRM
 cno
 coG
-cpI
+cbc
 aaa
 aaj
 aaa
@@ -268747,7 +268728,7 @@ cld
 bRM
 cnp
 coG
-cpI
+cbc
 aaa
 aaj
 aaa
@@ -269249,7 +269230,7 @@ clh
 bRM
 bYs
 coG
-cpK
+cbd
 aaa
 aaj
 aaa
@@ -271768,7 +271749,7 @@ bYs
 cvr
 crE
 cwT
-cpI
+cbc
 aaa
 aaa
 aaa
@@ -272270,7 +272251,7 @@ cur
 bym
 cvX
 cwT
-cpI
+cbc
 aaa
 aaa
 aaa
@@ -272772,7 +272753,7 @@ cus
 cvq
 cvY
 cwT
-cpK
+cbd
 aaa
 aaa
 aaa

--- a/maps/waystation.dmm
+++ b/maps/waystation.dmm
@@ -7122,8 +7122,7 @@
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
@@ -15123,8 +15122,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
@@ -15597,8 +15595,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -17725,8 +17722,7 @@
 	},
 /obj/item/device/mmi/radio_enabled,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -20583,8 +20579,7 @@
 "eST" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -20610,8 +20605,7 @@
 "eTs" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/full/reinforced,
@@ -20757,8 +20751,7 @@
 "eVl" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/full/reinforced,
@@ -20770,8 +20763,7 @@
 "eVy" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -21018,8 +21010,7 @@
 "eWS" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -21030,8 +21021,7 @@
 "eXa" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/full/reinforced,
@@ -21046,8 +21036,7 @@
 "eXb" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -21118,8 +21107,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
@@ -23365,8 +23353,7 @@
 "fzw" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/full/reinforced,
@@ -24405,8 +24392,7 @@
 "fMa" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -24840,8 +24826,7 @@
 "fSe" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -25464,8 +25449,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -36727,8 +36711,7 @@
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -39787,8 +39770,7 @@
 "jFx" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -40301,8 +40283,7 @@
 "jLX" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -48541,8 +48522,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint{
@@ -55163,8 +55143,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -56524,8 +56503,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/full/reinforced,
 /turf/unsimulated/floor{
@@ -56833,8 +56811,7 @@
 	},
 /obj/structure/window/full/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/centcom/evac)
@@ -58433,8 +58410,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -64339,8 +64315,7 @@
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -64870,8 +64845,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
@@ -68850,8 +68824,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint{
@@ -74309,8 +74282,7 @@
 	},
 /obj/structure/window/full/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/medical/genetics)
@@ -75005,8 +74977,7 @@
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{

--- a/maps/xoq.dmm
+++ b/maps/xoq.dmm
@@ -63098,25 +63098,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
-"cpM" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
-"cpN" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
 "cpO" = (
 /obj/structure/table,
 /obj/item/device/deskbell_assembly,
@@ -84300,10 +84281,6 @@
 /obj/structure/shuttle/engine/propulsion/right,
 /turf/space,
 /area/shuttle/supply)
-"dfF" = (
-/obj/structure/bed,
-/turf/unsimulated/floor/scorched,
-/area/prison/solitary)
 "dfG" = (
 /obj/effect/decal/cleanable/cobweb2,
 /turf/unsimulated/floor/broken{
@@ -84324,11 +84301,6 @@
 "dfJ" = (
 /obj/effect/decal/cleanable/blood,
 /turf/unsimulated/wall,
-/area/prison/solitary)
-"dfK" = (
-/turf/unsimulated/floor/broken{
-	icon_state = "plating"
-	},
 /area/prison/solitary)
 "dfL" = (
 /turf/unsimulated/floor{
@@ -84593,9 +84565,6 @@
 /turf/simulated/floor/shuttle,
 /area/shuttle/supply)
 "dgB" = (
-/turf/unsimulated/floor/scorched,
-/area/prison/solitary)
-"dgC" = (
 /turf/unsimulated/floor/scorched,
 /area/prison/solitary)
 "dgD" = (
@@ -209804,7 +209773,7 @@ aaa
 aaa
 aaa
 aaa
-cpN
+bWH
 cxo
 cww
 cvB
@@ -210306,7 +210275,7 @@ aaa
 aaa
 aaa
 aaa
-cpM
+bFQ
 cxo
 cwv
 bvn
@@ -210808,7 +210777,7 @@ aaa
 aaa
 aaa
 aaa
-cpM
+bFQ
 cxo
 crR
 cvA
@@ -213327,7 +213296,7 @@ aaa
 aaa
 aah
 aaa
-cpN
+bWH
 eLR
 bRw
 bPf
@@ -213829,7 +213798,7 @@ aaa
 aaa
 aah
 aaa
-cpM
+bFQ
 eLR
 cnd
 bPf
@@ -214331,7 +214300,7 @@ aaa
 aaa
 aah
 aaa
-cpM
+bFQ
 eLR
 cnc
 bPf
@@ -402229,7 +402198,7 @@ aaa
 aaa
 aaa
 dfy
-dfF
+dfN
 dfX
 dfy
 dgh
@@ -405743,11 +405712,11 @@ aaa
 aaa
 aaa
 dfy
-dfK
+dgi
 dfY
 dfy
 dfY
-dfK
+dgi
 dfy
 aaa
 dhM
@@ -407252,7 +407221,7 @@ dfy
 dfL
 dfO
 dfy
-dfK
+dgi
 dfL
 dfy
 aaa
@@ -408758,7 +408727,7 @@ dfy
 dfM
 dfI
 dfy
-dfK
+dgi
 dfL
 dfy
 aaa
@@ -411768,10 +411737,10 @@ aaa
 aaa
 dfy
 dfL
-dfK
+dgi
 dfy
 dfO
-dgC
+dgB
 dfy
 aaa
 aaa

--- a/maps/xoq.dmm
+++ b/maps/xoq.dmm
@@ -18023,9 +18023,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	pixel_y = -1
-	},
+/obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "aGf" = (
@@ -43781,9 +43779,7 @@
 /area/science/lab)
 "bFQ" = (
 /obj/structure/grille,
-/obj/structure/window/reinforced{
-	pixel_y = -1
-	},
+/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -46639,9 +46635,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	pixel_y = -1
-	},
+/obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/medical/genetics)
 "bLq" = (
@@ -46772,9 +46766,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	pixel_y = -1
-	},
+/obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/science/lab)
 "bLE" = (
@@ -50677,9 +50669,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	pixel_y = -1
-	},
+/obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/medical/genetics)
 "bSr" = (
@@ -50815,9 +50805,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	pixel_y = -1
-	},
+/obj/structure/window/reinforced,
 /obj/structure/window/full/reinforced,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -52870,9 +52858,7 @@
 /turf/simulated/floor/server,
 /area/tcomms/chamber)
 "bWB" = (
-/obj/structure/window/reinforced{
-	pixel_y = -1
-	},
+/obj/structure/window/reinforced,
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -52929,9 +52915,7 @@
 /area/hallway/secondary/entry)
 "bWH" = (
 /obj/structure/grille,
-/obj/structure/window/reinforced{
-	pixel_y = -1
-	},
+/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -61561,9 +61545,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	pixel_y = -1
-	},
+/obj/structure/window/reinforced,
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -65754,9 +65736,7 @@
 /area/science/xenobiology)
 "cuK" = (
 /obj/structure/grille,
-/obj/structure/window/reinforced{
-	pixel_y = -1
-	},
+/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 8;
 	one_way = 1
@@ -112956,9 +112936,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	pixel_y = -1
-	},
+/obj/structure/window/reinforced,
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
 /area/science/xenobiology/specimen_6)
@@ -114452,9 +114430,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	pixel_y = -1
-	},
+/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
 	},


### PR DESCRIPTION
[general]

## What this does
Checks another thing off of #33930.

## How it was tested
Checking each map in StrongDMM.

## Changelog
:cl:
 * tweak: Reinforced windows on all maps no longer have odd pixel offsets.