### PR TITLE
Fixes wall thermite overlay issues

### DIFF
--- a/code/game/smoothwall.dm
+++ b/code/game/smoothwall.dm
@@ -88,6 +88,10 @@
 	. = ..()
 	if(uses_overlays)
 		overlays.len = 0
+		if(thermite) //hotfix for this going away
+			var/image/thermover = image('icons/effects/effects.dmi', icon_state = "thermite")
+			thermover.plane = TURF_OVERLAY_PLANE
+			overlays += thermover
 		icon_state = walltype
 		if(uses_overlays >= RWALL_OVERLAY)
 			if(!src:d_state) //these lil ridges only show up when not building

--- a/code/modules/reagents/reagents/reagents_tools.dm
+++ b/code/modules/reagents/reagents/reagents_tools.dm
@@ -504,8 +504,10 @@
 
 	if(volume >= 5 && T.can_thermite)
 		T.thermite = 1
-		T.overlays.len = 0
-		T.overlays = image('icons/effects/effects.dmi', icon_state = "thermite")
+		var/image/thermover = image('icons/effects/effects.dmi', icon_state = "thermite")
+		thermover.plane = TURF_OVERLAY_PLANE
+		thermover.layer = TURF_LAYER + 1 //shows over it
+		T.overlays += thermover
 
 /datum/reagent/thermite/on_mob_life(var/mob/living/M)
 	if(..())


### PR DESCRIPTION
[bugfix][hotfix][sprites]

## What this does
Closes #39072.

## How it was tested
Thermiting a wall, calling relativewall() on it, setting it alight.

## Changelog
:cl:
 * bugfix: Thermited walls now have their proper sprite again.