### PR TITLE
Cherry flavored lube

### DIFF
--- a/__DEFINES/reagents.dm
+++ b/__DEFINES/reagents.dm
@@ -25,6 +25,7 @@
 #define VACCINE 			"vaccine"
 #define WATER 			"water"
 #define LUBE 			"lube"
+#define CHERRYLUBE 		"cherrylube"
 #define SODIUM_POLYACRYLATE			"sodium_polyacrylate"
 #define PHALANXIMINE 			"phalanximine"
 #define TOXIN 			"toxin"
@@ -620,6 +621,7 @@ var/list/cheartstopper = list(/*"potassium_chloride",*/ CHEESYGLOOP) //this stop
 #define DEXALINS list(DEXALIN, THYMOL)
 #define ACIDS list(SACID, PACID, FORMIC_ACID, PACID, PHENOL, ACIDSPIT, ACIDTEA)
 #define WATERS list(WATER, HOLYWATER, ICE)
+#define LUBES list(LUBE, CHERRYLUBE)
 #define CORES list(SOFTCORES, MEDCORES)
 #define ALLNANITES list(NANITES, AUTISTNANITES)
 #define SUGARS list(SUGAR, CORNSYRUP)

--- a/code/game/objects/structures/vehicles/janicart.dm
+++ b/code/game/objects/structures/vehicles/janicart.dm
@@ -44,7 +44,7 @@
 
 /obj/structure/bed/chair/vehicle/janicart/examine(mob/user)
 	..()
-	if(in_range(src, user) && reagents.has_reagent(LUBE))
+	if(in_range(src, user) && reagents.has_any_reagents(LUBES))
 		to_chat(user, "<span class='warning'>Something is very off about this water.</span>")
 	switch(health)
 		if(75 to 99)

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -681,14 +681,16 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 /turf/simulated/proc/is_wet() //Returns null if no puddle, otherwise returns the puddle
 	return locate(/obj/effect/overlay/puddle) in src
 
-/turf/simulated/proc/wet(delay = 800, slipperiness = TURF_WET_WATER)
+/turf/simulated/proc/wet(delay = 800, slipperiness = TURF_WET_WATER, custom_color)
 	var/obj/effect/overlay/puddle/P = is_wet()
 	if(P)
 		if(slipperiness > P.wet)
 			P.wet = slipperiness
 			P.lifespan = max(delay, P.lifespan)
 	else
-		new /obj/effect/overlay/puddle(src, slipperiness, delay)
+		P = new /obj/effect/overlay/puddle(src, slipperiness, delay)
+	if(custom_color)
+	P.color = custom_color
 
 /turf/simulated/proc/dry(slipperiness = TURF_WET_WATER)
 	var/obj/effect/overlay/puddle/P = is_wet()

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -690,7 +690,7 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 	else
 		P = new /obj/effect/overlay/puddle(src, slipperiness, delay)
 	if(custom_color)
-	P.color = custom_color
+		P.color = custom_color
 
 /turf/simulated/proc/dry(slipperiness = TURF_WET_WATER)
 	var/obj/effect/overlay/puddle/P = is_wet()

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -17,7 +17,7 @@
 	for(var/datum/organ/external/cosmetic_organ in cosmetic_organs)
 		cosmetic_organ.droplimb(TRUE, TRUE)
 	var/gib_radius = 0
-	if(reagents.has_reagent(LUBE))
+	if(reagents.has_any_reagents(LUBES))
 		gib_radius = 6 //Your insides are all lubed, so gibs travel much further
 
 	anim(target = src, a_icon = 'icons/mob/mob.dmi', flick_anim = "gibbed-h", sleeptime = 15)

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -852,7 +852,7 @@ var/list/has_died_as_golem = list()
 	H.death(1)
 	H.handle_body_destroyed()
 	var/gib_radius = 0
-	if(H.reagents.has_reagent(LUBE))
+	if(H.reagents.has_any_reagents(LUBES))
 		gib_radius = 6
 	hgibs(H.loc, H.virus2, H.dna, flesh_color, blood_color, gib_radius)
 	spawn()
@@ -1005,7 +1005,7 @@ var/list/has_died_as_golem = list()
 			//Override the current limb status and don't cause an explosion
 			E.droplimb(1, 1)
 	var/gib_radius = 0
-	if(H.reagents.has_reagent(LUBE))
+	if(H.reagents.has_any_reagents(LUBES))
 		gib_radius = 6
 
 	anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = "gibbed-h", sleeptime = 15)

