### PR TITLE
adds trader bells to most of the maps

### DIFF
--- a/maps/Dorfstation.dmm
+++ b/maps/Dorfstation.dmm
@@ -2076,6 +2076,11 @@
 	name = "Tradeship Windoor";
 	req_one_access_txt = "140"
 	},
+/obj/item/device/deskbell/signaler/trader{
+	pixel_y = 11;
+	pixel_x = 5;
+	name = "Trade Ship Counter Bell"
+	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor3"
 	},

--- a/maps/RoidStation.dmm
+++ b/maps/RoidStation.dmm
@@ -4870,6 +4870,11 @@
 	req_one_access_txt = "140"
 	},
 /obj/abstract/map/spawner/assistant/materials,
+/obj/item/device/deskbell/signaler/trader{
+	pixel_x = 10;
+	pixel_y = 5;
+	name = "Trade Ship Counter Bell"
+	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},

--- a/maps/bagelstation.dmm
+++ b/maps/bagelstation.dmm
@@ -9134,6 +9134,11 @@
 	name = "Firelock South"
 	},
 /obj/item/device/instrument/glockenspiel,
+/obj/item/device/deskbell/signaler/trader{
+	pixel_y = -4;
+	pixel_x = -4;
+	name = "Trade Post Desk Bell"
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters)
 "atr" = (
@@ -112594,6 +112599,11 @@
 "eNC" = (
 /obj/machinery/light,
 /obj/structure/table/woodentable,
+/obj/item/device/deskbell/signaler/trader{
+	pixel_y = 9;
+	pixel_x = 10;
+	name = "Trade Ship Bell"
+	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor2"
 	},

--- a/maps/defficiency.dmm
+++ b/maps/defficiency.dmm
@@ -97072,6 +97072,11 @@
 	id_tag = "TSdisplay";
 	name = "Tradeship Display Shutters"
 	},
+/obj/item/device/deskbell/signaler/trader{
+	pixel_x = 10;
+	pixel_y = -5;
+	name = "Trade Ship Counter Bell"
+	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},

--- a/maps/lowfatbagel.dmm
+++ b/maps/lowfatbagel.dmm
@@ -9880,6 +9880,11 @@
 	id_tag = "tradefloorstation";
 	name = "Trade Shutter"
 	},
+/obj/item/device/deskbell/signaler/trader{
+	pixel_x = 8;
+	pixel_y = 6;
+	name = "Trade Den Counter Bell"
+	},
 /turf/simulated/floor/plating,
 /area/vox_station/tradepost)
 "aAL" = (
@@ -43349,6 +43354,11 @@
 /obj/structure/sign/pox{
 	icon_state = "tradesign";
 	name = "Vox Tradepost"
+	},
+/obj/item/device/deskbell/signaler/trader{
+	pixel_x = 8;
+	pixel_y = -5;
+	name = "Trade Ship Bell"
 	},
 /turf/simulated/floor{
 	icon_state = "darkyellowfull";

--- a/maps/metaclub.dmm
+++ b/maps/metaclub.dmm
@@ -100687,6 +100687,11 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/item/device/deskbell/signaler/trader{
+	pixel_x = 10;
+	pixel_y = -5;
+	name = "Trade Ship Counter Bell"
+	},
 /turf/simulated/floor/carpet,
 /area/shuttle/trade/start)
 "eac" = (

--- a/maps/packedstation.dmm
+++ b/maps/packedstation.dmm
@@ -60940,6 +60940,11 @@
 	req_one_access_txt = "140"
 	},
 /obj/abstract/map/spawner/assistant/materials,
+/obj/item/device/deskbell/signaler/trader{
+	pixel_x = 10;
+	pixel_y = 5;
+	name = "Trade Ship Counter Bell"
+	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},

--- a/maps/snaxi.dmm
+++ b/maps/snaxi.dmm
@@ -75666,6 +75666,11 @@
 	id_tag = "TSdisplay";
 	name = "Tradeship Display Shutters"
 	},
+/obj/item/device/deskbell/signaler/trader{
+	pixel_y = 5;
+	pixel_x = 10;
+	name = "Trade Ship Counter Bell"
+	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},

--- a/maps/synergy.dmm
+++ b/maps/synergy.dmm
@@ -85317,6 +85317,11 @@
 /obj/structure/window/reinforced/plasma{
 	dir = 8
 	},
+/obj/item/device/deskbell/signaler/trader{
+	pixel_x = 10;
+	pixel_y = -5;
+	name = "Trade Ship Counter Bell"
+	},
 /turf/simulated/floor{
 	icon_state = "darkyellowfull";
 	tag = "icon-darkyellowfull"

--- a/maps/tgstation.dmm
+++ b/maps/tgstation.dmm
@@ -110716,6 +110716,11 @@
 	name = "Tradeship Windoor";
 	req_one_access_txt = "140"
 	},
+/obj/item/device/deskbell/signaler/trader{
+	pixel_x = 6;
+	pixel_y = -12;
+	name = "Trade Ship Counter Bell"
+	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},

--- a/maps/waystation.dmm
+++ b/maps/waystation.dmm
@@ -72391,6 +72391,11 @@
 	name = "Tradeship Windoor";
 	req_one_access_txt = "140"
 	},
+/obj/item/device/deskbell/signaler/trader{
+	pixel_x = 6;
+	pixel_y = 11;
+	name = "Trade Ship Counter Bell"
+	},
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "dark"

--- a/maps/wheelstation.dmm
+++ b/maps/wheelstation.dmm
@@ -43196,6 +43196,11 @@
 	name = "Trader Dock Shutters"
 	},
 /obj/structure/plasticflaps/mining,
+/obj/item/device/deskbell/signaler/trader{
+	pixel_x = 6;
+	pixel_y = 8;
+	name = "Trade Counter Bell"
+	},
 /turf/simulated/floor/vox{
 	name = "floor"
 	},


### PR DESCRIPTION
[general] [qol]

## What this does
adds trader signaling bells (added in #39041) on the trade ship counter in the following stations:
* boxstation
* deficiency
* metaclub
* packed
* asteroid
* synergy
* lowfat bagel
* waystation
* wheelstation
* snaxi
* bagelstation
* dorf

## Why it's good
lets traders know when customers are at their ship if they're away, and allows vox haters to annoy traders by spamming the bell.

## How it was tested
wan't. i just added them in the map editor and called it a day. they do work, though, as tested in the previous PR

## Changelog
:cl:
 * rscadd: Added bells to the trader ship. remember to get a PDA.