### PR TITLE
Fixes advanced graffiti on glass floors

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -21,6 +21,16 @@
 	//advanced_graffiti_overlay.SwapColor("#aaaaaaff", "#ffffff00")
 	overlays += advanced_graffiti_overlay
 
+/turf/simulated/floor/glass/render_advanced_graffiti(var/mob/user)
+	if (!advanced_graffiti)
+		return FALSE
+	overlays -= advanced_graffiti_overlay
+	advanced_graffiti_overlay = image(advanced_graffiti.render_on(icon(icon, icon_state)))
+	advanced_graffiti_overlay.plane = GLASSTILE_PLANE
+	advanced_graffiti_overlay.layer = ADVANCED_GRAFFITI_LAYER
+	//advanced_graffiti_overlay.SwapColor("#aaaaaaff", "#ffffff00")
+	overlays += advanced_graffiti_overlay
+
 /turf/simulated/New()
 	..()
 


### PR DESCRIPTION
[bugfix][hotfix]
## What this does
<img width="317" height="314" alt="image" src="https://github.com/user-attachments/assets/c250500c-4c45-48b1-b74c-775bded47c26" />

Closes #39083.

## How it was tested
Drawing on one, seen above.

## Changelog
:cl:
 * bugfix: Advanced graffiti now works on glass floors.