### PR TITLE
Halves medium fence hole climb through time

### DIFF
--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -4,7 +4,7 @@
 
 //Fence smashing sound downloaded from http://freesound.org/people/hintringer/sounds/274768/
 
-#define CLIMB_TIME (20 SECONDS)
+#define CLIMB_TIME (10 SECONDS)
 
 #define NO_HOLE 0 //section is intact
 #define SMALL_HOLE 1 //small hole in the section - can pass small items through.


### PR DESCRIPTION
[tweak]

## What this does
Done separately from #38969 for atomicity sake.

## Why it's good
Makes them even easier to deal with.

## How it was tested
Climbing through a spawned medium sized hole fence.

## Changelog
:cl:
 * tweak: Fences with medium sized holes now take half as long to climb through, 10 seconds, down from 20.