### PR TITLE
Makes the codebreaker use proper delay code

### DIFF
--- a/code/game/objects/items/devices/codebreaker.dm
+++ b/code/game/objects/items/devices/codebreaker.dm
@@ -22,18 +22,11 @@
 		operation = 1
 		icon_state = "codebreaker-working"
 		to_chat(user, "<span class='notice'>Stand still and keep the [src] in your hands while it cracks the [O]'s activation code.</span>")
-		var/turf/loc_user = get_turf(user)
-		var/turf/loc_nuke = get_turf(O)
-		var/crackduration = rand(100,300)
-		var/delayfraction = round(crackduration/6)
-
-		for(var/i = 0, i<6, i++)
-			sleep(delayfraction)
-			if(!user || user.incapacitated() || !(user.loc == loc_user) || !(O.loc == loc_nuke) || !user.is_holding_item(src))
-				to_chat(user, "<span class='warning'>You need to stand still for the whole duration of the code breaking for the device to work, and keep it in one of your hands.</span>")
-				icon_state = "codebreaker"
-				operation = 0
-				return
+		if(!do_after(user,O,rand(10,30) SECONDS))
+			to_chat(user, "<span class='warning'>You need to stand still for the whole duration of the code breaking for the device to work, and keep it in one of your hands.</span>")
+			icon_state = "codebreaker"
+			operation = 0
+			return
 
 		icon_state = "codebreaker-found"
 		playsound(src, 'sound/machines/info.ogg', 50, 1)


### PR DESCRIPTION
[consistency]

## What this does
Closes #39016.

## How it was tested
Using it on a nuke, moving around.

## Changelog
:cl:
 * tweak: The codebreaker now uses a proper delay bar system for cracking the nuke.