### PR TITLE
Mostly fix nanopaper video embed

### DIFF
--- a/code/modules/paperwork/nano_paper.dm
+++ b/code/modules/paperwork/nano_paper.dm
@@ -58,7 +58,7 @@
 		\[*\] : A dot used for lists.<br>
 		\[hr\] : Adds a horizontal rule. <br>
 		\[img\]http://url\[/img\] : add an image <br>
-		\[video\]http://url.wmv\[/video\] : add a video with simple controls, MUST BE IN WMV FORMAT!!<br>
+		\[video\]http://url\[/video\] : add a video with simple controls<br>
 		\[youtube\]Any youtube url\[/youtube\] : embed a youtube url into the nanopaper, should function with any youtube url format!<br>
 		<br>
 		<center>Fonts</center><br>

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -36,7 +36,7 @@
 	expr.index = 1
 	while(expr.Find(text, expr.index))
 		message_admins("[key_name_admin(user)] added a video ([html_encode(expr.group[1])]) to [P] at [formatJumpTo(get_turf(P))]")
-		var/rtxt   = "<embed src=\"[html_encode(expr.group[1])]\" width=\"420\" height=\"344\" type=\"x-ms-wmv\" volume=\"85\" autoStart=\"0\" autoplay=\"true\" />"
+		var/rtxt   = "<video src=\"[html_encode(expr.group[1])]\" width=\"420\" height=\"344\" controls>Your browser does not support the video tag</video>"
 		text       = copytext(text, 1, expr.index) + rtxt + copytext(text, expr.index + length(expr.match))
 		expr.index = expr.index + length(rtxt)
 	return text
@@ -46,9 +46,9 @@
 	while(expr.Find(text,expr.index))
 		var/regex/youtubeid = regex("(youtu\\.be\\/|youtube\\.com\\/(watch\\?(.*&)?v=|(embed|v)\\/))(\[\\w\]+)", "gi")
 		youtubeid.Find(expr.group[1])
-		var/link = "http://www.youtube.com/embed/[youtubeid.group[5]]?autoplay=1&loop=1&controls=0&showinfo=0&rel=0"
+		var/link = "https://www.youtube.com/embed/[youtubeid.group[5]]?loop=1&controls=0&showinfo=0&rel=0"
 		message_admins("[key_name_admin(user)] added a youtube video ([html_encode(expr.group[1])]) to [P] at [formatJumpTo(get_turf(P))]")
-		var/rtxt   = "<iframe width=\"420\" height=\"345\" src=\"[link]\" frameborder=\"0\">"
+		var/rtxt   = "<iframe width=\"420\" height=\"345\" src=\"[link]\" frameborder=\"0\" allow=\"encrypted-media\"></iframe>"
 		text       = copytext(text, 1, expr.index) + rtxt + copytext(text, expr.index + length(expr.match))
 		expr.index = expr.index + length(rtxt)
 	return text


### PR DESCRIPTION
## What this does

Updates the nanopaper video embed to use `<video>` tags rather than the IE-specific `<embed type="x-ms-wmv">` thing that doesnt work anymore. A nice bonus is that we are no longer constrained to `wmv` format and can use whatever mp4, webm etc. shit you want, as long as the browser supports it you can use it
Also update the YouTube embed to use HTTPS and encrypted-media (some kinda DRM thing idk, its a nice-to-have)

<img width="894" height="705" alt="image" src="https://github.com/user-attachments/assets/c75ea4d6-3221-4ec5-a2db-5ba59fc6dc97" />

### HOWEVER

We can't have autoplay with sound. We can have muted autoplay but I felt it would be wrong to mute the video and require the user to unmute it. This is a limitation of webview, as far as I can find it's not something we can get around. Some bullshit about "security" and "good UX" is why we can't have nice things.
Removed the now-useless autoplay tags.

## Why it's good
you can put mario goatse on nanopaper and show it to the AI constantly through cameras

## How it was tested

before change: try to embed video on nanopaper, observe unsupported plugin error screen
after change: try to embed video on nanopaper, observe video

## Changelog
:cl:
 * bugfix: You can now embed lots of different video formats on nanopaper. It can't autoplay though.
