### PR TITLE
Odyssey Fixes

### DIFF
--- a/code/controllers/shuttle_controller.dm
+++ b/code/controllers/shuttle_controller.dm
@@ -172,6 +172,11 @@ var/global/datum/emergency_shuttle/emergency_shuttle
 			else
 				D.open()
 
+// Returns the shuttle's linked docking port for use in admin log messages.
+// Overridden by map-specific subtypes that don't use the escape shuttle var.
+/datum/emergency_shuttle/proc/get_linked_port()
+	return shuttle ? shuttle.linked_port : null
+
 /datum/emergency_shuttle/proc/force_shutdown()
 	online=0
 	shutdown=1

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -862,50 +862,6 @@
 
 //////////////////////////////////////////////
 //                                          //
-//          ODYSSEY XENOMORPH               ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//                                          //
-//////////////////////////////////////////////
-
-/datum/dynamic_ruleset/midround/from_ghosts/faction_based/odyssey_xeno
-	name = "Alien Stowaway"
-	role_category = /datum/role/xenomorph
-	enemy_jobs = list()
-	required_pop = list(0,0,0,0,0,0,0,0,0,0)
-	required_enemies = list(0,0,0,0,0,0,0,0,0,0)
-	required_candidates = 1
-	max_candidates = 1
-	weight = 12
-	weight_category = "Alien"
-	cost = 5
-	requirements = list(20,15,10,10,10,10,10,10,10,10)
-	high_population_requirement = 10
-	logo = "xeno-logo"
-	my_fac = /datum/faction/xenomorph
-
-/datum/dynamic_ruleset/midround/from_ghosts/faction_based/odyssey_xeno/ready(var/forced = 0)
-	if(map.nameShort != "odyssey")
-		return FALSE
-
-	if(!xeno_spawn.len)
-		log_admin("Odyssey xeno ruleset: No xeno_spawn landmarks found.")
-		message_admins("Odyssey xeno ruleset: No xeno_spawn landmarks found.")
-		return FALSE
-
-	return ..()
-
-/datum/dynamic_ruleset/midround/from_ghosts/faction_based/odyssey_xeno/generate_ruleset_body(var/mob/applicant)
-	var/turf/spawn_loc = pick(xeno_spawn)
-	var/mob/living/carbon/alien/larva/new_xeno = new(spawn_loc)
-	new_xeno.key = applicant.key
-	new_xeno << sound('sound/voice/alienspawn.ogg')
-
-	spawn(rand(90 SECONDS, 120 SECONDS))
-		captain_announce("Unidentified life signs detected aboard the NTEV Odyssey.")
-
-	return new_xeno
-
-//////////////////////////////////////////////
-//                                          //
 //                PULSE DEMON               ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //                                          //
 //////////////////////////////////////////////

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -292,6 +292,17 @@ var/list/meteor_warnings = list()
 	explosion(get_turf(src), -1, 1, 3, 4, 0, 1, 0) //Tiny meteor doesn't cause too much damage
 	qdel(src)
 
+/obj/item/projectile/meteor/small/microdebris
+	name = "micro debris"
+	desc = "A tiny fragment of rock. It stings."
+
+/obj/item/projectile/meteor/small/microdebris/to_bump(atom/A)
+	if(loc == null)
+		return
+
+	explosion(get_turf(src), -1, 0, 1, 2, 0, 1, 0)
+	qdel(src)
+
 /obj/item/projectile/meteor/small/flash
 	name = "flash meteor"
 	desc = "A absolutely stunning rock specimen of blinding beauty."

--- a/code/game/machinery/planet_scanner.dm
+++ b/code/game/machinery/planet_scanner.dm
@@ -657,6 +657,7 @@
 	if(waiting_for_generation && !scanning)
 		if(!SSmapping.generating)
 			waiting_for_generation = FALSE
+			SSmapping.scanning = FALSE
 			scans_completed++
 			playsound(src, 'sound/machines/twobeep.ogg', 50, 1)
 			visible_message("<span class='notice'>[src] has passively detected a new planet in hyperspace.</span>")

--- a/code/modules/admin/emergency_shuttle_panel.dm
+++ b/code/modules/admin/emergency_shuttle_panel.dm
@@ -8,8 +8,11 @@
 	dat += "Current Status:"
 
 	var/area/shuttle_loc = locate(/area/shuttle/escape/centcom)
