### PR TITLE
More wet/dry vacuum reagents

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -302,6 +302,7 @@ var/global/list/blood_list = list()
 	gender = PLURAL
 	density = 0
 	anchored = 1
+	reagent = MUCUS
 	icon = 'icons/effects/blood.dmi'
 	icon_state = "mucus"
 	random_icon_states = list("mucus")

--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -207,6 +207,7 @@
 	desc = "Some kind of fruit smear."
 	density = 0
 	anchored = 1
+	reagent = NUTRIMENT
 	icon = 'icons/effects/tomatodecal.dmi'
 	random_icon_states = list("fruit_smudge1", "fruit_smudge2", "fruit_smudge3")
 	icon_state = "fruit_smudge1"
@@ -225,6 +226,7 @@
 	desc = "It's pie cream from a cream pie."
 	density = 0
 	anchored = 1
+	reagent = NUTRIMENT
 	icon = 'icons/effects/tomatodecal.dmi'
 	random_icon_states = list("smashed_pie")
 
@@ -242,6 +244,7 @@
 	desc = "Now how are you gonna sweep it back up, smartass?"
 	density = 0
 	anchored = 1
+	reagent = SILICA
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "sand"
 	gender = PLURAL
@@ -502,6 +505,7 @@ var/list/salts_particle_emitters = list(
 	gender = PLURAL
 	density = 0
 	anchored = 1
+	reagent = FAKE_CREEP
 	icon = 'icons/mob/alien.dmi'
 	icon_state = "weeds"
 
@@ -510,6 +514,7 @@ var/list/salts_particle_emitters = list(
 	desc = "The floor is sticky!"
 	density = 0
 	anchored = 1
+	reagent = GLUE
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "glue"
 	color = COLOR_GLUE

--- a/code/game/objects/effects/decals/Cleanable/robots.dm
+++ b/code/game/objects/effects/decals/Cleanable/robots.dm
@@ -1,6 +1,7 @@
 /obj/effect/decal/cleanable/blood/gibs/robot
 	name = "robot debris"
 	desc = "It's a useless heap of junk... <i>or is it?</i>"
+	reagent = IRON
 	icon = 'icons/mob/robots.dmi'
 	icon_state = "gib1"
 	basecolor=ROBOT_OIL
@@ -42,7 +43,7 @@
 	name = "motor oil"
 	desc = "It's black and greasy. Looks like Beepsky made another mess."
 	basecolor=ROBOT_OIL
-
+	reagent = FUEL
 	fake_DNA = "oil splatters"
 	stain_name = "oil"
 


### PR DESCRIPTION
[oversight]

## What this does
Closes #39120.

## How it was tested
Spawning the cleanables and a wet dry vacuum, using it on it, checking the vacuums reagents datum.

## Changelog
:cl:
 * tweak: Wet dry vacuums can now suck reagents up from scattered sand, fruit smudges, pie smudges, fake alien weeds, glue, mucus and robot oil.