### PR TITLE
chefsauce icon hotfix

### DIFF
--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -219,7 +219,7 @@
 			if(CHEFSPECIAL)
 				name = "\improper Chef Excellence's Special Sauce"
 				desc = "A potent sauce distilled from the toxin glands of 1000 Space Carp with an extra touch of LSD, because why not?"
-				icon_state = "emptycondiment"
+				icon_state = "chefsauce"
 			if(VINEGAR)
 				name = "malt vinegar bottle"
 				desc = "Perfect for fish and chips!"


### PR DESCRIPTION
The sprite was there and merged (#36658) but the file called for emptycondiment instead of chefsauce.
:cl:
 * bugfix: Chef sauce will now look like they were supposed to.