-	var/turf/shuttle_turf = pick(shuttle_loc.area_turfs)
-	dat += "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[shuttle_turf.x];Y=[shuttle_turf.y];Z=[shuttle_turf.z]'>"
+	var/turf/shuttle_turf = shuttle_loc ? pick(shuttle_loc.area_turfs) : null
+	if(shuttle_turf)
+		dat += "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[shuttle_turf.x];Y=[shuttle_turf.y];Z=[shuttle_turf.z]'>"
+	else
+		dat += "<span>"
 
 	switch (emergency_shuttle.location)
 		if(0)
@@ -27,7 +30,7 @@
 		if(2)
 			dat += "<b>At Central Command</b> (Round Ended)"
 
-	dat += "</a><br>"
+	dat += shuttle_turf ? "</a><br>" : "</span><br>"
 
 	if (!emergency_shuttle.online)
 		dat += "<a href='?src=\ref[src];call_shuttle=1'>Call Shuttle</a><br>"

--- a/code/modules/admin/emergency_shuttle_panel.dm
+++ b/code/modules/admin/emergency_shuttle_panel.dm
@@ -8,7 +8,7 @@
 	dat += "Current Status:"
 
 	var/area/shuttle_loc = locate(/area/shuttle/escape/centcom)
-	var/turf/shuttle_turf = shuttle_loc ? pick(shuttle_loc.area_turfs) : null
+	var/turf/shuttle_turf = (shuttle_loc && shuttle_loc.area_turfs && shuttle_loc.area_turfs.len) ? pick(shuttle_loc.area_turfs) : null
 	if(shuttle_turf)
 		dat += "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[shuttle_turf.x];Y=[shuttle_turf.y];Z=[shuttle_turf.z]'>"
 	else

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -418,9 +418,12 @@
 						casual = 0
 					if("No")
 						emergency_shuttle.shuttle_phase("centcom",1)
-		var/obj/docking_port/shuttle/P = emergency_shuttle.shuttle.linked_port
+		var/obj/docking_port/shuttle/P = emergency_shuttle.get_linked_port()
 		log_admin("[key_name(usr)] moved the emergency shuttle to [href_list["move_emergency_shuttle"]][casual?" (no round triggers)":""].</span>")
-		message_admins("<span class='notice'>[key_name_admin(usr)] moved the emergency shuttle to <a href='?_src_=holder;adminplayerobservecoodjump=1;X=[P.x];Y=[P.y];Z=[P.z]'>[href_list["move_emergency_shuttle"]]</a>[casual?" (no round triggers)":""].</span>", 1)
+		if(P)
+			message_admins("<span class='notice'>[key_name_admin(usr)] moved the emergency shuttle to <a href='?_src_=holder;adminplayerobservecoodjump=1;X=[P.x];Y=[P.y];Z=[P.z]'>[href_list["move_emergency_shuttle"]]</a>[casual?" (no round triggers)":""].</span>", 1)
+		else
+			message_admins("<span class='notice'>[key_name_admin(usr)] moved the emergency shuttle to [href_list["move_emergency_shuttle"]][casual?" (no round triggers)":""].</span>", 1)
 		href_list["secretsadmin"] = "emergency_shuttle_panel"
 
 	else if(href_list["move_emergency_dock"])
@@ -428,6 +431,9 @@
 			return
 		var/obj/docking_port/destination/port
 		var/datum/shuttle/escape/E = emergency_shuttle.shuttle
+		if(!E)
+			alert("This shuttle type does not support dock repositioning.")
+			return
 		switch (href_list["move_emergency_dock"])
 			if ("station")
 				port = E.dock_station
@@ -446,6 +452,9 @@
 			return
 		var/obj/docking_port/destination/port
 		var/datum/shuttle/escape/E = emergency_shuttle.shuttle
+		if(!E)
+			alert("This shuttle type does not support dock repositioning.")
+			return
 		switch (href_list["reset_emergency_dock"])
 			if ("station")
 				port = E.dock_station

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -343,6 +343,13 @@ Doesn't work on other aliens/AI.*/
 	return ..()
 
 /spell/aoe_turf/evolve/larva/spell_do_after(mob/living/carbon/alien/user)
