### PR TITLE
Bumping into a diagonal wall moves you along it

### DIFF
--- a/code/game/turfs/simulated/shuttle.dm
+++ b/code/game/turfs/simulated/shuttle.dm
@@ -156,7 +156,7 @@
 		adjacent = get_step(src,counterclockwise_perpendicular_dirs[dir])
 	else if(get_dir(src,AM) == counterclockwise_perpendicular_dirs[dir])
 		dest = get_step(AM,dir)
-		adjacent = get_step(screen_alarms_locs,dir)
+		adjacent = get_step(src,dir)
 	if(!adjacent.density && !adjacent.has_dense_content())
 		if(!dest.density)
 			var/obj/structure/shuttle/diag_wall/other = locate() in dest

--- a/code/game/turfs/simulated/shuttle.dm
+++ b/code/game/turfs/simulated/shuttle.dm
@@ -147,6 +147,13 @@
 		return 0
 	return !density
 
+/obj/structure/shuttle/diag_wall/Bumped(atom/movable/AM)
+	. = ..()
+	if(get_dir(src,AM) == dir)
+		AM.Move(get_step(AM,counterclockwise_perpendicular_dirs[dir]))
+	else if(get_dir(src,AM) == counterclockwise_perpendicular_dirs[dir])
+		AM.Move(get_step(AM,dir))
+
 /obj/structure/shuttle/diag_wall/ex_act(severity)
 	return
 

--- a/code/game/turfs/simulated/shuttle.dm
+++ b/code/game/turfs/simulated/shuttle.dm
@@ -158,6 +158,10 @@
 		dest = get_step(AM,dir)
 		adjacent = get_step(screen_alarms_locs,dir)
 	if(!adjacent.density && !adjacent.has_dense_content())
+		if(!dest.density)
+			var/obj/structure/shuttle/diag_wall/other = locate() in dest
+			if(other && other.dir = opposite_dirs[dir] && !dest.has_dense_content(other))
+				dest = adjacent
 		AM.Move(dest)
 
 /obj/structure/shuttle/diag_wall/ex_act(severity)

--- a/code/game/turfs/simulated/shuttle.dm
+++ b/code/game/turfs/simulated/shuttle.dm
@@ -149,10 +149,16 @@
 
 /obj/structure/shuttle/diag_wall/Bumped(atom/movable/AM)
 	. = ..()
+	var/turf/dest
+	var/turf/adjacent
 	if(get_dir(src,AM) == dir)
-		AM.Move(get_step(AM,counterclockwise_perpendicular_dirs[dir]))
+		dest = get_step(AM,counterclockwise_perpendicular_dirs[dir])
+		adjacent = get_step(src,counterclockwise_perpendicular_dirs[dir])
 	else if(get_dir(src,AM) == counterclockwise_perpendicular_dirs[dir])
-		AM.Move(get_step(AM,dir))
+		dest = get_step(AM,dir)
+		adjacent = get_step(screen_alarms_locs,dir)
+	if(!adjacent.density && !adjacent.has_dense_content())
+		AM.Move(dest)
 
 /obj/structure/shuttle/diag_wall/ex_act(severity)
 	return

--- a/code/game/turfs/simulated/shuttle.dm
+++ b/code/game/turfs/simulated/shuttle.dm
@@ -160,7 +160,7 @@
 	if(!adjacent.density && !adjacent.has_dense_content())
 		if(!dest.density)
 			var/obj/structure/shuttle/diag_wall/other = locate() in dest
-			if(other && other.dir = opposite_dirs[dir] && !dest.has_dense_content(other))
+			if(other && other.dir == opposite_dirs[dir] && !dest.has_dense_content(other))
 				dest = adjacent
 		AM.Move(dest)
 


### PR DESCRIPTION
[tweak]

## What this does

https://github.com/user-attachments/assets/67f61494-47ff-4331-bb6b-903581d65f61

Namely, if facing its concave side, pushes you out to the other direction facing said side if neither the turf adjacent to the wall or yourself in that direction is dense... unless there's an opposite facing diagonal wall there, in which case you get pushed directly to the tile beside the first wall.

## Why it's good
Coming to a stop at them felt too odd.

## How it was tested
Walking into a concave side of a spawned wall, with and without a closed closet placed on each relevent tile.

## Changelog
:cl:
 * tweak: Bumping into the diagonal end of a diagonal shuttle wall now moves you "along" the wall cardinally, if the other side facing that end has free space to move into opposite of it or yourself in that direction. If another diagonal wall is on the tile facing the other way, you move directly into the tile beside the first wall.