### PR TITLE
Fix some runtimes

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -469,7 +469,7 @@ var/area/space_area
 /area/Exited(atom/movable/Obj)
 	var/turf/T = get_turf(Obj)
 	var/datum/virtual_z/new_v = T.v
-	if(!new_v || v != new_v)
+	if(v && (!new_v || v != new_v))
 		if(istype(Obj, /mob/living))
 			var/mob/living/L = Obj
 			v.mob_exited(L)

--- a/code/modules/ZAS/ConnectionGroup.dm
+++ b/code/modules/ZAS/ConnectionGroup.dm
@@ -189,7 +189,7 @@ Class Procs:
 	return A == Z
 
 /connection_edge/unsimulated/tick()
-	if(A.invalid)
+	if(A.invalid || !air)
 		erase()
 		return
 

--- a/code/modules/surgery/vox_feather_pluck.dm
+++ b/code/modules/surgery/vox_feather_pluck.dm
@@ -14,8 +14,9 @@
 
 /datum/surgery_step/pluck/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	// Only Vox, only chest
+	if(!isvox(target)) return 0
 	var/datum/butchering_product/feathers/vox/F = locate(/datum/butchering_product/feathers/vox) in target.butchering_drops
-	if(!isvox(target) || F.amount == 0) return 0
+	if(!F || F.amount == 0) return 0
 	if(user.a_intent != I_GRAB) return 0 // So that they don't accidentally pluck someone while trying to help them.
 	return target_zone == LIMB_CHEST
 


### PR DESCRIPTION
## What this does

Fix 3 runtimes.

### 1. Space has a null `v` level
e.g.
```
Runtime in code/game/area/areas.dm,475: Cannot execute null.mob exited().
  proc name: Exited (/area/Exited)
  usr: Jakob Jakobsen (alone) (/mob/living/carbon/human)
  usr.loc: Asteroid (280, 159, 5) (/turf/unsimulated/floor/asteroid)
  src: Space (/area)
  call stack:
  Space (/area): Exited(Jakob Jakobsen (/mob/living/carbon/human), Asteroid (280,159,5) (/turf/unsimulated/floor/asteroid))
  Jakob Jakobsen (/mob/living/carbon/human): Move(Asteroid (280,159,5) (/turf/unsimulated/floor/asteroid), 4, 0, 0, 0)
  Jakob Jakobsen (/mob/living/carbon/human): Move(Asteroid (280,159,5) (/turf/unsimulated/floor/asteroid), 4, 0, 0, 0)
  Jakob Jakobsen (/mob/living/carbon/human): Move(Asteroid (280,159,5) (/turf/unsimulated/floor/asteroid), 4, 0, 0, 0)
  Jakob Jakobsen (/mob/living/carbon/human): Move(Asteroid (280,159,5) (/turf/unsimulated/floor/asteroid), 4, 0, 0, 0)
  Alone (/client): Move(space (279,159,5) (/turf/space), 4, 0, 0, 0)
  Alone (/client): move loop()
  Alone (/client): MoveKey(4, 1)
```

This happens when you walk from space onto something that isn't space because space is special and has a null `v`. I asked west about this and he said a null check is okay for now (this thing runtimes a lot) but he needs to go over the design to be sure.

### 2. some funky ZAS shit

```
[18:49:28] Runtime in code/modules/ZAS/ConnectionGroup.dm,198: Cannot execute null.return pressure().
  proc name: tick (/connection_edge/unsimulated/tick)
  src: /connection_edge/unsimulated (/connection_edge/unsimulated)
  call stack:
  /connection_edge/unsimulated (/connection_edge/unsimulated): tick()
  Air (/datum/subsystem/air): process part(3)
  Air (/datum/subsystem/air): fire(0)
  Air (/datum/subsystem/air): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
```
and 
```
[18:49:28] Runtime in code/modules/ZAS/_gas_mixture.dm,425: Cannot read null.volume
  proc name: share space (/datum/gas_mixture/proc/share_space)
  src: /datum/gas_mixture (/datum/gas_mixture)
  call stack:
  /datum/gas_mixture (/datum/gas_mixture): share space(null, 1)
  /connection_edge/unsimulated (/connection_edge/unsimulated): tick()
  Air (/datum/subsystem/air): process part(3)
  Air (/datum/subsystem/air): fire(0)
  Air (/datum/subsystem/air): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
```