+	if(istype(user,/mob/living/carbon/alien))
+		var/mob/living/carbon/alien/larva/L = user
+		if(L.stowaway)
+			to_chat(user, "<span class='notice'><B>You are a lone stowaway - the only path open to you is that of the Hunter.</B></span>")
+			spawning = /mob/living/carbon/alien/humanoid/hunter
+			return ..()
+
 	var/explanation_message = {"<span class='notice'><B>You are growing into a beautiful alien! It is time to choose a caste.</B><br>
 	There are three castes to choose from:<br>
 	<B>Hunters</B> are strong and agile, able to hunt away from the hive and rapidly move through ventilation shafts. Hunters generate plasma slowly and have low reserves.<br>

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -13,6 +13,7 @@
 
 	var/growth = 0
 	var/time_of_birth
+	var/stowaway = FALSE // If TRUE, evolution is restricted to Hunter only (set by odyssey_xeno ruleset)
 
 //This is fine right now, if we're adding organ specific damage this needs to be updated
 /mob/living/carbon/alien/larva/New()

--- a/code/modules/procedural mapping/planetGenerator/story_generator/_story_generator.dm
+++ b/code/modules/procedural mapping/planetGenerator/story_generator/_story_generator.dm
@@ -506,7 +506,7 @@ var/list/datum/story_theme/story_themes = list()
 		return
 
 	activating = TRUE
-	var/reboot_time = rand(5, 15) MINUTES
+	var/reboot_time = (map.nameShort == "odyssey") ? rand(2, 5) MINUTES : rand(5, 15) MINUTES
 
 	visible_message("<span class='notice'>\The [src] begins to hum as [user] initiates the boot sequence...</span>")
 	playsound(src, 'sound/machines/click.ogg', 50, 1)

--- a/maps/odyssey.dmm
+++ b/maps/odyssey.dmm
@@ -46,17 +46,14 @@
 	name = "Engineering Supplies";
 	id_tag = "eng supplies";
 	pixel_y = 25;
-	pixel_x = -5
+	pixel_x = -5;
+	req_one_access_txt = "11"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layered{
 	dir = 10;
 	tag = ""
 	},
 /obj/machinery/camera/autoname,
-/obj/effect/landmark{
-	name = "xeno_spawn";
-	pixel_x = -1
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -175,10 +172,6 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/effect/landmark{
-	name = "xeno_spawn";
-	pixel_x = -1
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -2222,10 +2215,6 @@
 	},
 /area/surface/nt_outpost/clinic)
 "he" = (
-/obj/effect/landmark{
-	name = "xeno_spawn";
-	pixel_x = -1
-	},
 /turf/simulated/floor/plating,
 /area/shuttle/odyssey/maintenance/port)
 "hh" = (
@@ -2598,10 +2587,6 @@
 	dir = 1;
 	on = 1
 	},
-/obj/effect/landmark{
-	name = "xeno_spawn";
-	pixel_x = -1
-	},
 /turf/simulated/floor/wood,
 /area/shuttle/odyssey/quarters/crew)
 "iJ" = (
@@ -2719,10 +2704,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/obj/effect/landmark{
-	name = "xeno_spawn";
-	pixel_x = -1
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -2804,10 +2785,6 @@
 "jr" = (
 /obj/structure/wc/toilet{
 	pixel_y = 8
-	},
-/obj/effect/landmark{
-	name = "xeno_spawn";
-	pixel_x = -1
 	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
@@ -6748,7 +6725,8 @@
 	name = "Starboard Gas Storage Lockdown";
 	id_tag = "starboard gas";
 	pixel_y = -27;
-	pixel_x = 8
+	pixel_x = 8;
+	req_access_txt = "11"
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/odyssey/engineering/gas_storage/starboard)
@@ -7211,7 +7189,8 @@
 	name = "Port Gas Storage Lockdown";
 	id_tag = "port gas";
 	pixel_y = 27;
-	pixel_x = 8
+	pixel_x = 8;
+	req_one_access_txt = "11"
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/odyssey/engineering/gas_storage/port)
@@ -8172,10 +8151,6 @@
 	d2 = 2;
 	icon_state = "0-2";
 	pixel_y = 1
-	},
-/obj/effect/landmark{
-	name = "xeno_spawn";
-	pixel_x = -1
 	},
 /obj/machinery/light_switch{
 	pixel_x = 12;
@@ -10560,10 +10535,6 @@
 	},
 /obj/machinery/media/receiver/boombox/wallmount/muzak{
 	pixel_x = -30
-	},
-/obj/effect/landmark{
-	name = "xeno_spawn";
-	pixel_x = -1
 	},
 /turf/simulated/floor/wood,
 /area/shuttle/odyssey/quarters/heads)