--- a/code/modules/mob/living/simple_animal/hostile/human/civilian.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/civilian.dm
@@ -75,7 +75,7 @@
 	say(pick("Time to take out the trash!","Hope you wiped your feet before you came in.","It's time to take you to the cleaners."))
 
 /mob/living/simple_animal/hostile/humanoid/janitor/Shoot(var/atom/target, var/atom/start, var/mob/user)
-	if(prob(30) && CS.reagents.has_reagent(LUBE))
+	if(prob(30) && CS.reagents.has_any_reagents(LUBES))
 		visible_message("<span class = 'warning'>\The [src] lets loose a blast of lubricant from their chemical sprayer!</span>")
 		playsound(src, 'sound/effects/spray2.ogg', 50, 1, -6)
 		CS.make_puff(target, user)

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -309,7 +309,7 @@
 	id = CHERRYLUBE
 	result = CHERRYLUBE
 	required_reagents = list(LUBE = 1, CHERRYJELLY = 1)
-	result_amount = 1
+	result_amount = 2
 
 /datum/chemical_reaction/sodium_polyacrylate
 	name = "Sodium Polyacrylate"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -329,14 +329,14 @@
 	name = "Absorb Lube"
 	id = "absorblube"
 	result = CHEMICAL_WASTE
-	required_reagents = list(SODIUM_POLYACRYLATE = 0.3, LUBE = 1)
+	required_reagents = list(SODIUM_POLYACRYLATE = 0.3, LUBES = 1)
 	result_amount = 0.3
 
 /datum/chemical_reaction/sludge
 	name = "Sludge"
 	id = CHEMICAL_WASTE
 	result = CHEMICAL_WASTE
-	required_reagents = list(LUBE = 1)
+	required_reagents = list(LUBES = 1)
 	result_amount = 0.2
 	required_temp = 3500
 	react_discretely = TRUE

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -304,6 +304,13 @@
 	required_reagents = list(WATER = 2, SILICA = 3, SILICON = 1)
 	result_amount = 8
 
+/datum/chemical_reaction/cherrylube
+	name = "Cherry-Flavored Lube"
+	id = CHERRYLUBE
+	result = CHERRYLUBE
+	required_reagents = list(LUBE = 1, CHERRYJELLY = 1)
+	result_amount = 1
+
 /datum/chemical_reaction/sodium_polyacrylate
 	name = "Sodium Polyacrylate"
 	id = SODIUM_POLYACRYLATE

--- a/code/modules/reagents/reagents/reagents_tools.dm
+++ b/code/modules/reagents/reagents/reagents_tools.dm
@@ -141,6 +141,14 @@
 	if(volume >= 1)
 		T.wet(800, TURF_WET_LUBE)
 
+/datum/reagent/lube/cherry
+	name = "Cherry-Flavored Lube"
+	id = CHERRYLUBE
+	description = "Your favorite."
+	color = "#FF80B0"
+	density = 1.11775
+	specheatcap = 2.71388
+
 /datum/reagent/luminol
 	name = "Luminol"
 	id = LUMINOL

--- a/code/modules/reagents/reagents/reagents_tools.dm
+++ b/code/modules/reagents/reagents/reagents_tools.dm
@@ -133,13 +133,14 @@
 	overdose_am = REAGENTS_OVERDOSE
 	density = 1.11775
 	specheatcap = 2.71388
+	var/lube_color = null
 
 /datum/reagent/lube/reaction_turf(var/turf/simulated/T, var/volume)
 	if(..())
 		return 1
 
 	if(volume >= 1)
-		T.wet(800, TURF_WET_LUBE)
+		T.wet(800, TURF_WET_LUBE, lube_color)
 
 /datum/reagent/lube/cherry
 	name = "Cherry-Flavored Lube"
@@ -148,6 +149,7 @@
 	color = "#FF80B0"
 	density = 1.11775
 	specheatcap = 2.71388
+	lube_color = "#FF80B0"
 
 /datum/reagent/luminol
 	name = "Luminol"


### PR DESCRIPTION
[content]

## What this does
<img width="187" height="285" alt="image" src="https://github.com/user-attachments/assets/45ea68ed-f3b8-486f-b652-b6307354bc87" />

Adds it as a subtype of space lube, mixing it with cherry jelly.
Functionally the exact same except for a slightly different floor-wet color.

## Why it's good
Extra use for cherry jelly for extra lube, for things like the TEG.

## How it was tested
Mixing cherry jelly and space lube in a beaker, pouring some on the floor.

## Changelog
:cl:
 * rscadd: One day while mixing cherry jelly and space lube, players got cherry flavored lube! Their favorite, it works the same as regular lube, including in sodium polyacrylate recipes, with a more cherry tinged hue on floors.