These happen when ticking a connection edge between a simulated zone and an unsimulated zone *somehow*. 
In ZAS, adjacent turfs have a `connection` between them. Rather than expensively ticking every single `connection`, adjacent `connection`s between two `zone`s form a `connection_edge` for ticking. Between a simulated `zone` and an unsimulated `zone`, you get a `connection_edge/unsimulated`. 
The runtime happens when `air` is somehow `null`. As far as I can find nothing sets this or calls `del` on `air` so I dunno lol. Maybe Byond is deleting it when refs go to 0. In any case, if `air` is null then the edge is also invalid and should be `erase`'d.

### 3. Vox feather plucking

```
[21:53:42] Runtime in code/modules/surgery/vox_feather_pluck.dm,18: Cannot read null.amount
  proc name: can use (/datum/surgery_step/pluck/can_use)
  usr: Kayihiyachka (falcon2346) (/mob/living/carbon/human/vox)
  usr.loc: The floor (247, 222, 1) (/turf/simulated/floor)
  src: /datum/surgery_step/pluck (/datum/surgery_step/pluck)
  call stack:
  /datum/surgery_step/pluck (/datum/surgery_step/pluck): can use(Kayihiyachka (/mob/living/carbon/human/vox), Taylor Swift (/mob/living/carbon/human), "chest", the hemostat (/obj/item/tool/hemostat))
  do surgery(Taylor Swift (/mob/living/carbon/human), Kayihiyachka (/mob/living/carbon/human/vox), the hemostat (/obj/item/tool/hemostat), 0)
  the hemostat (/obj/item/tool/hemostat): handle attack(the hemostat (/obj/item/tool/hemostat), Taylor Swift (/mob/living/carbon/human), Kayihiyachka (/mob/living/carbon/human/vox), null, null)
  the hemostat (/obj/item/tool/hemostat): attack(Taylor Swift (/mob/living/carbon/human), Kayihiyachka (/mob/living/carbon/human/vox), null, null)
  Taylor Swift (/mob/living/carbon/human): attackby(the hemostat (/obj/item/tool/hemostat), Kayihiyachka (/mob/living/carbon/human/vox), "icon-x=24;icon-y=15;vis-x=11;v...", null, null)
  Kayihiyachka (/mob/living/carbon/human/vox): ClickOn(Taylor Swift (/mob/living/carbon/human), "icon-x=24;icon-y=15;vis-x=11;v...")
  Taylor Swift (/mob/living/carbon/human): Click(the floor (247,221,1) (/turf/simulated/floor), "mapwindow.map", "icon-x=24;icon-y=15;vis-x=11;v...")
```

This is a band-aid fix. Note that Taylor Swift is a `mob/living/carbon/human` - but reading the logs she was definitely turned into a filthy disgusting vox. The `isvox` check has to return true here, so her species datum is definitely vox, but the mob type is still human.
I'm not sure how this happened yet but in any case, the changed proc assumes that the target of the plucking surgery will definitely have feathers in its butcher table. **This is not the case with whatever the fuck happened here and `F` was null, which is why the runtime happened.** Until I know how Taylor ended up the way she did, just guarding against null `F` is enough to stop this from happening. 
Thinking about it tho I should probably reinitialise the butchery table in `set_species`, that would be good too

## Why it's good
runtimes bad

## How it was tested

1. confirmed runtime walking off space turf onto roid, confirmed runtime didnt happen after change
2. ran around the station blowing up welder tanks and deleting walls, but this is an awkward one to trigger on purpose
3. it wasn't :) I messaged TayIor on Byond pager for more info on how this happened and will improve the fix later

## Changelog
:cl:
TBD
