### PR TITLE
Curse of Norwood will no longer waste a spellbook bundle slot

### DIFF
--- a/code/game/gamemodes/wizard/spellbook_oneuse.dm
+++ b/code/game/gamemodes/wizard/spellbook_oneuse.dm
@@ -14,6 +14,7 @@
 	spine_color = "#fff"
 	spine_overlay = "#fff"
 	var/disabled_from_bundle //if true, this will not appear in the spellbook bundle
+	var/bundle_freebie //if true, if it appears in the spellbook bundle it will add another spellbook to be rolled
 
 /obj/item/weapon/spellbook/oneuse/New()
 	..()
@@ -612,7 +613,7 @@
 	icon_state ="booknorwood"
 	desc = "This book suddenly stops about 29 pages in. After, it is written 'it's over' in every language that has ever existed, will ever exist, and even in some which shouldn't theoretically exist."
 	spine_overlay = "#ff0"
-	disabled_from_bundle = TRUE //Too weak for the bundle
+	bundle_freebie = TRUE //Too weak
 
 ///// ANCIENT SPELLBOOK /////
 

--- a/code/game/gamemodes/wizard/spellbook_oneuse.dm
+++ b/code/game/gamemodes/wizard/spellbook_oneuse.dm
@@ -13,7 +13,7 @@
 	desc = "This template spellbook was never meant for the eyes of man..."
 	spine_color = "#fff"
 	spine_overlay = "#fff"
-	var/disabled_from_bundle //if 1, this will not appear in the spellbook bundle
+	var/disabled_from_bundle //if true, this will not appear in the spellbook bundle
 
 /obj/item/weapon/spellbook/oneuse/New()
 	..()
@@ -129,7 +129,7 @@
 	icon_state ="bookforcewall"
 	desc = "This book has a dedication to finger gun-toting mimes everywhere inside the front cover."
 	spine_overlay = "#8ff"
-	disabled_from_bundle = 1
+	disabled_from_bundle = TRUE
 
 /obj/item/weapon/spellbook/oneuse/unwall/attack_self(mob/user)
 	if(ishuman(user))
@@ -214,7 +214,7 @@
 	spellname = "charging"
 	icon_state ="bookcharge"
 	desc = "This book is made of 100% post-consumer wizard."
-	disabled_from_bundle = 1
+	disabled_from_bundle = TRUE
 	spine_overlay = "#8ff"
 
 /obj/item/weapon/spellbook/oneuse/charge/recoil(mob/user)
@@ -340,7 +340,7 @@
 	icon_state = "bookhighlander"
 	desc = "You can hear the bagpipes playing already."
 	spine_overlay = "#00f"
-	disabled_from_bundle = 1
+	disabled_from_bundle = TRUE
 
 /obj/item/weapon/spellbook/oneuse/disorient
 	spell = /spell/targeted/disorient
@@ -412,7 +412,7 @@
 	spell = /spell/lightning/sith
 	spellname = "sith lightning"
 	desc = "You can faintly hear it yell 'UNLIMITED POWER'."
-	disabled_from_bundle = 1
+	disabled_from_bundle = 	TRUE
 
 /obj/item/weapon/spellbook/oneuse/timestop
 	spell = /spell/aoe_turf/fall
@@ -601,7 +601,7 @@
 	icon_state ="bookabsorb"
 	desc = "This book glows with sinister energy."
 	spine_overlay = "#00f"
-	disabled_from_bundle = 1
+	disabled_from_bundle = TRUE
 
 
 ///// Norwood curse ////
@@ -612,6 +612,7 @@
 	icon_state ="booknorwood"
 	desc = "This book suddenly stops about 29 pages in. After, it is written 'it's over' in every language that has ever existed, will ever exist, and even in some which shouldn't theoretically exist."
 	spine_overlay = "#ff0"
+	disabled_from_bundle = TRUE //Too weak for the bundle
 
 ///// ANCIENT SPELLBOOK /////
 

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -837,15 +837,18 @@
 
 /obj/item/weapon/storage/box/spellbook/New()
 	..()
+	var/limit = BOX_SPACE
 	var/list/possible_books = subtypesof(/obj/item/weapon/spellbook/oneuse)
 	for(var/S in possible_books)
 		var/obj/item/weapon/spellbook/oneuse/O = S
 		if(initial(O.disabled_from_bundle))
 			possible_books -= O
-	for(var/i =1; i <= BOX_SPACE; i++)
+	for(var/i =1; i <= limit; i++)
 		var/randombook = pick(possible_books)
-		var/book = new randombook(src)
+		var/obj/item/weapon/spellbook/oneuse/book = new randombook(src)
 		src.contents += book
+		if(book.bundle_freebie)
+			limit++
 		possible_books -= randombook
 	var/randomsprite = pick("a","b")
 	icon_state = "wizbox-[randomsprite]"


### PR DESCRIPTION
The spell is too weak for it to replace other spellbooks in a spellbook bundle, so instead whenever it does show up it allows another spellbook to appear in the bundle.

:cl:
 * tweak: If the Curse of Norwood spellbook shows up in the wizard's spellbook bundle it will now cause another spellbook to appear.