### PR TITLE
24 bugfixes

### DIFF
--- a/code/datums/gamemode/objectives/target/syndicate/skulls.dm
+++ b/code/datums/gamemode/objectives/target/syndicate/skulls.dm
@@ -37,6 +37,8 @@
 		if(!H.organ_data)
 			continue
 		var/mob/living/carbon/brain/B = H.brainmob
+		if(!B)
+			continue
 		if(!B.client)
 			if(!B.mind)
 				continue

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -764,11 +764,14 @@ var/list/discounted_items_of_the_round = list()
 				continue
 			if(I.get_cost(U.job, U.species, 0.5) > U.telecrystals)
 				continue
+			if(I.num_in_stock && I.times_bought >= I.num_in_stock)
+				continue
 			possible_items += I
 
 	if(possible_items.len)
 		var/datum/uplink_item/I = pick(possible_items)
 		U.telecrystals -= max(0, I.get_cost(U.job, U.species, 0.5))
+		I.times_bought += 1
 		feedback_add_details("traitor_uplink_items_bought","RN")
 		return I
 

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -744,7 +744,7 @@ var/datum/controller/gameticker/ticker
 	create_random_orders(3) //Populate the order system so cargo has something to do
 	if(istype(mode, /datum/gamemode/dynamic))
 		var/datum/gamemode/dynamic/D = mode
-		if(D.living_players.len < 6) // Fill all the SMES to capacity if there's 5 or less players, to give players more time to set up the power.
+		if(D.roundstart_pop_ready < 6) // Fill all the SMES to capacity if there's 5 or less players, to give players more time to set up the power.
 			for(var/obj/machinery/power/battery/smes/S in power_machines)
 				if(S.charge) //Only do this if the SMES has any charge in the first place
 					S.charge = S.capacity

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -895,6 +895,8 @@
 	if(..())
 		return TRUE
 	if(href_list["cook"])
+		if(stat & (NOPOWER|BROKEN|FORCEDISABLE))
+			return
 		if(on)
 			to_chat(usr, "<span class='danger'>\The [src] is already turned on!</span>")
 			return
@@ -924,6 +926,8 @@
 
 /obj/machinery/sleeper/mancrowave/process()
 	..()
+	if(stat & (NOPOWER|BROKEN|FORCEDISABLE))
+		return
 	if(automatic && occupant && !on)
 		cook("Thermoregulate")
 	if(!istype(occupant,/mob/living/carbon))

--- a/code/game/machinery/computer/gas_extraction.dm
+++ b/code/game/machinery/computer/gas_extraction.dm
@@ -48,7 +48,7 @@
 	if(!anchored)
 		to_chat(user, "<span class='warning'>\The [src] must be anchored to function.</span>")
 		return
-	if(!Adjacent(user))
+	if(!isAI(user) && !Adjacent(user))
 		to_chat(user, "<span class='warning'>You're too far away.</span>")
 		return
 	tgui_interact(user)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1293,7 +1293,7 @@ About the new airlock wires panel:
 	if (iswelder(I))
 		if (density && !operating)
 			var/obj/item/tool/weldingtool/WT = I
-			if (WT.remove_fuel(0, user))
+			if (WT.remove_fuel(1, user))
 				if (!welded)
 					welded = 1
 				else

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -308,7 +308,7 @@ var/global/list/alert_overlays_global = list()
 
 	if(iswelder(C))
 		var/obj/item/tool/weldingtool/W = C
