### PR TITLE
Makes water source delete on WC object deletion

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -14,6 +14,10 @@
 	if(watertype)
 		watersource = new watertype
 
+/obj/structure/wc/Destroy()
+	QDEL_NULL(watersource)
+	. = ..()
+
 /obj/structure/wc/verb/empty_container_into()
 	set name = "Empty container into"
 	set category = "Object"


### PR DESCRIPTION
[oversight]

## What this does
Stops these taking up memory.

## How it was tested
SELECT /obj/item/reagent_core after deletion of all /obj/structure/wc items.

## Changelog
No user facing changelog.