### PR TITLE
hopefully stops powercreepers from destroying the server on jungle

### DIFF
--- a/code/game/gamemodes/events/powercreeper.dm
+++ b/code/game/gamemodes/events/powercreeper.dm
@@ -87,6 +87,9 @@
 			if(environment.temperature < T0C)
 				die()
 				return
+			if(istype(T,/turf/unsimulated/floor/planetary) && prob(25))
+				die()
+				return
 		//add power to powernet through converting atmospheric heat to power
 		add_avail(-(environment.add_thermal_energy(max(environment.get_thermal_energy_change(T0C),-POWER_PER_FRUIT*10)/10)))
 		if(growdirs)
@@ -166,6 +169,8 @@
 		return 0
 	if(T.has_dense_content())
 		return CANZAP
+	if(istype(T,/turf/unsimulated/floor/planetary) && prob(90))
+		return 0
 	return CANGROW|CANZAP
 
 


### PR DESCRIPTION
[hotfix] [bugfix] [jungle]

## What this does
closes #39116 by making it so that powercreeper vines die off over time and spread very slowly on planetary turfs

## Why it's good
stops the server from being unplayable

## How it was tested
wasn't

## Changelog
:cl:
 * bugfix: powercreepers should no longer spread through the jungle infinitely