@@ -14795,10 +14766,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
-	},
-/obj/effect/landmark{
-	name = "xeno_spawn";
-	pixel_x = -1
 	},
 /turf/simulated/floor{
 	icon_state = "dark"

--- a/maps/odyssey.dmm
+++ b/maps/odyssey.dmm
@@ -2508,7 +2508,6 @@
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/supply)
 "iu" = (
-/obj/machinery/door/airlock/engineering,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -2526,6 +2525,7 @@
 	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance_hatch,
 /turf/simulated/floor/plated_catwalk/dark,
 /area/shuttle/odyssey/hallway/starboard)
 "iv" = (
@@ -4156,6 +4156,8 @@
 	pixel_y = -30;
 	dir = 1
 	},
+/obj/item/weapon/circuitboard/shuttle_control/odyssey,
+/obj/item/weapon/circuitboard/communications/odyssey,
 /turf/simulated/floor/wood,
 /area/shuttle/odyssey/quarters/heads)
 "nU" = (
@@ -5300,15 +5302,10 @@
 	pixel_x = -4;
 	pixel_y = -5
 	},
-/obj/item/weapon/storage/box/flashbangs{
-	pixel_x = 4;
-	pixel_y = 5
-	},
 /obj/item/weapon/storage/box/smokebombs{
 	pixel_x = 5;
 	pixel_y = -5
 	},
-/obj/item/weapon/storage/box/smokebombs,
 /obj/machinery/media/receiver/boombox/wallmount/muzak{
 	pixel_y = -30
 	},
