### PR TITLE
Tweaks how Canvas UI lists the available colors, separating them into groups of 5 colors.

### DIFF
--- a/code/modules/html_interface/paintTool/canvas.css
+++ b/code/modules/html_interface/paintTool/canvas.css
@@ -87,10 +87,14 @@
 }
 
 .palette div.paletteColor {
-	width: 28px;
-	height: 28px;
+	width: 30px;
+	height: 30px;
 	display: inline-block;
 	border: 1px solid #000000;
+}
+
+.palette div.paletteColor:nth-child(5n) {
+	margin-right: 10px;
 }
 
 .palette div.paletteButton {


### PR DESCRIPTION
## What this does
<img width="665" height="298" alt="image" src="https://github.com/user-attachments/assets/79b3fdcb-5f39-4a3e-b00b-5bc149b0a697" />

Might look like ass if we add a bigger canvas, like 32x32 (sigh), but it looks alright for what we have now.
## Why it's good
Makes it easier to count the colors if you're using a template with several similar colors.
## How it was tested
It worked when testing on a localhost copy of the jellyveggie repo canvas UI. Just messed with the numbers until it looked right.
:cl:
 * tweak: Canvas UI will now group available colors into sets of 5, for easier counting.