### PR TITLE
You can now make your own plant analyzers in the protolathe

### DIFF
--- a/code/modules/hydroponics/hydro_tools.dm
+++ b/code/modules/hydroponics/hydro_tools.dm
@@ -18,6 +18,8 @@
 	icon = 'icons/obj/device.dmi'
 	icon_state = "hydro"
 	item_state = "analyzer"
+	starting_materials = list(MAT_IRON = 100, MAT_GLASS = 40)
+	origin_tech = Tc_MAGNETS + "=2;" + Tc_ENGINEERING + "=2" + Tc_BIOTECH + "=2"
 	var/form_title //Descriptive title of the last plant scanned, example: mutant watermelon (#81)
 	var/last_data  //Stores the entire last scan, for printing purposes.
 	var/tmp/last_print = 0 //When was the last printing, works as a cooldown to prevent paperspam

--- a/code/modules/hydroponics/hydro_tools.dm
+++ b/code/modules/hydroponics/hydro_tools.dm
@@ -19,7 +19,7 @@
 	icon_state = "hydro"
 	item_state = "analyzer"
 	starting_materials = list(MAT_IRON = 100, MAT_GLASS = 40)
-	origin_tech = Tc_MAGNETS + "=2;" + Tc_ENGINEERING + "=2" + Tc_BIOTECH + "=2"
+	origin_tech = Tc_MAGNETS + "=2;" + Tc_ENGINEERING + "=2;" + Tc_BIOTECH + "=2;"
 	var/form_title //Descriptive title of the last plant scanned, example: mutant watermelon (#81)
 	var/last_data  //Stores the entire last scan, for printing purposes.
 	var/tmp/last_print = 0 //When was the last printing, works as a cooldown to prevent paperspam

--- a/code/modules/research/designs/misc.dm
+++ b/code/modules/research/designs/misc.dm
@@ -9,6 +9,8 @@
 	build_path = /obj/item/floral_somatoray
 
 /datum/design/plant_analyzer
+	name = "plant analyzer"
+	desc = "A hand-held botanical scanner that reports detailed information about seeds, plants and produce."
 	req_tech = list(Tc_MAGNETS = 2, Tc_ENGINEERING = 2, Tc_BIOTECH = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_IRON = 200, MAT_GLASS = 100)

--- a/code/modules/research/designs/misc.dm
+++ b/code/modules/research/designs/misc.dm
@@ -9,7 +9,7 @@
 	build_path = /obj/item/floral_somatoray
 
 /datum/design/plant_analyzer
-	name = "plant analyzer"
+	name = "Plant Analyzer"
 	desc = "A hand-held botanical scanner that reports detailed information about seeds, plants and produce."
 	id = "plant_analyzer"
 	req_tech = list(Tc_MAGNETS = 2, Tc_ENGINEERING = 2, Tc_BIOTECH = 2)

--- a/code/modules/research/designs/misc.dm
+++ b/code/modules/research/designs/misc.dm
@@ -11,11 +11,12 @@
 /datum/design/plant_analyzer
 	name = "plant analyzer"
 	desc = "A hand-held botanical scanner that reports detailed information about seeds, plants and produce."
+	id = "plant_analyzer"
 	req_tech = list(Tc_MAGNETS = 2, Tc_ENGINEERING = 2, Tc_BIOTECH = 2)
 	build_type = PROTOLATHE
+	build_path = /obj/item/device/analyzer/plant_analyzer
 	materials = list(MAT_IRON = 200, MAT_GLASS = 100)
 	category = "Misc"
-	build_path = /obj/item/device/analyzer/plant_analyzer
 
 /datum/design/janicart_upgrade
 	name = "Janicart Upgrade Module"

--- a/code/modules/research/designs/misc.dm
+++ b/code/modules/research/designs/misc.dm
@@ -8,6 +8,13 @@
 	category = "Misc"
 	build_path = /obj/item/floral_somatoray
 
+/datum/design/plant_analyzer
+	req_tech = list(Tc_MAGNETS = 2, Tc_ENGINEERING = 2, Tc_BIOTECH = 2)
+	build_type = PROTOLATHE
+	materials = list(MAT_IRON = 200, MAT_GLASS = 100)
+	category = "Misc"
+	build_path = /obj/item/device/analyzer/plant_analyzer
+
 /datum/design/janicart_upgrade
 	name = "Janicart Upgrade Module"
 	desc = "Used to allow the janicart to clean surfaces while moving."


### PR DESCRIPTION
## What this does
The only thing more surprising than me realizing that you could only spawn with, order from cargo or find these in vaults, was realizing that no one else had noticed.

## Why it's good
Making things good.

## How it was tested
<img width="905" height="367" alt="image" src="https://github.com/user-attachments/assets/d6f89ccd-3a9d-4bdb-ad71-7587b5bbdd68" />

## Changelog
:cl:
 * rscadd: You can fabricate plant analyzers in the protolathe.

