### PR TITLE
Changes phazon salt's tackling modifiers

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -2107,9 +2107,9 @@ var/datum/record_organ //This is just a dummy proc, not storing any variables he
 	if(prob(5))
 		species.chem_flags = rand(0,65535)
 	if(prob(15))
-		species.tackleRange = max(0, rand(species.tackleRange-2, species.tackleRange+2))	//Leaving this with no upper limit is a choice I'm making today. God help us tomorrow.
+		species.tackleRange = max(0, rand(species.tackleRange-1, species.tackleRange+2))	//Leaving this with no upper limit is a choice I'm making today. God help us tomorrow.
 	if(prob(15))
-		species.tacklePower = max(0, rand(species.tacklePower*0.5, species.tacklePower*1.5))
+		species.tacklePower = max(0, rand(species.tacklePower*0.75, species.tacklePower*2))
 
 
 	if(!can_be_fat)


### PR DESCRIPTION
## What this does
Phazon Salt can, on top of everything else, randomize how strong you tackle and how far you tackle. 
Current tackling range usually averages out to no change, and current tackling power trends downwards, so with enough rolls of the phazon dice, you end up tackling the same distance as before, but get out-tackled by a mild breeze.

This PR ups both factors so they trend slightly upwards.
In order to get any meaningful buffs out of this you'd need to take a fair bit of phazon, and more often than not, become a crime against creation that gets poisoned plasma but needs to breathe plasma, or gets crushed by pressure at 50kpa, or become unable to eat, drink and speak, etc.
:cl:
 * tweak: Phazon salts tackle power/range buffs are now better overall.