### PR TITLE
Soldering fixes

### DIFF
--- a/code/game/turfs/simulated/invulnerable_wall.dm
+++ b/code/game/turfs/simulated/invulnerable_wall.dm
@@ -16,20 +16,12 @@
 	penetration_dampening = 40
 
 /turf/simulated/wall/invulnerable/attackby(obj/item/W as obj, mob/user as mob)
-
 	if (!user.dexterity_check())
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return
 
-	if(istype(W,/obj/item/tool/solder) && bullet_marks)
-		var/obj/item/tool/solder/S = W
-		if(!S.remove_fuel(bullet_marks*2,user))
-			return
-		S.playtoolsound(loc, 100)
-		to_chat(user, "<span class='notice'>You remove the bullet marks with \the [W].</span>")
-		bullet_marks = 0
-		icon = initial(icon)
-		return
+	if(issolder(W) && bullet_marks)
+		remove_holes(W,user)
 
 /turf/simulated/wall/invulnerable/attack_construct(mob/user as mob)
 	return 0

--- a/code/game/turfs/simulated/shuttle.dm
+++ b/code/game/turfs/simulated/shuttle.dm
@@ -31,14 +31,8 @@
 	if (!user.dexterity_check())
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return
-	if(istype(W,/obj/item/tool/solder) && bullet_marks)
-		var/obj/item/tool/solder/S = W
-		if(!S.remove_fuel(bullet_marks*2,user))
-			return
-		S.playtoolsound(loc, 100)
-		to_chat(user, "<span class='notice'>You remove the bullet marks with \the [W].</span>")
-		bullet_marks = 0
-		icon = initial(icon)
+	if(issolder(W) && bullet_marks)
+		remove_holes(W,user)
 
 /turf/simulated/wall/shuttle/ex_act(severity)
 	return

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -214,22 +214,24 @@
 /turf/simulated/wall/r_wall/attack_rotting(mob/user as mob)
 	to_chat(user, "<span class='notice'>This [src] feels rather unstable.</span>")
 
+/turf/simulated/wall/proc/remove_holes(obj/item/weapon/solder/S, mob/user)
+	if(!S.remove_fuel(bullet_marks*2,user))
+		return
+	S.playtoolsound(loc, 100)
+	to_chat(user, "<span class='notice'>You remove the hole[bullet_marks > 1 ? "s" : ""] with \the [W].</span>")
+	bullet_marks = 0
+	icon = initial(icon)
+	if(peepers)
+		reset_view()
+
 /turf/simulated/wall/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	user.delayNextAttack(W.attack_delay)
 	if (!user.dexterity_check())
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return
 
-	if(istype(W,/obj/item/tool/solder) && bullet_marks)
-		var/obj/item/tool/solder/S = W
-		if(!S.remove_fuel(bullet_marks*2,user))
-			return
-		playsound(loc, 'sound/items/Welder.ogg', 100, 1)
-		to_chat(user, "<span class='notice'>You remove the hole[bullet_marks > 1 ? "s" : ""] with \the [W].</span>")
-		bullet_marks = 0
-		icon = initial(icon)
-		if(peepers)
-			reset_view()
+	if(issolder(W) && bullet_marks)
+		remove_holes(W,user)
 		return
 
 	//Get the user's location

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -217,7 +217,7 @@
 /turf/simulated/wall/proc/remove_holes(obj/item/tool/solder/S, mob/user)
 	if(!S.remove_fuel(bullet_marks*2,user))
 		return
-	S.playtoolsound(loc, 100)
+	S.playtoolsound(src, 100)
 	to_chat(user, "<span class='notice'>You remove the hole[bullet_marks > 1 ? "s" : ""] with \the [S].</span>")
 	bullet_marks = 0
 	icon = initial(icon)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -214,7 +214,7 @@
 /turf/simulated/wall/r_wall/attack_rotting(mob/user as mob)
 	to_chat(user, "<span class='notice'>This [src] feels rather unstable.</span>")
 
-/turf/simulated/wall/proc/remove_holes(obj/item/weapon/solder/S, mob/user)
+/turf/simulated/wall/proc/remove_holes(obj/item/tool/solder/S, mob/user)
 	if(!S.remove_fuel(bullet_marks*2,user))
 		return
 	S.playtoolsound(loc, 100)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -218,7 +218,7 @@
 	if(!S.remove_fuel(bullet_marks*2,user))
 		return
 	S.playtoolsound(loc, 100)
-	to_chat(user, "<span class='notice'>You remove the hole[bullet_marks > 1 ? "s" : ""] with \the [W].</span>")
+	to_chat(user, "<span class='notice'>You remove the hole[bullet_marks > 1 ? "s" : ""] with \the [S].</span>")
 	bullet_marks = 0
 	icon = initial(icon)
 	if(peepers)

--- a/code/game/turfs/simulated/walls_reinforced.dm
+++ b/code/game/turfs/simulated/walls_reinforced.dm
@@ -61,14 +61,8 @@
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return
 
-	if(istype(W,/obj/item/tool/solder) && bullet_marks)
-		var/obj/item/tool/solder/S = W
-		if(!S.remove_fuel(bullet_marks*2,user))
-			return
-		playsound(loc, 'sound/items/Welder.ogg', 100, 1)
-		to_chat(user, "<span class='notice'>You remove the bullet marks with \the [W].</span>")
-		bullet_marks = 0
-		icon = initial(icon)
+	if(issolder(W) && bullet_marks)
+		remove_holes(W,user)
 		return
 
 	//Get the user's location

--- a/code/game/turfs/unsimulated/walls.dm
+++ b/code/game/turfs/unsimulated/walls.dm
@@ -54,7 +54,7 @@
 	if (!user.dexterity_check())
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return
-	if(istype(W,/obj/item/tool/solder) && bullet_marks)
+	if(issolder(W) && bullet_marks)
 		var/obj/item/tool/solder/S = W
 		if(!S.remove_fuel(bullet_marks*2,user))
 			return

--- a/code/modules/media/broadcast/transmitters/broadcast.dm
+++ b/code/modules/media/broadcast/transmitters/broadcast.dm
@@ -101,6 +101,7 @@
 		if(S.do_solder(user, src,4 SECONDS, 4))
 			S.playtoolsound(loc, 100)
 			integrity = 100
+			update_icon()
 			to_chat(user, "<span class='notice'>You repair the blown fuses on [src].</span>")
 
 /obj/machinery/media/transmitter/broadcast/attack_hand(var/mob/user as mob)


### PR DESCRIPTION
## What this does
[bugfix][sprites]

## How it was tested
Calling emp_act(1) on a transmitter, using a solder on it.
Shooting a preloaded railgun through an rwall and a shuttle wall, using a solder on each.

## Changelog
:cl:
 * bugfix: Solder repaired transmitters now update their sprite properly.
 * bugfix: Solder repairing bullet holes in all types of walls now properly resets view through it.