### PR TITLE
fixes a couple things on jungle

### DIFF
--- a/code/game/objects/items/vouchers.dm
+++ b/code/game/objects/items/vouchers.dm
@@ -47,7 +47,7 @@
 
 /obj/item/voucher/warp/kinetic_accelerator/vouch_condition()
 	var/turf/T = get_turf(src)
-	if(istype(T.loc, /area/mine/explored)||istype(T.loc, /area/mine/unexplored)||istype(T.loc, /area/surface/mine))
+	if(istype(T.loc, /area/mine/explored)||istype(T.loc, /area/mine/unexplored)||istype(T.loc, /area/surface/mine) || istype(T.loc,/area/surface/jungle/mining))
 		return TRUE
 	return FALSE
 

--- a/code/game/objects/structures/flora/flora.dm
+++ b/code/game/objects/structures/flora/flora.dm
@@ -702,6 +702,8 @@
 	desc = "I eated the purple berries."
 	icon = 'icons/obj/hydroponics/berry.dmi'
 	icon_state="stage-6"
+	anchored=TRUE
+	shovelaway=TRUE
 	var/hasberries=FALSE
 	var/tickssincelastgrowth=0
 

--- a/maps/junglestation.dmm
+++ b/maps/junglestation.dmm
@@ -34316,6 +34316,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -48703,9 +48704,6 @@
 	pixel_x = 3;
 	pixel_y = 4
 	},
-/obj/item/weapon/reagent_containers/food/condiment/sugar{
-	pixel_x = -8
-	},
 /turf/unsimulated/floor/planetary/path/jungle_plated,
 /area/crew_quarters/kitchen)
 "rTj" = (
@@ -50832,9 +50830,6 @@
 /obj/structure/table,
 /obj/item/weapon/kitchen/rollingpin{
 	pixel_y = 5
-	},
-/obj/item/weapon/reagent_containers/food/drinks/flour{
-	pixel_x = 3
 	},
 /turf/unsimulated/floor/planetary/path/jungle_plated,
 /area/crew_quarters/kitchen)

--- a/maps/junglestation.dmm
+++ b/maps/junglestation.dmm
@@ -48703,6 +48703,9 @@
 	pixel_x = 3;
 	pixel_y = 4
 	},
+/obj/item/weapon/reagent_containers/food/condiment/sugar{
+	pixel_x = -8
+	},
 /turf/unsimulated/floor/planetary/path/jungle_plated,
 /area/crew_quarters/kitchen)
 "rTj" = (
@@ -50827,7 +50830,12 @@
 /area/science/hallway)
 "sIe" = (
 /obj/structure/table,
-/obj/item/weapon/kitchen/rollingpin,
+/obj/item/weapon/kitchen/rollingpin{
+	pixel_y = 5
+	},
+/obj/item/weapon/reagent_containers/food/drinks/flour{
+	pixel_x = 3
+	},
 /turf/unsimulated/floor/planetary/path/jungle_plated,
 /area/crew_quarters/kitchen)
 "sIE" = (


### PR DESCRIPTION
[bugfix] [hotfix] [itsloose]

## What this does
makes it so that jungle berry bushes are anchored, and can be removed with a shovel like other foliage
adds a flour sack and sugar bottle to kitchen at roundstart
closes #39065

## Why it's good
allows chefs to chef better
fixes a bug

## How it was tested
i didn't but these are very simple changes so they should be fine, right?

## Changelog
:cl:
 * rscadd: flour and sugar has been added to jungle's kitchen
 * bugfix: Jungle berry bushes can no longer be dragged
 * bugfix: PKA vouchers work on the jungle roid now.