### PR TITLE
Fixes charge gene being blocked by table doors

### DIFF
--- a/code/modules/dna/genes/vg_powers.dm
+++ b/code/modules/dna/genes/vg_powers.dm
@@ -271,6 +271,10 @@ Obviously, requires DNA2.
                 var/obj/structure/table/T = O
                 T.destroy()
                 breakthrough = 1
+            else if(istype(O, /obj/machinery/door/table))
+                var/obj/machinery/door/table/TD = O
+                TD.dismantle()
+                breakthrough = 1
             else if(istype(O, /obj/structure/rack))
                 new /obj/item/weapon/rack_parts(O.loc)
                 qdel(O)


### PR DESCRIPTION
[consistency][bugfix]

## What this does
Closes #39128.

## How it was tested
Activating gene, spawning table door, using charge spell on it.

## Changelog
:cl:
 * bugfix: The charge gene's spell now works on breaking table doors too.