-		if(W.remove_fuel(0, user))
+		if(W.remove_fuel(1, user))
 			blocked = !blocked
 			user.visible_message("<span class='attack'>\The [user] [blocked ? "welds" : "unwelds"] \the [src] with \a [W].</span>",\
 			"You [blocked ? "weld" : "unweld"] \the [src] with \the [W].",\

--- a/code/game/machinery/landline.dm
+++ b/code/game/machinery/landline.dm
@@ -257,6 +257,7 @@
 	attached_to.overlays.Add(phone_overlay)
 
 /obj/landline/red
+	name = "red phone"
 	overlay_icon = 'icons/obj/items.dmi'
 	overlay_iconstate = "red_phone_handset"
 

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -894,13 +894,14 @@ a {
 	if(component_parts)
 		if(panel_open || W.bluespace)
 			var/obj/item/weapon/circuitboard/CB = locate(/obj/item/weapon/circuitboard) in component_parts
+			var/list/sorted_parts = sortTim(W.contents.Copy(), /proc/cmp_rped_sort)
 			var/P
 			for(var/obj/item/A in component_parts)
 				for(var/D in CB.req_components)
 					if(ispath(A.type, D))
 						P = D
 						break
-				for(var/obj/item/B in W.contents)
+				for(var/obj/item/B in sorted_parts)
 					if(istype(B, P) && istype(A, P))
 						if(B.get_rating() > A.get_rating())
 							W.remove_from_storage(B, src)
@@ -908,6 +909,7 @@ a {
 							remove_part(A)
 							add_part(B)
 							B.forceMove(null)
+							sorted_parts -= B
 							to_chat(user, "<span class='notice'>[A.name] replaced with [B.name].</span>")
 							shouldplaysound = 1 //Only play the sound when parts are actually replaced!
 							break

--- a/code/game/objects/items/beacon.dm
+++ b/code/game/objects/items/beacon.dm
@@ -116,6 +116,6 @@ var/global/list/emergency_beacons = list()
 	name = "Tracking Bacon"
 	desc = "A bacon used by a teleporter."
 
-/obj/item/beacon/bacon/New()
-	..()
+/obj/item/beacon/bacon/Destroy()
 	verbs -= /obj/item/beacon/verb/alter_signal
+	..()

--- a/code/game/objects/items/beacon.dm
+++ b/code/game/objects/items/beacon.dm
@@ -115,3 +115,7 @@ var/global/list/emergency_beacons = list()
 /obj/item/beacon/bacon //shouldn't be visible unless manually spawned by an admeme
 	name = "Tracking Bacon"
 	desc = "A bacon used by a teleporter."
+
+/obj/item/beacon/bacon/New()
+	..()
+	verbs -= /obj/item/beacon/verb/alter_signal

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -105,7 +105,7 @@
 	if(!proximity)
 		return
 	..()
-	if(A && wielded && (istype(A,/obj/structure/window))) //destroys windows and grilles in one hit
+	if(A && wielded && istype(A,/obj/structure/window) && !istype(A,/obj/structure/window/barricade)) //destroys windows and grilles in one hit
 		user.delayNextAttack(8)
 		if(istype(A,/obj/structure/window))
 			var/pdiff=performWallPressureCheck(A.loc)

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -172,7 +172,7 @@
 	if (iswelder(W) && ( (istext(glass)) || (glass == 1) || (!anchored) ))
 		var/obj/item/tool/weldingtool/WT = W
 
-		if (WT.remove_fuel(0, user))
+		if (WT.remove_fuel(1, user))
 			busy = TRUE
 			playsound(src, 'sound/items/Welder2.ogg', 50, 1)
 

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -315,6 +315,12 @@ BLIND     // can't see anything
 	nearsighted_modifier = 5
 	species_fit = list(VOX_SHAPED, GREY_SHAPED, INSECT_SHAPED)
 
+/obj/item/clothing/glasses/welding/equipped(mob/M, slot)
+	if(slot == slot_glasses && up)
+		nearsighted_modifier = 0
+		eyeprot = 0
+	..()
+
 /obj/item/clothing/glasses/welding/attack_self()
 	toggle()
 

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -274,7 +274,7 @@
 	toolspeed = 0.3
 	origin_tech = Tc_MATERIALS + "=2;" + Tc_POWERSTORAGE + "=3;" + Tc_ENGINEERING + "=2"
 	desc = "Yours is the drill that will pierce through the rock walls."
-	starting_materials = list(MAT_IRON = CC_PER_SHEET_METAL * 4)
+	starting_materials = list(MAT_IRON = 6000, MAT_GLASS = 1000)
 	drill_verb = "drilling"
 	hitsound = 'sound/weapons/circsawhit.ogg'
 	diggables = DIG_ROCKS | DIG_SOIL //drills are multipurpose

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -274,6 +274,7 @@
 	toolspeed = 0.3
 	origin_tech = Tc_MATERIALS + "=2;" + Tc_POWERSTORAGE + "=3;" + Tc_ENGINEERING + "=2"
 	desc = "Yours is the drill that will pierce through the rock walls."
+	starting_materials = list(MAT_IRON = CC_PER_SHEET_METAL * 4)
 	drill_verb = "drilling"
 	hitsound = 'sound/weapons/circsawhit.ogg'
 	diggables = DIG_ROCKS | DIG_SOIL //drills are multipurpose

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -8,8 +8,10 @@
 
 	var/datum/emote/E
 	E = E.emote_list[lowertext(act)]
-	if(!E || !E.run_emote(src, param, m_type, ignore_status, arguments))
+	if(!E)
 		to_chat(src, "<span class='notice'>Unusable emote '[act]'. Say *help for a list.</span>")
+	else
+		E.run_emote(src, param, m_type, ignore_status, arguments)
 
 /datum/emote/flip
 	key = "flip"

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -372,6 +372,10 @@ emp_act
 	if(shoes && istype(shoes, /obj/item/clothing/shoes))
 		var/obj/item/clothing/shoes/S = shoes
 		damage = S.impact_dampen(source, damage)
+		if(damage && istype(S, /obj/item/clothing/shoes/magboots))
+			var/obj/item/clothing/shoes/magboots/MB = S
+			if(MB.stored_shoes)
+				damage = MB.stored_shoes.impact_dampen(source, damage)
 	if(!damage)
 		return FALSE
 	if(!ourfoot)

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -5,7 +5,7 @@
 	var/hangman_phrase = ""
 
 /mob/living/carbon/human/say(var/message)
-	if(species && (species.flags & SPECIES_NO_MOUTH) && !get_message_mode(message) && !findtext(message, "*", 1, 2))
+	if(species && (species.flags & SPECIES_NO_MOUTH) && !get_message_mode(message) && !findtext(message, "*", 1, 2) && stat != DEAD)
 		species.silent_speech(src,message)
 	else
 		..()

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -249,7 +249,7 @@ var/global/list/damage_icon_parts = list()
 			else
 				stand_icon.Blend(rgb(-my_appearance.s_tone, -my_appearance.s_tone, -my_appearance.s_tone), ICON_SUBTRACT)
 
-	if(husk)
+	if(husk && has_head)
 		var/icon/mask = new(stand_icon)
 		var/icon/husk_over = new(race_icon,"overlay_husk")
 		mask.MapColors(0,0,0,1, 0,0,0,1, 0,0,0,1, 0,0,0,1, 0,0,0,0)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -414,7 +414,7 @@
 			TryToShoot(target_turf, ttarget)
 			sleep(1)
 			TryToShoot(target_turf, ttarget)
-	if(doubleshot)
+	else if(doubleshot)
 		spawn()
 			TryToShoot(target_turf, ttarget)
 			sleep(1)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -391,21 +391,21 @@
 			update_overlay |= APC_UPOVERLAY_EQUIPMENT0
 		else if(equipment == 1)
 			update_overlay |= APC_UPOVERLAY_EQUIPMENT1
-		else if(equipment == 2)
+		else if(equipment >= 2)
 			update_overlay |= APC_UPOVERLAY_EQUIPMENT2
 
 		if(!lighting)
 			update_overlay |= APC_UPOVERLAY_LIGHTING0
 		else if(lighting == 1)
 			update_overlay |= APC_UPOVERLAY_LIGHTING1
-		else if(lighting == 2)
+		else if(lighting >= 2)
 			update_overlay |= APC_UPOVERLAY_LIGHTING2
 
 		if(!environ)
 			update_overlay |= APC_UPOVERLAY_ENVIRON0
 		else if(environ==1)
 			update_overlay |= APC_UPOVERLAY_ENVIRON1
-		else if(environ==2)
+		else if(environ>=2)
 			update_overlay |= APC_UPOVERLAY_ENVIRON2
 
 		if(pulselock)

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -373,7 +373,7 @@
 		charger.icon_state = "recharger2"
 		return
 
-	icon_state = "recharger1"
+	charger.icon_state = "recharger1"
 
 	var/charged_amount = 0
 	for(var/datum/lawgiver_mode/mode in ammo_counters)

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -2217,13 +2217,11 @@
 		update_icon()
 		return 1
 	else if(I.is_hot())
-		if(molotov == 1)
-			light(user,I)
-			update_brightness(user)
-			return
-		attempt_heating(I, user)
 		light(user,I)
 		update_brightness(user)
+		if(molotov == 1)
+			return
+		attempt_heating(I, user)
 	else if(istype(I, /obj/item/device/assembly/igniter))
 		var/obj/item/device/assembly/igniter/C = I
 		C.activate()

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -2217,6 +2217,10 @@
 		update_icon()
 		return 1
 	else if(I.is_hot())
+		if(molotov == 1)
+			light(user,I)
+			update_brightness(user)
+			return
 		attempt_heating(I, user)
 		light(user,I)
 		update_brightness(user)

--- a/code/modules/reagents/reagents/reagents_ethanol.dm
+++ b/code/modules/reagents/reagents/reagents_ethanol.dm
@@ -1067,6 +1067,10 @@
 	description = "Whoah, this stuff looks volatile!"
 	reagent_state = REAGENT_STATE_LIQUID
 	color = "#664300" //rgb: 102, 67, 0
+	dizzy_adj = 12
+	slurr_adj = 8
+	slur_start = 25
+	blur_start = 60
 	glass_icon_state = "gargleblasterglass"
 	glass_name = "\improper Pan-Galactic Gargle Blaster"
 	glass_desc = "Does... does this mean that Arthur and Ford are on the station? Oh joy."

--- a/code/modules/reagents/reagents/reagents_medical.dm
+++ b/code/modules/reagents/reagents/reagents_medical.dm
@@ -1149,6 +1149,7 @@ var/global/list/charcoal_doesnt_remove=list(
 			if (E.status & ORGAN_BROKEN)
 				E.status &= ~ORGAN_BROKEN //What do I owe you?
 				E.status &= ~ORGAN_SPLINTED //Nothing, it's for free!
+				E.brute_dam = min(E.brute_dam, E.min_broken_damage) //Heal enough to prevent immediate re-fracture
 				holder.remove_reagent(MEDNANOBOTS, 0.10)
 			if (E.status & ORGAN_BLEEDING)
 				E.status &= ~ORGAN_BLEEDING //FOR FREE?!

--- a/code/modules/research/xenoarchaeology/tools/bunsen_burner.dm
+++ b/code/modules/research/xenoarchaeology/tools/bunsen_burner.dm
@@ -312,6 +312,7 @@
 		if(BUNSEN_OPEN)
 			heating = BUNSEN_OFF
 			to_chat(user, "<span class = 'warning'>You close the fuel port on \the [src].</span>")
+	update_icon()
 
 
 /obj/machinery/bunsen_burner/mapped //for the sci break room

--- a/code/modules/trader/trade_gear.dm
+++ b/code/modules/trader/trade_gear.dm
@@ -25,7 +25,7 @@
 	var/spine_color = "#ff0"
 	var/spine_overlay = "#000"
 	var/mob/living/owner
-	var/owner_ckey
+	var/datum/mind/owner_mind
 	var/owner_name
 	var/datum/language/tongue
 	var/progress = 0
@@ -44,7 +44,7 @@
 	tongue = all_languages[LANGUAGE_VOX]
 
 /obj/item/dictionary/Destroy()
-	owner_ckey = null
+	owner_mind = null
 	tongue = null
 	..()
 
@@ -57,10 +57,12 @@
 	if(tongue in user.languages)
 		to_chat(user,"<span class='danger'>You already know this language!</span>")
 		return
-	if(!owner_ckey)
-		owner_ckey = user.ckey
+	if(!owner_mind)
+		if(!user.mind) //impacts many of our players smdh
+			return
+		owner_mind = user.mind
 		owner_name = user.name
-	if(owner_ckey != user.ckey)
+	if(owner_mind != user.mind)
 		to_chat(user,"<span class='danger'>This nanodictionary is already partially used up. Useless. You need the fundamentals.</span>")
 		return
 	busy = TRUE

--- a/code/modules/trader/trade_gear.dm
+++ b/code/modules/trader/trade_gear.dm
@@ -25,6 +25,8 @@
 	var/spine_color = "#ff0"
 	var/spine_overlay = "#000"
 	var/mob/living/owner
+	var/owner_ckey
+	var/owner_name
 	var/datum/language/tongue
 	var/progress = 0
 	var/progress_goal = 6 //How many times do you need to progress to master the language?
@@ -42,7 +44,7 @@
 	tongue = all_languages[LANGUAGE_VOX]
 
 /obj/item/dictionary/Destroy()
-	master = null
+	owner_ckey = null
 	tongue = null
 	..()
 
@@ -55,9 +57,10 @@
 	if(tongue in user.languages)
 		to_chat(user,"<span class='danger'>You already know this language!</span>")
 		return
-	if(!master)
-		master = user
-	if(master != user)
+	if(!owner_ckey)
+		owner_ckey = user.ckey
+		owner_name = user.name
+	if(owner_ckey != user.ckey)
 		to_chat(user,"<span class='danger'>This nanodictionary is already partially used up. Useless. You need the fundamentals.</span>")
 		return
 	busy = TRUE
@@ -98,7 +101,7 @@
 			say(phrase, tongue)
 
 /obj/item/dictionary/GetVoice()
-	return master
+	return owner_name
 
 //Talonifier
 /obj/item/talonprosthetic


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
24 bugfixes:

Fixes welding doors/assemblies not consuming fuel (Closes #38217)
- code/game/machinery/doors/airlock.dm: Changed remove_fuel(0, user) to remove_fuel(1, user)
- code/game/machinery/doors/firedoor.dm: Changed remove_fuel(0, user) to remove_fuel(1, user)
- code/game/objects/structures/door_assembly.dm: Changed remove_fuel(0, user) to remove_fuel(1, user)

Fixes infinite megaphones via random uplink item (Closes #38558)
- code/datums/uplink_item.dm: Added num_in_stock/times_bought check to random item selection

Fixes RPED prioritizing T3 parts over T4 (Closes #38437)
- code/game/machinery/machinery.dm: Sort RPED contents by rating before exchange loop

Fixes fireaxe on wooden barricade spawning glass shards (Closes #38410)
- code/game/objects/items/weapons/twohanded.dm: Exclude barricades from fireaxe window-shatter afterattack

Fixes mancrowave working without power (Closes #38423)
- code/game/machinery/Sleeper.dm: Added NOPOWER/BROKEN/FORCEDISABLE check in mancrowave process() and Topic()

Fixes mednanos causing screaming every tick (Closes #38754)
- code/modules/reagents/reagents/reagents_medical.dm: Heal brute_dam to fracture threshold when fixing broken bone

Fixes Pan-Galactic Gargle Blaster not causing drunk vision (Closes #38783)
- code/modules/reagents/reagents/reagents_ethanol.dm: Added proper dizzy_adj, slurr_adj, slur_start, blur_start values

Fixes SPECIES_NO_MOUTH blocking deadchat (Closes #38838)
- code/modules/mob/living/carbon/human/say.dm: Added stat != DEAD check to bypass no-mouth filter for dead mobs

Fixes autolathe unable to recycle mining drill (Closes #38952)
- code/modules/mining/mine_items.dm: Added iron-only starting_materials to drill (was inheriting wood from pickaxe parent)

Fixes APC lights not updating after EMP expires (Closes #38397)
- code/modules/power/apc.dm: Changed == 2 to >= 2 in overlay checks so value 3 (AUTO_ON) is handled

Fixes bunsen burner becoming invisible when toggling fuelport (Closes #38445)
- code/modules/research/xenoarchaeology/tools/bunsen_burner.dm: Added update_icon() call to toggle_fuelport()

Fixes magboots over RD shoes negating toe stubbing protection (Closes #38213)
- code/modules/mob/living/carbon/human/human_defense.dm: Check stored_shoes inside magboots in foot_impact()

Fixes welding goggles dimming vision when re-equipped while pushed up (Closes #38983)
- code/modules/clothing/glasses/glasses.dm: Added equipped() override to sync nearsighted_modifier/eyeprot with up state

Fixes "Alter Beacon's Signal" verb appearing after eating tracking bacon (Closes #38224)
- code/game/objects/items/beacon.dm: Strip alter_signal verb from bacon beacon subtype in New()

Fixes ranged syndicate simplemobs shooting extra times (Closes #38771)
- code/modules/mob/living/simple_animal/hostile/hostile.dm: Changed if(doubleshot) to else if(doubleshot) to prevent rapid mobs from also firing the else branch

Fixes headless husked bodies showing head overlay (Closes #38210)
- code/modules/mob/living/carbon/human/update_icons.dm: Added has_head check to husk overlay application

Fixes decapitated heads in trophy belt not counting for objectives (Closes #38351)
- code/datums/gamemode/objectives/target/syndicate/skulls.dm: Added null check for brainmob before accessing .client

Fixes SMES units starting at max charge regardless of player count (Closes #38686)
- code/game/gamemodes/gameticker.dm: Changed D.living_players.len to D.roundstart_pop_ready (living_players is empty at roundstart)

Fixes AIs unable to interface with gas extractor control console (Closes #38812)
- code/game/machinery/computer/gas_extraction.dm: Added isAI() exemption to adjacency check

Fixes molotov cocktail warming instead of lighting when set on fire (Closes #38322)
- code/modules/reagents/reagent_containers/food/drinks.dm: Skip attempt_heating() for molotovs, go straight to light()

Fixes Tajaran automatic gasping outputting two error messages (Closes #38460)
- code/modules/mob/emote.dm: Only show "Unusable emote" when emote datum is not found, not when it's found but can't run

Fixes lawgiver mag charger corrupting magazine sprite (Closes #38305)
- code/modules/projectiles/ammunition/magazines.dm: Changed icon_state = to charger.icon_state =

Fixes red telephone displaying as "The red" instead of "The red phone" (Closes #38455)
- code/game/machinery/landline.dm: Added name = "red phone" to /obj/landline/red

Fixes nanodictionaries not working after cloning (Closes #38339)
- code/modules/trader/trade_gear.dm: Track owner by ckey instead of mob reference

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Bugs bad

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Tested fixes which weren't blatantly obvious such as the MANCROWAVE, beacon, husking, and welding goggle fixes. The rest are untested but straightforward.

No CL