@@ -5409,7 +5406,9 @@
 /turf/simulated/floor/shuttle,
 /area/shuttle/odyssey_transfer)
 "sB" = (
-/obj/machinery/door/airlock/glass_command,
+/obj/machinery/door/airlock/glass_command{
+	req_access_txt = "19"
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -5484,8 +5483,8 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/engineering,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance_hatch,
 /turf/simulated/floor/plated_catwalk/dark,
 /area/shuttle/odyssey/hallway/port)
 "sL" = (
@@ -7181,7 +7180,8 @@
 	name = "Engineering RC";
 	pixel_y = -30
 	},
-/obj/item/weapon/circuitboard/communications,
+/obj/item/weapon/circuitboard/communications/odyssey,
+/obj/item/weapon/circuitboard/shuttle_control/odyssey,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -7403,7 +7403,9 @@
 /turf/unsimulated/floor/planetary/concrete,
 /area/shuttle/odyssey_transfer)
 "yM" = (
-/obj/machinery/door/airlock/engineering,
+/obj/machinery/door/airlock/engineering{
+	req_access_txt = "11"
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -8363,7 +8365,7 @@
 	},
 /area/surface/nt_outpost/admin)
 "Cb" = (
-/obj/machinery/computer/communications,
+/obj/machinery/computer/communications/odyssey,
 /turf/simulated/floor{
 	icon_state = "dark_navy";
 	tag = "icon-dark_navy (WEST)"
@@ -10779,7 +10781,9 @@
 /turf/unsimulated/floor/planetary/concrete,
 /area/surface/nt_outpost)
 "KB" = (
-/obj/machinery/door/airlock/glass_atmos,
+/obj/machinery/door/airlock/glass_atmos{
+	req_access_txt = "11"
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -11485,7 +11489,9 @@
 	},
 /area/surface/nt_outpost/clinic)
 "MJ" = (
-/obj/machinery/door/airlock/glass_command,
+/obj/machinery/door/airlock/glass_command{
+	req_access_txt = "19"
+	},
 /obj/machinery/atmospherics/pipe/layer_adapter/scrubbers/hidden{
 	dir = 4
 	},
@@ -11699,7 +11705,9 @@
 /turf/simulated/floor/plating,
 /area/shuttle/odyssey/maintenance/starboard)
 "Nw" = (
-/obj/machinery/door/airlock/engineering,
+/obj/machinery/door/airlock/engineering{
+	req_access_txt = "11"
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -12459,7 +12467,9 @@
 /turf/simulated/floor/plating/vox,
 /area/shuttle/trade/start)
 "PS" = (
-/obj/machinery/door/airlock/glass_atmos,
+/obj/machinery/door/airlock/glass_atmos{
+	req_access_txt = "11"
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -12876,7 +12886,9 @@
 /turf/simulated/floor/wood,
 /area/derelict/bar)
 "QV" = (
-/obj/machinery/door/airlock/engineering,
+/obj/machinery/door/airlock/engineering{
+	req_access_txt = "11"
+	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
@@ -14668,7 +14680,9 @@
 /turf/simulated/floor/plating,
 /area/shuttle/odyssey/engineering/engine_room)
 "WH" = (
-/obj/machinery/door/airlock/security,
+/obj/machinery/door/airlock/security{
+	req_access_txt = "1"
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;

--- a/maps/odyssey/events.dm
+++ b/maps/odyssey/events.dm
@@ -256,9 +256,6 @@
 	return valid_spawns
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/odyssey_xeno/ready(var/forced = 0)
-	if(map.nameShort != "odyssey")
-		return FALSE
-
 	var/list/spawns = get_valid_spawns()
 	if(!spawns.len)
 		log_admin("Odyssey xeno ruleset: No valid shuttle spawn turfs found.")

--- a/maps/odyssey/events.dm
+++ b/maps/odyssey/events.dm
@@ -235,36 +235,45 @@
 	logo = "xeno-logo"
 	my_fac = /datum/faction/xenomorph
 
+/datum/dynamic_ruleset/midround/from_ghosts/faction_based/odyssey_xeno/proc/get_valid_spawns()
+	var/list/valid_area_types = list(
+		/area/shuttle/odyssey/engineering,
+		/area/shuttle/odyssey/maintenance/port,
+		/area/shuttle/odyssey/maintenance/starboard,
+		/area/shuttle/odyssey/janitor,
+		/area/shuttle/odyssey/restroom,
+		/area/shuttle/odyssey/quarters/crew,
+		/area/shuttle/odyssey/quarters/heads
+	)
+	var/list/valid_spawns = list()
+	for(var/area/shuttle/odyssey/A in world)
+		if(!(A.type in valid_area_types))
+			continue
+		for(var/turf/simulated/floor/T in A)
+			if(T.density)
+				continue
+			valid_spawns += T
+	return valid_spawns
+
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/odyssey_xeno/ready(var/forced = 0)
 	if(map.nameShort != "odyssey")
 		return FALSE
 
-	if(!xeno_spawn.len)
-		log_admin("Odyssey xeno ruleset: No xeno_spawn landmarks found.")
-		message_admins("Odyssey xeno ruleset: No xeno_spawn landmarks found.")
-		return FALSE
-
-	var/list/valid_spawns = list()
-	for(var/turf/T in xeno_spawn)
-		if(istype(get_area(T), /area/shuttle/odyssey))
-			valid_spawns += T
-
-	if(!valid_spawns.len)
-		log_admin("Odyssey xeno ruleset: No xeno_spawn landmarks are currently on the shuttle.")
-		message_admins("Odyssey xeno ruleset: No xeno_spawn landmarks are currently on the shuttle.")
+	var/list/spawns = get_valid_spawns()
+	if(!spawns.len)
+		log_admin("Odyssey xeno ruleset: No valid shuttle spawn turfs found.")
+		message_admins("Odyssey xeno ruleset: No valid shuttle spawn turfs found.")
 		return FALSE
 
 	return ..()
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/odyssey_xeno/generate_ruleset_body(var/mob/applicant)
-	var/list/valid_spawns = list()
-	for(var/turf/T in xeno_spawn)
-		if(istype(get_area(T), /area/shuttle/odyssey))
-			valid_spawns += T
-
-	var/turf/spawn_loc = valid_spawns.len ? pick(valid_spawns) : pick(xeno_spawn)
+	var/list/valid_spawns = get_valid_spawns()
+	if(!valid_spawns.len)
+		return
+	var/turf/spawn_loc = pick(valid_spawns)
 	var/mob/living/carbon/alien/larva/new_xeno = new(spawn_loc)
-	new_xeno.stowaway = TRUE // Restrict this xeno's evolution to Hunter only
+	new_xeno.stowaway = TRUE
 	new_xeno.key = applicant.key
 	new_xeno << sound('sound/voice/alienspawn.ogg')
 

--- a/maps/odyssey/events.dm
+++ b/maps/odyssey/events.dm
@@ -125,14 +125,17 @@
 
 /datum/odyssey_event/micro_meteors
 	name = "Micro Meteors"
-	required_roll = 20
+	required_roll = 65
 	state_flags = ODYSSEY_STATE_HYPERSPACE
 	announce_message = "Sensors detect incoming micro-debris field. Brace for impact."
 
 /datum/odyssey_event/micro_meteors/execute(datum/shuttle/odyssey/shuttle)
-	var/count = rand(5, 10)
+	var/count = rand(2, 4)
 	for(var/i = 1 to count)
-		shuttle.spawn_vz_meteor(/obj/item/projectile/meteor/small)
+		var/meaty_type = /obj/item/projectile/meteor/small/microdebris
+		if(prob(25))
+			meaty_type = /obj/item/projectile/meteor/small
+		shuttle.spawn_vz_meteor(meaty_type)
 		sleep(rand(3, 5))
 
 /datum/odyssey_event/gib_storm
@@ -209,6 +212,66 @@
 	for(var/i = 1 to count)
 		var/turf/T = pick(space_turfs)
 		new /mob/living/simple_animal/hostile/carp(T)
+
+//////////////////////////////////////////////
+//                                          //
+//          ODYSSEY XENOMORPH               ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//                                          //
+//////////////////////////////////////////////
+
+/datum/dynamic_ruleset/midround/from_ghosts/faction_based/odyssey_xeno
+	name = "Alien Stowaway"
+	role_category = /datum/role/xenomorph
+	enemy_jobs = list()
+	required_pop = list(0,0,0,0,0,0,0,0,0,0)
+	required_enemies = list(0,0,0,0,0,0,0,0,0,0)
+	required_candidates = 1
+	max_candidates = 1
+	weight = 12
+	weight_category = "Alien"
+	cost = 5
+	requirements = list(20,15,10,10,10,10,10,10,10,10)
+	high_population_requirement = 10
+	logo = "xeno-logo"
+	my_fac = /datum/faction/xenomorph
+
+/datum/dynamic_ruleset/midround/from_ghosts/faction_based/odyssey_xeno/ready(var/forced = 0)
+	if(map.nameShort != "odyssey")
+		return FALSE
+
+	if(!xeno_spawn.len)
+		log_admin("Odyssey xeno ruleset: No xeno_spawn landmarks found.")
+		message_admins("Odyssey xeno ruleset: No xeno_spawn landmarks found.")
+		return FALSE
+
+	var/list/valid_spawns = list()
+	for(var/turf/T in xeno_spawn)
+		if(istype(get_area(T), /area/shuttle/odyssey))
+			valid_spawns += T
+
+	if(!valid_spawns.len)
+		log_admin("Odyssey xeno ruleset: No xeno_spawn landmarks are currently on the shuttle.")
+		message_admins("Odyssey xeno ruleset: No xeno_spawn landmarks are currently on the shuttle.")
+		return FALSE
+
+	return ..()
+
+/datum/dynamic_ruleset/midround/from_ghosts/faction_based/odyssey_xeno/generate_ruleset_body(var/mob/applicant)
+	var/list/valid_spawns = list()
+	for(var/turf/T in xeno_spawn)
+		if(istype(get_area(T), /area/shuttle/odyssey))
+			valid_spawns += T
+
+	var/turf/spawn_loc = valid_spawns.len ? pick(valid_spawns) : pick(xeno_spawn)
+	var/mob/living/carbon/alien/larva/new_xeno = new(spawn_loc)
+	new_xeno.stowaway = TRUE // Restrict this xeno's evolution to Hunter only
+	new_xeno.key = applicant.key
+	new_xeno << sound('sound/voice/alienspawn.ogg')
+
+	spawn(rand(90 SECONDS, 120 SECONDS))
+		captain_announce("Unidentified life signs detected aboard the NTEV Odyssey.")
+
+	return new_xeno
 
 #undef ODYSSEY_STATE_HYPERSPACE
 #undef ODYSSEY_STATE_DEEPSPACE

--- a/maps/odyssey/shuttles.dm
+++ b/maps/odyssey/shuttles.dm
@@ -161,8 +161,14 @@ var/global/datum/shuttle/odyssey_transfer/odyssey_transfer_shuttle = new(startin
 			return 0
 	return ..()
 
+/obj/item/weapon/circuitboard/shuttle_control/odyssey
+	name = "Circuit board (NTEV Odyssey Shuttle Control)"
+	desc = "A circuit board for running the NTEV Odyssey's shuttle control computer."
+	build_path = /obj/machinery/computer/shuttle_control/odyssey
+
 /obj/machinery/computer/shuttle_control/odyssey
 	name = "NTEV Odyssey shuttle control computer"
+	circuit = "/obj/item/weapon/circuitboard/shuttle_control/odyssey"
 
 /obj/machinery/computer/shuttle_control/odyssey/New()
 	link_to(odyssey_shuttle)
@@ -257,6 +263,31 @@ var/global/datum/shuttle/odyssey_transfer/odyssey_transfer_shuttle = new(startin
 			return
 	return ..()
 
+/obj/item/weapon/circuitboard/communications/odyssey
+	name = "Circuit board (Odyssey Bridge Communications)"
+	desc = "A circuit board for running the Odyssey bridge communications console."
+	build_path = /obj/machinery/computer/communications/odyssey
+
+/obj/machinery/computer/communications/odyssey
+	circuit = "/obj/item/weapon/circuitboard/communications/odyssey"
+
+/obj/machinery/computer/communications/odyssey/proc/trigger_bluespace_jump()
+	if(!emergency_shuttle || emergency_shuttle.online || emergency_shuttle.departed || emergency_shuttle.shutdown)
+		return
+	emergency_shuttle.incall()
+	log_game("Communications Console destroyed. Bluespace jump initiated.")
+	message_admins("Communications Console destroyed. Bluespace jump initiated.", 1)
+
+/obj/machinery/computer/communications/odyssey/set_broken()
+	. = ..()
+	if(.)
+		trigger_bluespace_jump()
+
+/obj/machinery/computer/communications/odyssey/Destroy()
+	if(!(stat & BROKEN))
+		trigger_bluespace_jump()
+	return ..()
+
 // Odyssey-specific emergency shuttle controller
 // Instead of calling a separate escape shuttle, the Odyssey itself performs a Bluespace jump to CentComm
 
@@ -264,6 +295,9 @@ var/global/datum/shuttle/odyssey_transfer/odyssey_transfer_shuttle = new(startin
 
 /datum/emergency_shuttle/odyssey
 	var/obj/effect/overlay/bluespacify/bs_overlay // Single shared overlay instance
+
+/datum/emergency_shuttle/odyssey/get_linked_port()
+	return odyssey_shuttle ? odyssey_shuttle.linked_port : null
 
 /datum/emergency_shuttle/odyssey/process()
 	if(!online || shutdown)
@@ -370,6 +404,10 @@ var/global/datum/shuttle/odyssey_transfer/odyssey_transfer_shuttle = new(startin
 
 /datum/emergency_shuttle/odyssey/shuttle_phase(phase, casual = 1)
 	switch(phase)
+		if("station")
+			message_admins("Emergency shuttle panel: 'move to station' is not applicable for the Odyssey Bluespace Jump.")
+			return
+
 		if("transit")
 			// Move Odyssey to its transit port
 			location = SHUTTLE_ON_STANDBY

--- a/maps/odyssey/shuttles.dm
+++ b/maps/odyssey/shuttles.dm
@@ -275,6 +275,7 @@ var/global/datum/shuttle/odyssey_transfer/odyssey_transfer_shuttle = new(startin
 	if(!emergency_shuttle || emergency_shuttle.online || emergency_shuttle.departed || emergency_shuttle.shutdown)
 		return
 	emergency_shuttle.incall()
+	captain_announce("The NTEV Odyssey's bridge communications array has been destroyed; Central Command cannot authorize continued exploration operations. Automated emergency protocol engaged: the Bluespace Drive is now charging for immediate return to Central Command.")
 	log_game("Communications Console destroyed. Bluespace jump initiated.")
 	message_admins("Communications Console destroyed. Bluespace jump initiated.", 1)
 


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Fixes a variety of issues found during the first NTEV Odyssey round. See CL for list.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
It insists upon itself.
 
## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Minimally

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: The Emergency Shuttle Panel is no longer unusable on Odyssey.
 * bugfix: Reduced micrometeor damage and likelihood while in hyperspace.
 * bugfix: Fixed passive scan not working in hyperspace.
 * bugfix: Stowaway xenos can now only become Hunters.
 * bugfix: Reduced old database reboot time for planetary comms while playing on Odyssey.
 * bugfix: The Bluespace Jump countdown will immediately begin if the comms console breaks.
 * bugfix: The stowaway Xeno will now always spawn on the ship.
 * tweak: Added access requirements to bridge, engineering, security office on Odyssey.
 * tweak: Added backup shuttle computer and comms console boards in two locations to Odyssey.