### PR TITLE
More Odyssey Fixes

### DIFF
--- a/__DEFINES/map.dm
+++ b/__DEFINES/map.dm
@@ -68,9 +68,10 @@
 #define VZ_PROTECTED	4		// protected area (centcomm, inaccessible dungeons, away missions, etc)
 #define VZ_SPACE		5		// space area (station, encounter areas, derelict, dj sat, etc)
 
-// Whether the Odyssey shuttle is in hyperspace or deep space
+// Whether the Odyssey shuttle is in hyperspace, deep space, or docked at a planet
 #define ODYSSEY_STATE_HYPERSPACE (1<<0)
 #define ODYSSEY_STATE_DEEPSPACE  (1<<1)
+#define ODYSSEY_STATE_PLANETSIDE (1<<2)
 
 // System vLevel offset - system vLevels (station, centcomm, etc) use IDs 101+
 // to differentiate them from dynamically created vLevels which use IDs 1+

--- a/__DEFINES/map.dm
+++ b/__DEFINES/map.dm
@@ -68,6 +68,10 @@
 #define VZ_PROTECTED	4		// protected area (centcomm, inaccessible dungeons, away missions, etc)
 #define VZ_SPACE		5		// space area (station, encounter areas, derelict, dj sat, etc)
 
+// Whether the Odyssey shuttle is in hyperspace or deep space
+#define ODYSSEY_STATE_HYPERSPACE (1<<0)
+#define ODYSSEY_STATE_DEEPSPACE  (1<<1)
+
 // System vLevel offset - system vLevels (station, centcomm, etc) use IDs 101+
 // to differentiate them from dynamically created vLevels which use IDs 1+
 #define SYSTEM_VLEVEL_OFFSET	100

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -20,8 +20,10 @@
 /// Cell size for spatial bucketing of mobs
 #define SPATIAL_BUCKET_SIZE 15
 
-/// Minimum space turfs between any point of the shuttle and the vlevel edge in encounters
-#define ENCOUNTER_EDGE_BUFFER 7
+/// Minimum space turfs between any point of the shuttle and the vlevel's transition zone in encounters.
+/// Must exceed TRANSITIONEDGE so the shuttle (and any crew walking near it) cannot overlap the
+/// outer band that would teleport them to another z-level.
+#define ENCOUNTER_EDGE_BUFFER (TRANSITIONEDGE + 7)
 
 /// Fixed encounter zone size (must be large enough for shuttle + vaults)
 #define ENCOUNTER_ZONE_SIZE 145

--- a/code/datums/shuttle.dm
+++ b/code/datums/shuttle.dm
@@ -1104,6 +1104,8 @@
 			qdel(E)
 		if(T in corner_turfs)
 			continue
+		if(dest_v)
+			T.v = dest_v
 		if(source_climate)
 			source_climate.unregister_weather_turf(T)
 		if(dest_climate)

--- a/code/game/machinery/ROSA.dm
+++ b/code/game/machinery/ROSA.dm
@@ -15,6 +15,7 @@ var/list/obj/machinery/power/rosa/rosa_machines = list()
 	starting_terminal = 1
 	var/deployed = FALSE
 	var/deploying = FALSE
+	var/deploy_generation = 0
 	var/list/panels = list()
 	var/frequency = 1449
 	var/datum/radio_frequency/radio_connection
@@ -29,6 +30,8 @@ var/list/obj/machinery/power/rosa/rosa_machines = list()
 		stat |= BROKEN
 	if(radio_controller && frequency)
 		set_frequency(frequency)
+	spawn(1)
+		send_status()
 
 /obj/machinery/power/rosa/Destroy()
 	for(var/obj/structure/rosa_panel/panel in panels)
@@ -130,13 +133,20 @@ var/list/obj/machinery/power/rosa/rosa_machines = list()
 		deploy()
 
 /obj/machinery/power/rosa/proc/deploy()
+	deploy_generation++
+	var/our_gen = deploy_generation
 	deploying = TRUE
 	flick("rollerpanel-open", src)
 	sleep(7)
+	if(deploy_generation != our_gen)
+		return
 	flick("rollerpanel-deploy", src)
 	sleep(3)
+	if(deploy_generation != our_gen)
+		return
 	spawn(20)
-		icon_state = "rollerpanel-deployed"
+		if(deploy_generation == our_gen && deploying)
+			icon_state = "rollerpanel-deployed"
 	var/turf/current = get_turf(src)
 	for(var/i = 1 to 4)
 		current = get_step(current, dir)
@@ -150,11 +160,14 @@ var/list/obj/machinery/power/rosa/rosa_machines = list()
 		panel.dir = dir
 		flick("solarpanel-deploy", panel)
 		sleep(8)
+		if(deploy_generation != our_gen)
+			return
 	deployed = TRUE
 	deploying = FALSE
 	send_status()
 
 /obj/machinery/power/rosa/proc/force_retract()
+	deploy_generation++
 	deploying = FALSE
 	for(var/obj/structure/rosa_panel/panel in panels)
 		qdel(panel)
@@ -164,12 +177,20 @@ var/list/obj/machinery/power/rosa/rosa_machines = list()
 	send_status()
 
 /obj/machinery/power/rosa/proc/retract()
+	deploy_generation++
+	var/our_gen = deploy_generation
 	deploying = TRUE
 	for(var/i = panels.len to 1 step -1)
+		if(deploy_generation != our_gen)
+			return
+		if(i > panels.len)
+			continue
 		var/obj/structure/rosa_panel/panel = panels[i]
 		if(!QDELETED(panel))
 			flick("solarpanel-retract", panel)
 			sleep(5)
+			if(deploy_generation != our_gen)
+				return
 			qdel(panel)
 	panels.Cut()
 	icon_state = "rollerpanel"

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -70,6 +70,10 @@ var/list/shuttle_log = list()
 		/datum/malfhack_ability/oneuse/emag,
 	)
 
+	// Subtypes (e.g. the Odyssey bridge console) set this to skip the
+	// zMainStation/zCentcomm distance check so they work from anywhere.
+	var/ignore_station_z_check = FALSE
+
 	// Blob stuff
 	var/defcon_1_enabled = FALSE
 	var/last_transfer_time = -1 // Game mechanics
@@ -94,7 +98,7 @@ var/list/shuttle_log = list()
 			usr.unset_machine()
 		return 1
 
-	if (!(src.z in list(map.zMainStation,map.zCentcomm)))
+	if (!ignore_station_z_check && !(src.z in list(map.zMainStation,map.zCentcomm)))
 		to_chat(usr, "<span class='danger'>Unable to establish a connection: </span>You're too far away from the station!")
 		return
 
@@ -428,7 +432,7 @@ var/list/shuttle_log = list()
 	if(..(user))
 		return
 
-	if (!(src.z in list(map.zMainStation, map.zCentcomm)))
+	if (!ignore_station_z_check && !(src.z in list(map.zMainStation, map.zCentcomm)))
 		to_chat(user, "<span class='danger'>Unable to establish a connection: </span>You're too far away from the station!")
 		return
 

--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -76,6 +76,18 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 
 		signal.data["level"] |= listening_level
 
+		// Collect coverage from every relay (planetary, ship, or preset) reachable through our hub that can broadcast this signal.
+		if(!signal.data["virtual_z"])
+			signal.data["virtual_z"] = list()
+		for(var/obj/machinery/telecomms/hub/H in links)
+			for(var/obj/machinery/telecomms/relay/R in H.links)
+				if(!R.can_send(signal))
+					continue
+				signal.data["level"] |= R.listening_level
+				var/datum/virtual_z/rvz = R.get_virtual_z()
+				if(rvz)
+					signal.data["virtual_z"] |= rvz
+
 	   /** #### - Normal Broadcast - #### **/
 
 		if(signal.data["type"] == 0)

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -131,11 +131,13 @@
 	var/turf/position = get_turf(src)
 
 	// Toggle on/off getting signals from the station or the current Z level
-	if(src.listening_level == map.zMainStation) // equals the station
+	if(listening_level_locked)
 		src.listening_level = position.z
+		listening_level_locked = FALSE
 		return 1
 	else if(position.z == map.zTCommSat)
 		src.listening_level = map.zMainStation
+		listening_level_locked = TRUE
 		return 1
 	return 0
 
@@ -169,7 +171,7 @@
 /obj/machinery/telecomms/relay/Options_Menu()
 	var/dat = ""
 	if(src.z == map.zTCommSat)
-		dat += "<br>Signal Locked to Station: <A href='?src=\ref[src];change_listening=1'>[listening_level == map.zMainStation ? "TRUE" : "FALSE"]</a>"
+		dat += "<br>Signal Locked to Station: <A href='?src=\ref[src];change_listening=1'>[listening_level_locked ? "TRUE" : "FALSE"]</a>"
 
 	dat += {"<br>Broadcasting: <A href='?src=\ref[src];broadcast=1'>[broadcasting ? "YES" : "NO"]</a>
 		<br>Receiving:    <A href='?src=\ref[src];receive=1'>[receiving ? "YES" : "NO"]</a>"}

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -34,6 +34,7 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	var/long_range_link = 0	// Can you link it across Z levels or on the otherside of the map? (Relay & Hub)
 	var/hide = 0				// Is it a hidden machine?
 	var/listening_level = 0	// 0 = auto set in New() - this is the z level that the machine is listening to.
+	var/listening_level_locked = FALSE // If TRUE, listening_level is manually pinned and won't auto-refresh when the machine moves.
 
 	var/moody_state
 
@@ -163,6 +164,15 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	if(!listening_level)
 		//Defaults to our Z level!
 		var/turf/position = get_turf(src)
+		listening_level = position.z
+
+// Keep listening_level in sync when the machine is physically moved (e.g. on a shuttle).
+/obj/machinery/telecomms/forceMove(atom/destination, step_x = 0, step_y = 0, no_tp = FALSE, harderforce = FALSE, glide_size_override = 0)
+	. = ..()
+	if(listening_level_locked)
+		return
+	var/turf/position = get_turf(src)
+	if(position)
 		listening_level = position.z
 
 /obj/machinery/telecomms/initialize()
@@ -367,18 +377,14 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	flick("receiver_receive", src)
 
 /obj/machinery/telecomms/receiver/proc/check_receive_level(datum/signal/signal)
-
-
-	if(signal.data["level"] != listening_level)
-		for(var/obj/machinery/telecomms/hub/H in links)
-			var/list/connected_levels = list()
-			for(var/obj/machinery/telecomms/relay/R in H.links)
-				if(R.can_receive(signal))
-					connected_levels |= R.listening_level
-			if(signal.data["level"] in connected_levels)
+	// A signal can only enter the network via a relay whose own vlevel matches the signal's origin.
+	for(var/obj/machinery/telecomms/hub/H in links)
+		for(var/obj/machinery/telecomms/relay/R in H.links)
+			if(!R.can_receive(signal))
+				continue
+			if(signal.data["level"] == R.listening_level)
 				return 1
-		return 0
-	return 1
+	return 0
 
 
 /*
@@ -548,7 +554,7 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 		return 0
 	if(!broadcasting)
 		return 0
-	return in_virtual_z(signal)
+	return TRUE
 
 /obj/machinery/telecomms/relay/planetary/can_receive(datum/signal/signal)
 	if(!can(signal))
@@ -586,6 +592,32 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	return TRUE
 
 /obj/machinery/telecomms/relay/planetary/checkheat()
+	return
+
+// A mobile subspace relay that rides aboard a ship.
+/obj/machinery/telecomms/relay/planetary/ship
+	name = "subspace communications relay"
+	desc = "A compact subspace relay designed to travel aboard a ship, providing comms wherever its host vessel goes."
+	icon_state = "relay"
+	on = TRUE
+	toggled = TRUE
+	activated = TRUE
+	hide = FALSE
+	use_power = MACHINE_POWER_USE_IDLE
+	idle_power_usage = 30
+	network = "tcommsat"
+	autolinkers = list("relay")
+
+/obj/machinery/telecomms/relay/planetary/ship/update_power()
+	// Always on when operational, regardless of activation state.
+	if(stat & (BROKEN|NOPOWER|EMPED|FORCEDISABLE) || get_integrity() <= 0)
+		on = FALSE
+		return
+	on = TRUE
+
+/obj/machinery/telecomms/relay/planetary/ship/post_ruin_load()
+	// Mobile relay — do not register to any vz.comms_relay slot, and skip the
+	// planetary-specific ruin setup that CRASHes when there's no planet_type on the vz.
 	return
 
 /*

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -505,12 +505,13 @@
 		var/turf/position = get_turf(src)
 		if(!position || !(position.z in level))
 			return -1
-		// If we're on a planet, check if our virtual zLevel can receive the signal
-		var/datum/virtual_z/vz = get_virtual_z()
-		if(planet && vz)
-			if(!(vz in v_levels))
-				return -1
-			else
+		// Virtual z filtering: vlevels act as independent z-levels. A broadcast only
+		// reaches radios whose virtual_z is in the signal's v_levels list. If the
+		// caller didn't supply any v_levels, skip this check (e.g. local fallback
+		// broadcasts from non-subspace radios).
+		if(v_levels?.len)
+			var/datum/virtual_z/our_vz = get_virtual_z()
+			if(!(our_vz in v_levels))
 				return -1
 	if(freq == SYND_FREQ)
 		if(!(src.syndie))//Checks to see if it's allowed on that frequency, based on the encryption keys

--- a/code/game/turfs/simulated/shuttle.dm
+++ b/code/game/turfs/simulated/shuttle.dm
@@ -589,8 +589,6 @@
 				user.visible_message("<span class='warning'>[user] cuts through \the [src]'s reinforced plating, exposing the support rods.</span>", \
 					"<span class='notice'>You cut through \the [src]'s reinforced plating, exposing the support rods.</span>", \
 					"<span class='warning'>You hear welding noises.</span>")
-				// Drop the plasteel used in construction
-				new /obj/item/stack/sheet/plasteel(src, 2)
 				// Transition to intermediate state — needs wirecutters next
 				var/turf/simulated/wall/shuttle/reinforced/panel/welded/W_turf = ChangeTurf(/turf/simulated/wall/shuttle/reinforced/panel/welded)
 				W_turf.add_fingerprint(user)
@@ -627,11 +625,12 @@
 			if(!istype(src, /turf/simulated/wall/shuttle/reinforced/panel/welded))
 				return
 			W.playtoolsound(src, 100)
-			user.visible_message("<span class='warning'>[user] cuts through \the [src]'s support rods.</span>", \
-				"<span class='notice'>You cut through \the [src]'s support rods and remove the reinforcement.</span>", \
+			user.visible_message("<span class='warning'>[user] cuts through \the [src]'s support rods, and the loosened plating falls away.</span>", \
+				"<span class='notice'>You cut through \the [src]'s support rods, and the loosened plating falls away.</span>", \
 				"<span class='warning'>You hear snipping sounds.</span>")
-			// Drop the rods used in construction
+			// Drop the materials used in construction
 			new /obj/item/stack/rods(src, 4)
+			new /obj/item/stack/sheet/plasteel(src, 2)
 			// Revert to a black panel shuttle wall
 			var/turf/simulated/wall/shuttle/panel/black/new_wall = ChangeTurf(/turf/simulated/wall/shuttle/panel/black)
 			new_wall.add_fingerprint(user)

--- a/code/modules/cmc/crew.dm
+++ b/code/modules/cmc/crew.dm
@@ -134,11 +134,15 @@ GENERAL PROCS
 		deactivate(user)
 		return
 
-	// Build list of valid vLevel IDs (those with gps_allowed)
+	// Build list of valid vLevel IDs (those with gps_allowed, plus the console's own
+	// vlevel so it still works in transit / at encounters).
 	var/list/valid_vlevels = list()
 	for(var/datum/virtual_z/V in map.vLevels)
 		if(V.gps_allowed)
 			valid_vlevels += V.id
+	var/datum/virtual_z/own_vz = get_virtual_z()
+	if(own_vz && !(own_vz.id in valid_vlevels))
+		valid_vlevels += own_vz.id
 
 	// 0 means "ALL" vLevels, which is always valid
 	if(holomap_z[uid] != 0 && !(holomap_z[uid] in valid_vlevels)) //catching some more unwanted behaviours
@@ -178,6 +182,9 @@ GENERAL PROCS
 	for(var/datum/virtual_z/V in map.vLevels)
 		if(V.gps_allowed)
 			entries["[V.id]"] = list()
+	var/datum/virtual_z/own_vz = get_virtual_z()
+	if(own_vz && !("[own_vz.id]" in entries))
+		entries["[own_vz.id]"] = list()
 
 	//looping though carbons
 	for(var/mob/living/carbon/human/H in mob_list)
@@ -208,9 +215,8 @@ GENERAL PROCS
 				if (H.z == 0 && entry_turf.z != z)
 					continue
 
-				// Get virtual z-level and check gps_allowed
 				var/datum/virtual_z/entry_vz = entry_turf.get_virtual_z()
-				if(!entry_vz || !entry_vz.gps_allowed)
+				if(!entry_vz || (!entry_vz.gps_allowed && entry_vz != own_vz))
 					continue
 
 				var/obj/item/weapon/card/id/I = H.wear_id ? H.wear_id.GetID() : null
@@ -254,7 +260,7 @@ GENERAL PROCS
 
 		var/turf/pos = get_turf(B)
 		var/datum/virtual_z/vz = pos?.get_virtual_z()
-		if(!isnull(pos) && vz && vz.gps_allowed && istype(M) && M.brainmob == B && !isrobot(M.loc))
+		if(!isnull(pos) && vz && (vz.gps_allowed || vz == own_vz) && istype(M) && M.brainmob == B && !isrobot(M.loc))
 			var/see_x = pos.x - get_world_x_offset(vz.id)
 			var/see_y = pos.y - get_world_y_offset(vz.id)
 			var/see_z = vz.id
@@ -287,9 +293,9 @@ HOLOMAP PROCS
 */
 //initializes the holomap
 /obj/machinery/computer/crew/proc/openHolomap(var/mob/user)
-	// Create holomap images for each vLevel with gps_allowed
+	var/datum/virtual_z/own_vz = get_virtual_z()
 	for(var/datum/virtual_z/V in map.vLevels)
-		if(!V.gps_allowed)
+		if(!V.gps_allowed && V != own_vz)
 			continue
 		var/holomap_bgmap = "cmc_\ref[src]_\ref[user]_[V.id]"
 		if(!(holomap_bgmap in holomap_cache))
@@ -471,10 +477,10 @@ TGUI PROCS
 
 	data["currentZLevel"] = current_z
 
-	// Build list of vLevels with gps_allowed and their holomap availability
+	var/datum/virtual_z/own_vz = get_virtual_z()
 	var/list/vlevel_data = list()
 	for(var/datum/virtual_z/V in map.vLevels)
-		if(V.gps_allowed)
+		if(V.gps_allowed || V == own_vz)
 			var/real_z = V.parent_z.z
 			var/has_holomap = (holoMiniMaps.len >= real_z) && (holoMiniMaps[real_z] != null)
 			vlevel_data += list(list(
@@ -494,7 +500,7 @@ TGUI PROCS
 	var/list/vlevels_to_scan = list()
 	if(current_z == 0)
 		for(var/datum/virtual_z/V in map.vLevels)
-			if(V.gps_allowed)
+			if(V.gps_allowed || V == own_vz)
 				vlevels_to_scan += "[V.id]"
 	else
 		vlevels_to_scan += "[current_z]"

--- a/code/modules/cmc/crew.dm
+++ b/code/modules/cmc/crew.dm
@@ -103,6 +103,10 @@ Crew Monitor by Paul, based on the holomaps by Deity
 /*
 GENERAL PROCS
 */
+//returns whether a virtual z-level should be visible to this console.
+/obj/machinery/computer/crew/proc/is_vlevel_valid(var/datum/virtual_z/V)
+	return V && V.gps_allowed
+
 //initializes all important vars for a new user
 /obj/machinery/computer/crew/proc/initializeUser(var/mob/user)
 	var/uid = "\ref[user]"
@@ -134,15 +138,11 @@ GENERAL PROCS
 		deactivate(user)
 		return
 
-	// Build list of valid vLevel IDs (those with gps_allowed, plus the console's own
-	// vlevel so it still works in transit / at encounters).
+	// Build list of valid vLevel IDs (those with gps_allowed)
 	var/list/valid_vlevels = list()
 	for(var/datum/virtual_z/V in map.vLevels)
-		if(V.gps_allowed)
+		if(is_vlevel_valid(V))
 			valid_vlevels += V.id
-	var/datum/virtual_z/own_vz = get_virtual_z()
-	if(own_vz && !(own_vz.id in valid_vlevels))
-		valid_vlevels += own_vz.id
 
 	// 0 means "ALL" vLevels, which is always valid
 	if(holomap_z[uid] != 0 && !(holomap_z[uid] in valid_vlevels)) //catching some more unwanted behaviours
@@ -180,11 +180,8 @@ GENERAL PROCS
 	//clearing all vLevel entries
 	entries = list()
 	for(var/datum/virtual_z/V in map.vLevels)
-		if(V.gps_allowed)
+		if(is_vlevel_valid(V))
 			entries["[V.id]"] = list()
-	var/datum/virtual_z/own_vz = get_virtual_z()
-	if(own_vz && !("[own_vz.id]" in entries))
-		entries["[own_vz.id]"] = list()
 
 	//looping though carbons
 	for(var/mob/living/carbon/human/H in mob_list)
@@ -216,7 +213,7 @@ GENERAL PROCS
 					continue
 
 				var/datum/virtual_z/entry_vz = entry_turf.get_virtual_z()
-				if(!entry_vz || (!entry_vz.gps_allowed && entry_vz != own_vz))
+				if(!is_vlevel_valid(entry_vz))
 					continue
 
 				var/obj/item/weapon/card/id/I = H.wear_id ? H.wear_id.GetID() : null
@@ -260,7 +257,7 @@ GENERAL PROCS
 
 		var/turf/pos = get_turf(B)
 		var/datum/virtual_z/vz = pos?.get_virtual_z()
-		if(!isnull(pos) && vz && (vz.gps_allowed || vz == own_vz) && istype(M) && M.brainmob == B && !isrobot(M.loc))
+		if(!isnull(pos) && is_vlevel_valid(vz) && istype(M) && M.brainmob == B && !isrobot(M.loc))
 			var/see_x = pos.x - get_world_x_offset(vz.id)
 			var/see_y = pos.y - get_world_y_offset(vz.id)
 			var/see_z = vz.id
@@ -293,9 +290,8 @@ HOLOMAP PROCS
 */
 //initializes the holomap
 /obj/machinery/computer/crew/proc/openHolomap(var/mob/user)
-	var/datum/virtual_z/own_vz = get_virtual_z()
 	for(var/datum/virtual_z/V in map.vLevels)
-		if(!V.gps_allowed && V != own_vz)
+		if(!is_vlevel_valid(V))
 			continue
 		var/holomap_bgmap = "cmc_\ref[src]_\ref[user]_[V.id]"
 		if(!(holomap_bgmap in holomap_cache))
@@ -477,10 +473,9 @@ TGUI PROCS
 
 	data["currentZLevel"] = current_z
 
-	var/datum/virtual_z/own_vz = get_virtual_z()
 	var/list/vlevel_data = list()
 	for(var/datum/virtual_z/V in map.vLevels)
-		if(V.gps_allowed || V == own_vz)
+		if(is_vlevel_valid(V))
 			var/real_z = V.parent_z.z
 			var/has_holomap = (holoMiniMaps.len >= real_z) && (holoMiniMaps[real_z] != null)
 			vlevel_data += list(list(
@@ -500,7 +495,7 @@ TGUI PROCS
 	var/list/vlevels_to_scan = list()
 	if(current_z == 0)
 		for(var/datum/virtual_z/V in map.vLevels)
-			if(V.gps_allowed || V == own_vz)
+			if(is_vlevel_valid(V))
 				vlevels_to_scan += "[V.id]"
 	else
 		vlevels_to_scan += "[current_z]"
@@ -616,6 +611,22 @@ TGUI PROCS
 	var/datum/tgui/ui = SStgui.get_open_ui(user, src)
 	if(ui)
 		ui.close()
+
+
+// NTEV Odyssey variant
+/obj/machinery/computer/crew/odyssey
+	name = "expedition crew monitoring computer"
+
+/obj/machinery/computer/crew/odyssey/is_vlevel_valid(var/datum/virtual_z/V)
+	if(!V)
+		return FALSE
+	if(V.gps_allowed)
+		return TRUE
+	return V == get_virtual_z()
+
+//Forces the Show Holomap button off regardless of which vLevel is selected.
+/obj/machinery/computer/crew/odyssey/handle_sanity(var/mob/user)
+	return FALSE
 
 /*
 Tooltip interface

--- a/code/modules/events/event_dynamic.dm
+++ b/code/modules/events/event_dynamic.dm
@@ -4,7 +4,7 @@ var/list/possibleEvents = list()
 //Always triggers an event when called, dynamically chooses events based on job population
 /proc/spawn_dynamic_event(var/forced=FALSE)
 	if(!forced)
-		if(!config.allow_random_events || (map && map.dorf))
+		if(!config.allow_random_events || (map && (map.dorf || map.disable_random_events)))
 			return
 
 		var/minutes_passed = world.time/600

--- a/code/modules/events/event_dynamic.dm
+++ b/code/modules/events/event_dynamic.dm
@@ -1,10 +1,18 @@
 var/list/possibleEvents = list()
 //A list of events and their weights. These range from quite uncommon like a rod (15) to very common like carp (40)
 
+var/datum/event/queued_event = null
+var/queued_event_expiry = 0
+
 //Always triggers an event when called, dynamically chooses events based on job population
 /proc/spawn_dynamic_event(var/forced=FALSE)
+	// Any queued event is preempted by a new natural roll
+	if(queued_event)
+		message_admins("EVENT QUEUE CLEARED: [queued_event] preempted by new event roll.")
+		queued_event = null
+
 	if(!forced)
-		if(!config.allow_random_events || (map && (map.dorf || map.disable_random_events)))
+		if(!config.allow_random_events || (map && map.dorf))
 			return
 
 		var/minutes_passed = world.time/600
@@ -45,6 +53,16 @@ var/list/possibleEvents = list()
 	var/datum/event/picked_event = pickweight(drawing)
 	if(!picked_event)
 		return
+
+	// Map-specific check: queue if the picked event fails the map's gate
+	if(!map.map_specific_event_checks(picked_event))
+		queued_event = picked_event
+		queued_event_expiry = world.time + 5 MINUTES
+		message_admins("EVENT QUEUED: [picked_event] failed map_specific_event_checks, waiting up to 5 minutes.")
+		spawn(15 SECONDS)
+			retry_queued_event(picked_event)
+		return 1
+
 	message_admins("EVENT: [picked_event] started with [drawing[picked_event]] weight.")
 	possibleEvents -= picked_event
 	if(!picked_event.oneShot)
@@ -69,6 +87,65 @@ var/list/possibleEvents = list()
 	score.eventsendured++
 
 	return 1
+
+/proc/retry_queued_event(var/datum/event/my_event)
+	// Exit silently if preempted by a new natural roll (or cleared).
+	if(queued_event != my_event)
+		return
+
+	// Map gate now satisfied — fire normally.
+	if(map.map_specific_event_checks(my_event))
+		message_admins("EVENT QUEUE FIRED: [my_event] map gate satisfied.")
+		fire_queued_event(my_event)
+		queued_event = null
+		return
+
+	// Expired; re-roll.
+	if(world.time >= queued_event_expiry)
+		message_admins("EVENT QUEUE EXPIRED: [my_event] timed out, re-rolling.")
+		queued_event = null
+		reroll_on_queue_expiry()
+		return
+
+	// Still waiting; poll again.
+	spawn(15 SECONDS)
+		retry_queued_event(my_event)
+
+/proc/fire_queued_event(var/datum/event/E)
+	possibleEvents -= E
+	if(!E.oneShot)
+		var/newtype = E.type
+		var/datum/event/to_add = new newtype(FALSE)
+		to_add.last_fired = world.time
+		possibleEvents += to_add
+
+	var/debug_message = "Firing queued event. "
+	for(var/datum/event/O in possibleEvents)
+		debug_message += "[O]:[possibleEvents[O]]"
+	debug_message += "|||Picked:[E]"
+	log_debug(debug_message)
+
+	E.setup()
+	events.Add(E)
+	score.eventsendured++
+
+/proc/reroll_on_queue_expiry()
+	var/list/active_with_role = number_active_with_role()
+	var/list/drawing = list()
+	for(var/datum/event/E in possibleEvents)
+		drawing[E] = max(0, E.can_start(active_with_role) - E.recency_weight())
+
+	for(var/i = 1 to 10)
+		var/datum/event/picked = pickweight(drawing)
+		if(!picked)
+			break
+		if(map.map_specific_event_checks(picked))
+			message_admins("EVENT (queue fallback): [picked] started (attempt [i]).")
+			fire_queued_event(picked)
+			return
+		// Map gate still unmet for this event; remove it from drawing and retry
+		drawing -= picked
+	message_admins("EVENT QUEUE FALLBACK: no valid event found in 10 rolls.")
 
 // Returns a list of how many characters are currently active with a specific role
 // see: (not logged out, not AFK for more than 10 minutes)

--- a/code/modules/mob/living/carbon/human/life/handle_weather.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_weather.dm
@@ -12,6 +12,11 @@
 		clear_weather_effects()
 		return
 
+	var/area/A = get_area(src)
+	if(istype(A, /area/shuttle))
+		clear_weather_effects()
+		return
+
 	var/datum/climate/climate = SSweather.get_climate_from_turf(T)
 	if(!climate?.current_weather)
 		clear_weather_effects()
@@ -20,7 +25,6 @@
 	var/datum/weather/weather = climate.current_weather
 
 	// Check if we're in an open surface area (weather-affected area)
-	var/area/A = get_area(src)
 	if(!A || !isopensurface(A))
 		clear_weather_effects()
 		return

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1251,8 +1251,11 @@ Thanks.
 //shuttle_act is called when a shuttle collides with the mob
 /mob/living/shuttle_act(datum/shuttle/S)
 	if(!(src.flags & INVULNERABLE))
-		src.attack_log += "\[[time_stamp()]\] was gibbed by a shuttle ([S.name], [S.type])!"
-		gib()
+		src.attack_log += "\[[time_stamp()]\] was destroyed by a shuttle ([S.name], [S.type])!"
+		if(ishuman(src))
+			gib()
+		else
+			qdel(src)
 	return
 
 //mob verbs are a lot faster than object verbs

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -400,15 +400,15 @@ var/list/nums_to_hl_num = list("1" = 'sound/items/one.wav', "2" = 'sound/items/t
 /obj/item/device/gps/planetary/get_location_name()
 	var/turf/device_turf = get_turf(src)
 	var/area/device_area = get_area(src)
+	var/datum/virtual_z/vz = device_turf?.get_virtual_z()
 	if(emped)
 		return "ERROR"
 	else if(!device_turf || !device_area)
 		return "UNKNOWN"
-	else if(!device_turf.planet)
+	else if(!vz?.planet)
 		return "NOT ON PLANET"
 	else
 		// coordinates are relative to each vlevel
-		var/datum/virtual_z/vz = device_turf.get_virtual_z()
 		if(!istype(vz))
 			return "[format_text(device_area.name)] (UNKNOWN)"
 		var/planet_name = vz.planet ? vz.planet.planet_name : "Unknown Planet"
@@ -427,10 +427,10 @@ var/list/nums_to_hl_num = list("1" = 'sound/items/one.wav', "2" = 'sound/items/t
 	data["beacon_time_remaining"] = beacon_active ? max(0, round((beacon_cooldown - world.time) / 10)) : 0
 	var/list/devices = list()
 	var/turf/device_turf = get_turf(src)
+	var/datum/virtual_z/vz = device_turf?.get_virtual_z()
 
 	// Only show other devices if we're on a planet and transmitting
-	if(!emped && transmitting && device_turf?.planet)
-		var/datum/virtual_z/vz = device_turf.get_virtual_z()
+	if(!emped && transmitting && vz?.planet)
 		if(istype(vz))
 			// Always show docking ports on this planet
 			for(var/obj/docking_port/destination/planet_surface/port in all_docking_ports)
@@ -450,9 +450,9 @@ var/list/nums_to_hl_num = list("1" = 'sound/items/one.wav', "2" = 'sound/items/t
 				if(!other.transmitting || other == src)
 					continue
 				var/turf/other_turf = get_turf(other)
-				if(!other_turf?.planet)
+				var/datum/virtual_z/other_vz = other_turf?.get_virtual_z()
+				if(!other_vz?.planet)
 					continue
-				var/datum/virtual_z/other_vz = other_turf.get_virtual_z()
 				if(other_vz == vz)
 					var/list/device_data = list()
 					device_data["tag"] = other.gpstag
@@ -473,12 +473,12 @@ var/list/nums_to_hl_num = list("1" = 'sound/items/one.wav', "2" = 'sound/items/t
 				to_chat(usr, "<span class='warning'>The GPS is experiencing electromagnetic interference!</span>")
 				return FALSE
 			var/turf/device_turf = get_turf(src)
-			if(!device_turf?.planet)
+			var/datum/virtual_z/vz = device_turf?.get_virtual_z()
+			if(!vz?.planet)
 				to_chat(usr, "<span class='warning'>The distress beacon only works on planet surfaces!</span>")
 				return FALSE
 
 			// planet information
-			var/datum/virtual_z/vz = device_turf.get_virtual_z()
 			if(!istype(vz))
 				to_chat(usr, "<span class='warning'>Unable to determine location!</span>")
 				return FALSE
@@ -574,11 +574,11 @@ var/list/nums_to_hl_num = list("1" = 'sound/items/one.wav', "2" = 'sound/items/t
 			to_chat(usr, "<span class='warning'>The GPS is experiencing electromagnetic interference!</span>")
 			return FALSE
 		var/turf/device_turf = get_turf(src)
-		if(!device_turf?.planet)
+		var/datum/virtual_z/vz = device_turf?.get_virtual_z()
+		if(!vz?.planet)
 			to_chat(usr, "<span class='warning'>The distress beacon only works on planetary surfaces!</span>")
 			return FALSE
 
-		var/datum/virtual_z/vz = device_turf.get_virtual_z()
 		if(!istype(vz))
 			to_chat(usr, "<span class='warning'>Unable to determine planetary location!</span>")
 			return FALSE

--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -67,7 +67,8 @@
 
 	var/list/event_blacklist = list(/datum/event/blizzard, /datum/event/omega_blizzard)
 	var/list/event_whitelist = list()
-	var/disable_random_events = FALSE //If TRUE, the standard /datum/event random event scheduler will not fire on this map.
+
+	var/datum/shuttle/ship_shuttle = null //Reference to "the ship" for map-specific features (events, etc). Set by map-specific init code.
 
 	//Map elements that should be loaded together with this map. Stuff like the holodeck areas, etc.
 	var/list/load_map_elements = list()
@@ -83,6 +84,10 @@
 	var/planet_size = 0 // If set, overrides planet allocation size for this map
 
 	var/list/daynight_z_lvls = list() //Z-levels that participate in the day/night cycle
+
+//Used for events; override as-needed.
+/datum/map/proc/map_specific_event_checks(var/datum/event/E)
+	return 1
 
 /datum/map/New()
 	. = ..()

--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -67,6 +67,7 @@
 
 	var/list/event_blacklist = list(/datum/event/blizzard, /datum/event/omega_blizzard)
 	var/list/event_whitelist = list()
+	var/disable_random_events = FALSE //If TRUE, the standard /datum/event random event scheduler will not fire on this map.
 
 	//Map elements that should be loaded together with this map. Stuff like the holodeck areas, etc.
 	var/list/load_map_elements = list()

--- a/maps/odyssey.dm
+++ b/maps/odyssey.dm
@@ -53,6 +53,7 @@
 	planet_size = 140
 	shuttle_call_label = "Begin Bluespace Jump"
 	shuttle_cancel_label = "Cancel Bluespace Jump"
+	disable_random_events = TRUE //Odyssey uses its own event system (see maps/odyssey/events.dm)
 
 /datum/map/active/map_ruleset(var/datum/dynamic_ruleset/DR)
 	if(ispath(DR.role_category,/datum/role/blob_overmind))

--- a/maps/odyssey.dm
+++ b/maps/odyssey.dm
@@ -78,7 +78,7 @@
 		/datum/event/money_lotto,
 		/datum/event/money_hacker,
 		/datum/event/profound_peace,
-		/datum/event/hog,
+		/datum/event/hog/odyssey,
 		/datum/event/ionstorm
 	)
 
@@ -102,6 +102,8 @@
 			return ODYSSEY_STATE_HYPERSPACE
 		if(VZ_PARKING, VZ_SPACE)
 			return ODYSSEY_STATE_DEEPSPACE
+		if(VZ_PLANET)
+			return ODYSSEY_STATE_PLANETSIDE
 	return 0
 
 /datum/map/active/proc/recently_on_planet()
@@ -126,6 +128,8 @@
 		required_state = ODYSSEY_STATE_HYPERSPACE | ODYSSEY_STATE_DEEPSPACE
 	else if(istype(E, /datum/event/odyssey_carp_swarm) || istype(E, /datum/event/rogue_drone/odyssey))
 		required_state = ODYSSEY_STATE_DEEPSPACE
+	else if(istype(E, /datum/event/hog/odyssey))
+		required_state = ODYSSEY_STATE_PLANETSIDE
 	if(required_state && !(get_ship_state() & required_state))
 		return 0
 	return 1

--- a/maps/odyssey.dm
+++ b/maps/odyssey.dm
@@ -53,7 +53,34 @@
 	planet_size = 140
 	shuttle_call_label = "Begin Bluespace Jump"
 	shuttle_cancel_label = "Cancel Bluespace Jump"
-	disable_random_events = TRUE //Odyssey uses its own event system (see maps/odyssey/events.dm)
+
+	event_whitelist = list(
+		// Odyssey-native events
+		/datum/event/micro_meteors,
+		/datum/event/gib_storm,
+		/datum/event/solar_flare,
+		/datum/event/odyssey_carp_swarm,
+		// Vanilla events with Odyssey overrides
+		/datum/event/radiation_storm/odyssey,
+		/datum/event/disease_outbreak/odyssey,
+		/datum/event/viral_infection/odyssey,
+		/datum/event/viral_outbreak/odyssey,
+		/datum/event/ancientpod/odyssey,
+		/datum/event/grid_check/odyssey,
+		/datum/event/immovable_rod/odyssey,
+		/datum/event/rogue_drone/odyssey,
+		/datum/event/brand_intelligence/odyssey,
+		/datum/event/old_vendotron_teleport/odyssey,
+		// Vanilla events that work as-is
+		/datum/event/organ_failure,
+		/datum/event/mass_hallucination,
+		/datum/event/pda_spam,
+		/datum/event/money_lotto,
+		/datum/event/money_hacker,
+		/datum/event/profound_peace,
+		/datum/event/hog,
+		/datum/event/ionstorm
+	)
 
 /datum/map/active/map_ruleset(var/datum/dynamic_ruleset/DR)
 	if(ispath(DR.role_category,/datum/role/blob_overmind))
@@ -63,6 +90,45 @@
 	else if(ispath(DR.role_category,/datum/role/nuclear_operative))
 		return FALSE
 	return ..()
+
+/datum/map/active/proc/get_ship_state()
+	if(!ship_shuttle || !ship_shuttle.current_port)
+		return 0
+	var/datum/virtual_z/vz = ship_shuttle.current_port.get_virtual_z()
+	if(!vz)
+		return 0
+	switch(vz.level_type)
+		if(VZ_TRANSIT)
+			return ODYSSEY_STATE_HYPERSPACE
+		if(VZ_PARKING, VZ_SPACE)
+			return ODYSSEY_STATE_DEEPSPACE
+	return 0
+
+/datum/map/active/proc/recently_on_planet()
+	if(!ship_shuttle)
+		return FALSE
+	// Currently docked at a planet?
+	if(ship_shuttle.current_port)
+		var/datum/virtual_z/vz = ship_shuttle.current_port.get_virtual_z()
+		if(vz && vz.level_type == VZ_PLANET)
+			return TRUE
+	// Or was within the last 15 minutes
+	var/datum/shuttle/odyssey/O = ship_shuttle
+	if(istype(O) && O.last_planet_dock_time && (world.time - O.last_planet_dock_time) < 15 MINUTES)
+		return TRUE
+	return FALSE
+
+/datum/map/active/map_specific_event_checks(var/datum/event/E)
+	var/required_state = 0
+	if(istype(E, /datum/event/micro_meteors) || istype(E, /datum/event/gib_storm) || istype(E, /datum/event/immovable_rod/odyssey))
+		required_state = ODYSSEY_STATE_HYPERSPACE
+	else if(istype(E, /datum/event/solar_flare) || istype(E, /datum/event/radiation_storm/odyssey))
+		required_state = ODYSSEY_STATE_HYPERSPACE | ODYSSEY_STATE_DEEPSPACE
+	else if(istype(E, /datum/event/odyssey_carp_swarm) || istype(E, /datum/event/rogue_drone/odyssey))
+		required_state = ODYSSEY_STATE_DEEPSPACE
+	if(required_state && !(get_ship_state() & required_state))
+		return 0
+	return 1
 
 /datum/zLevel/dynamic/odyssey
 	name = "odyssey"

--- a/maps/odyssey.dm
+++ b/maps/odyssey.dm
@@ -171,6 +171,12 @@
 			vz.register_weather_turfs(C)
 			break
 
+/datum/command_alert/emergency_shuttle_called/announce()
+	message = "The engines are charging in preparation for the Bluespace Jump. The ship will depart in [round(emergency_shuttle.timeleft()/60)] minutes."
+	if(justification)
+		message += " Justification: [justification]"
+	..()
+
 ////////////////////////////////////////////////////////////////
 #undef OUTPOST_MAX_X
 #undef OUTPOST_MAX_Y

--- a/maps/odyssey.dm
+++ b/maps/odyssey.dm
@@ -171,10 +171,36 @@
 			vz.register_weather_turfs(C)
 			break
 
+/datum/command_alert/emergency_shuttle_called
+	name = "Bluespace Jump Warning"
+	alert_title = "Priority Announcement"
+	force_report = 1
+	alert = null
+	var/justification = ""
+
 /datum/command_alert/emergency_shuttle_called/announce()
 	message = "The engines are charging in preparation for the Bluespace Jump. The ship will depart in [round(emergency_shuttle.timeleft()/60)] minutes."
 	if(justification)
 		message += " Justification: [justification]"
+	..()
+
+/datum/command_alert/emergency_shuttle_recalled
+	name = "Bluespace Jump Cancelled"
+	alert_title = "Priority Announcement"
+	force_report = 1
+	alert = null
+
+/datum/command_alert/emergency_shuttle_recalled/announce()
+	message = "The Bluespace Jump has been cancelled."
+	..()
+
+/datum/command_alert/emergency_shuttle_left
+	name = "Bluespace Jump Initiated"
+	alert_title = "Priority Announcement"
+	force_report = 1
+
+/datum/command_alert/emergency_shuttle_left/announce()
+	message = "The Bluespace Jump has begun. Estimate [round(emergency_shuttle.timeleft()/60,1)] minutes until the NTEV Odyssey docks at Central Command."
 	..()
 
 ////////////////////////////////////////////////////////////////

--- a/maps/odyssey.dmm
+++ b/maps/odyssey.dmm
@@ -435,9 +435,7 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor{
-	dir = 10;
-	icon_state = "dark_navy";
-	tag = "icon-dark_navy (WEST)"
+	icon_state = "dark"
 	},
 /area/shuttle/odyssey/hallway/fore/lobby)
 "bu" = (
@@ -1905,9 +1903,7 @@
 	},
 /obj/structure/bed/chair/comfy/couch/left/black,
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "dark_navy";
-	tag = "icon-dark_navy (NORTH)"
+	icon_state = "dark"
 	},
 /area/shuttle/odyssey/hallway/fore/lobby)
 "gi" = (
@@ -2015,9 +2011,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "dark_navy";
-	tag = "icon-dark_navy (NORTH)"
+	icon_state = "dark"
 	},
 /area/shuttle/odyssey/hallway/fore/lobby)
 "gw" = (
@@ -3320,9 +3314,7 @@
 	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark_navy";
-	tag = "icon-dark_navy (EAST)"
+	icon_state = "dark"
 	},
 /area/shuttle/odyssey/hallway/fore/lobby)
 "ls" = (
@@ -3630,13 +3622,6 @@
 	icon_state = "whiteblue"
 	},
 /area/odyssey/clinic)
-"mt" = (
-/obj/machinery/door_timer/cell_1{
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/simulated/wall/shuttle/reinforced/panel,
-/area/shuttle/odyssey/security/holding_cell)
 "mv" = (
 /turf/simulated/floor{
 	icon_state = "white"
@@ -5493,9 +5478,7 @@
 	},
 /obj/structure/bed/chair/comfy/couch/right/black,
 /turf/simulated/floor{
-	dir = 9;
-	icon_state = "dark_navy";
-	tag = "icon-dark_navy (NORTHWEST)"
+	icon_state = "dark"
 	},
 /area/shuttle/odyssey/hallway/fore/lobby)
 "tf" = (
@@ -5920,9 +5903,7 @@
 	pixel_x = -30
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "dark_navy";
-	tag = "icon-dark_navy (WEST)"
+	icon_state = "dark"
 	},
 /area/shuttle/odyssey/hallway/fore/lobby)
 "ux" = (
@@ -6267,9 +6248,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark_navy";
-	tag = "icon-dark_navy (EAST)"
+	icon_state = "dark"
 	},
 /area/shuttle/odyssey/hallway/fore/lobby)
 "vP" = (
@@ -6788,9 +6767,7 @@
 	pixel_x = 30
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark_navy";
-	tag = "icon-dark_navy (EAST)"
+	icon_state = "dark"
 	},
 /area/shuttle/odyssey/hallway/fore/lobby)
 "xi" = (
@@ -7298,9 +7275,6 @@
 /turf/unsimulated/floor/planetary/concrete,
 /area/shuttle/odyssey_transfer)
 "yM" = (
-/obj/machinery/door/airlock/engineering{
-	req_access_txt = "11"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -7312,6 +7286,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layered,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance_hatch,
 /turf/simulated/floor/plated_catwalk/dark,
 /area/shuttle/odyssey/hallway/aft)
 "yP" = (
@@ -8102,9 +8077,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "dark_navy";
-	tag = "icon-dark_navy (WEST)"
+	icon_state = "dark"
 	},
 /area/shuttle/odyssey/hallway/fore/lobby)
 "BB" = (
@@ -8401,9 +8374,7 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "dark_navy";
-	tag = "icon-dark_navy (WEST)"
+	icon_state = "dark"
 	},
 /area/shuttle/odyssey/hallway/fore/lobby)
 "Cy" = (
@@ -8929,8 +8900,7 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor{
-	icon_state = "dark_navy";
-	tag = "icon-dark_navy (WEST)"
+	icon_state = "dark"
 	},
 /area/shuttle/odyssey/hallway/fore/lobby)
 "Ev" = (
@@ -9442,7 +9412,9 @@
 /turf/simulated/floor/plating,
 /area/shuttle/odyssey/maintenance/starboard)
 "GA" = (
-/obj/machinery/door/airlock/glass_security,
+/obj/machinery/door/airlock/glass_security{
+	req_access_txt = "1"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layered{
 	dir = 3;
 	tag = ""
@@ -9666,9 +9638,7 @@
 	name = "Security Officer"
 	},
 /turf/simulated/floor{
-	dir = 6;
-	icon_state = "dark_navy";
-	tag = "icon-dark_navy (NORTHWEST)"
+	icon_state = "dark"
 	},
 /area/shuttle/odyssey/hallway/fore/lobby)
 "Hi" = (
@@ -12726,9 +12696,6 @@
 /turf/simulated/floor/wood,
 /area/derelict/bar)
 "QV" = (
-/obj/machinery/door/airlock/engineering{
-	req_access_txt = "11"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
@@ -12741,6 +12708,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layered,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance_hatch,
 /turf/simulated/floor/plated_catwalk/dark,
 /area/shuttle/odyssey/hallway/aft)
 "QZ" = (
@@ -13739,8 +13707,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor{
-	icon_state = "dark_navy";
-	tag = "icon-dark_navy (WEST)"
+	icon_state = "dark"
 	},
 /area/shuttle/odyssey/hallway/fore/lobby)
 "Un" = (
@@ -14645,9 +14612,7 @@
 	name = "Assistant"
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "dark_navy";
-	tag = "icon-dark_navy (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/shuttle/odyssey/hallway/fore/lobby)
 "Xb" = (
@@ -15258,10 +15223,10 @@
 /area/shuttle/odyssey/hallway/fore)
 "YW" = (
 /obj/structure/catwalk,
-/obj/machinery/disposal/deliveryChute,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
+/obj/structure/disposaloutlet,
 /turf/unsimulated/floor/planetary/concrete,
 /area/shuttle/odyssey/exterior)
 "YY" = (
@@ -29976,7 +29941,7 @@ lr
 xf
 vN
 Hg
-mt
+nx
 yl
 cQ
 QR

--- a/maps/odyssey.dmm
+++ b/maps/odyssey.dmm
@@ -357,7 +357,7 @@
 /area/security/perma)
 "ba" = (
 /turf/simulated/wall,
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "bd" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -387,7 +387,7 @@
 /obj/item/weapon/folder/blue,
 /obj/structure/table/woodentable,
 /turf/simulated/floor/carpet,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "bj" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -522,7 +522,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "bz" = (
 /obj/structure/table,
 /obj/item/device/antibody_scanner{
@@ -542,7 +542,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "bA" = (
 /obj/machinery/status_display/odyssey,
 /turf/simulated/wall/shuttle/panel/black,
@@ -642,11 +642,11 @@
 "bN" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/simulated/floor/server,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "bR" = (
 /obj/machinery/vending/sale,
 /turf/unsimulated/floor/planetary/path/jungle_plated,
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "bT" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -661,7 +661,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "bW" = (
 /obj/machinery/processor,
 /turf/simulated/floor{
@@ -706,7 +706,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "ce" = (
 /obj/machinery/door/window{
 	base_state = "right";
@@ -747,7 +747,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "cm" = (
 /obj/machinery/vending/tool{
 	contraband = list(/obj/item/tool/weldingtool/hugetank=2,/obj/item/clothing/gloves/yellow/vox=2);
@@ -760,7 +760,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floorgrime"
 	},
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "cr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layered{
 	dir = 4;
@@ -816,7 +816,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "cw" = (
 /obj/machinery/light{
 	dir = 1
@@ -824,7 +824,7 @@
 /turf/unsimulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/store)
+/area/odyssey/store)
 "cx" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "oxygen"
@@ -848,7 +848,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "cA" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -875,7 +875,7 @@
 	dir = 4;
 	icon_state = "whitepurple"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "cH" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -887,7 +887,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "cJ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -901,7 +901,7 @@
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "cM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/hydroponics,
@@ -1053,7 +1053,7 @@
 	dir = 9;
 	icon_state = "warnwhite"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "dc" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1121,7 +1121,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "dt" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1232,14 +1232,14 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "dL" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "dark"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "dN" = (
 /obj/machinery/washing_machine,
 /obj/machinery/media/receiver/boombox/wallmount/muzak{
@@ -1314,7 +1314,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/store)
+/area/odyssey/store)
 "eb" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -1444,15 +1444,6 @@
 	icon_state = "dark"
 	},
 /area/shuttle/odyssey/logistics)
-"eD" = (
-/obj/structure/shuttle/engine/heater{
-	dir = 4
-	},
-/obj/structure/window/reinforced/plasma{
-	dir = 8
-	},
-/turf/simulated/floor/shuttle/plating,
-/area/shuttle/supply)
 "eE" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4;
@@ -1460,7 +1451,7 @@
 	},
 /obj/structure/grille/window_spawner/reinforced/full,
 /turf/simulated/floor/plating,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "eJ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -1492,7 +1483,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "eQ" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/unary/vent,
@@ -1563,7 +1554,7 @@
 "fa" = (
 /obj/machinery/r_n_d/server/core,
 /turf/simulated/floor/server/bluegrid,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "fd" = (
 /obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
 	dir = 1;
@@ -1624,7 +1615,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor/plating,
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "fj" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	default_scrubbed_gases = list( "carbon_dioxide", "plasma", "oxygen" );
@@ -1659,7 +1650,7 @@
 	req_access_txt = "50"
 	},
 /turf/unsimulated/floor/planetary/path/jungle_plated,
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "fo" = (
 /obj/machinery/atmospherics/unary/vent_pump/on/layered{
 	dir = 8
@@ -1705,7 +1696,7 @@
 	dir = 10;
 	icon_state = "warnwhite"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "fy" = (
 /obj/machinery/suit_storage_unit/mining,
 /turf/simulated/floor{
@@ -1724,7 +1715,7 @@
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "fB" = (
 /obj/machinery/suit_storage_unit/security,
 /obj/item/device/radio/intercom{
@@ -1764,27 +1755,13 @@
 	icon_state = "floorgrime"
 	},
 /area/security/perma)
-"fH" = (
-/obj/machinery/door_control{
-	id_tag = "QMLoaddoor";
-	name = "Loading Doors";
-	pixel_x = -8;
-	pixel_y = -24
-	},
-/obj/machinery/door_control{
-	id_tag = "QMLoaddoor2";
-	name = "Loading Doors";
-	pixel_x = 8;
-	pixel_y = -24
-	},
-/turf/simulated/floor/shuttle,
-/area/shuttle/supply)
 "fI" = (
 /obj/machinery/photocopier,
+/obj/machinery/light,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "fJ" = (
 /obj/structure/mirror{
 	pixel_y = 28
@@ -1798,7 +1775,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "fN" = (
 /obj/structure/flora/pottedplant/random,
 /obj/machinery/atmospherics/unary/vent_pump/on/layered{
@@ -1822,7 +1799,7 @@
 	dir = 8;
 	icon_state = "whitegreen"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "fT" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/layered{
 	dir = 4;
@@ -1846,7 +1823,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "fV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -1865,7 +1842,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "fX" = (
 /obj/structure/sign/double/barsign{
 	desc = "Caw.";
@@ -1911,7 +1888,7 @@
 /turf/simulated/floor{
 	icon_state = "whiteblue"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "ge" = (
 /obj/effect/decal/warning_stripes{
 	dir = 4;
@@ -1922,7 +1899,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "gh" = (
 /obj/machinery/light{
 	dir = 1
@@ -1966,13 +1943,13 @@
 	dir = 4;
 	icon_state = "whitegreen"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "gm" = (
 /obj/structure/grille/window_spawner/reinforced/full,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "gn" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -1982,11 +1959,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/surface/nt_outpost/clinic)
-"go" = (
-/obj/structure/shuttle/diag_wall/smooth,
-/turf/unsimulated/floor/planetary/concrete,
-/area/shuttle/supply)
+/area/odyssey/clinic)
 "gq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -2030,7 +2003,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "gv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layered{
 	dir = 3;
@@ -2098,7 +2071,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "gD" = (
 /obj/structure/table,
 /obj/machinery/pos{
@@ -2111,7 +2084,7 @@
 /turf/unsimulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/store)
+/area/odyssey/store)
 "gE" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -2154,7 +2127,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "gN" = (
 /turf/unsimulated/wall/splashscreen,
 /area/start)
@@ -2208,7 +2181,7 @@
 /turf/unsimulated/floor{
 	icon_state = "bar"
 	},
-/area/surface/nt_outpost/store)
+/area/odyssey/store)
 "hc" = (
 /obj/machinery/atmospherics/pipe/manifold/insulated/hidden/blue{
 	dir = 4
@@ -2216,7 +2189,7 @@
 /turf/simulated/floor{
 	icon_state = "cmo"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "he" = (
 /turf/simulated/floor/plating,
 /area/shuttle/odyssey/maintenance/port)
@@ -2236,7 +2209,7 @@
 	tag = "icon-warning (NORTHEAST)"
 	},
 /turf/simulated/floor/plating,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "hm" = (
 /obj/structure/grille/window_spawner/reinforced/full,
 /obj/machinery/door/poddoor{
@@ -2248,7 +2221,7 @@
 "hn" = (
 /obj/structure/grille/window_spawner/reinforced/full,
 /turf/simulated/floor/plating,
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "ho" = (
 /obj/structure/bed,
 /obj/item/weapon/bedsheet,
@@ -2298,16 +2271,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/shuttle/odyssey/quarters/crew)
-"hw" = (
-/obj/machinery/conveyor{
-	id_tag = "QMLoad"
-	},
-/obj/machinery/door/poddoor{
-	id_tag = "QMLoaddoor";
-	name = "Supply Shuttle Loading Door"
-	},
-/turf/simulated/floor/shuttle/plating,
-/area/shuttle/supply)
 "hx" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal{
@@ -2355,7 +2318,7 @@
 /turf/simulated/floor{
 	icon_state = "whitegreen"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "hI" = (
 /obj/structure/closet/malf/suits,
 /obj/item/toy/gasha/AI/malf,
@@ -2365,7 +2328,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "hK" = (
 /obj/machinery/door_control{
 	name = "Starboard Engine Blast Door Control";
@@ -2389,12 +2352,12 @@
 /turf/unsimulated/floor{
 	icon_state = "floorgrime"
 	},
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "hQ" = (
 /obj/item/weapon/folder/red,
 /obj/structure/table/woodentable,
 /turf/simulated/floor/carpet,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "hS" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -2447,7 +2410,7 @@
 /turf/simulated/floor{
 	icon_state = "cmo"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "ii" = (
 /obj/effect/decal/warning_stripes{
 	dir = 9;
@@ -2460,20 +2423,10 @@
 /area/vox_trading_post/trading_floor{
 	name = "\improper Vox Casino"
 	})
-"ij" = (
-/obj/machinery/conveyor{
-	id_tag = "QMLoad2"
-	},
-/obj/machinery/door/poddoor{
-	id_tag = "QMLoaddoor2";
-	name = "Supply Shuttle Loading Door"
-	},
-/turf/simulated/floor/shuttle/plating,
-/area/shuttle/supply)
 "ik" = (
 /obj/machinery/status_display/supply,
 /turf/simulated/wall,
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "im" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -2492,14 +2445,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/clinic)
-"iq" = (
-/obj/structure/shuttle/window{
-	icon_state = "17"
-	},
-/obj/structure/grille,
-/turf/simulated/floor/shuttle/plating,
-/area/shuttle/supply)
+/area/odyssey/clinic)
 "iu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2559,7 +2505,7 @@
 	dir = 8;
 	icon_state = "dark vault corner"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "iC" = (
 /obj/structure/bed/chair/office/dark,
 /turf/simulated/floor/carpet,
@@ -2683,7 +2629,7 @@
 /area/shuttle/odyssey_transfer)
 "iU" = (
 /turf/simulated/floor/carpet,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "iV" = (
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -2761,7 +2707,7 @@
 "jh" = (
 /obj/machinery/mech_bay_recharge_port,
 /turf/unsimulated/floor/planetary/path/jungle_plated,
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "ji" = (
 /obj/machinery/computer/arcade,
 /turf/simulated/floor/light,
@@ -2779,7 +2725,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "jq" = (
 /obj/machinery/light,
 /turf/simulated/floor/vox{
@@ -3058,7 +3004,7 @@
 	dir = 8;
 	icon_state = "wood"
 	},
-/area/surface/nt_outpost/store)
+/area/odyssey/store)
 "kr" = (
 /obj/machinery/conveyor_switch/oneway{
 	convdir = -1;
@@ -3067,7 +3013,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "ks" = (
 /obj/structure/closet/crate/bin,
 /turf/simulated/floor{
@@ -3095,7 +3041,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floorgrime"
 	},
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "kB" = (
 /obj/machinery/light{
 	dir = 1
@@ -3134,7 +3080,7 @@
 /turf/unsimulated/floor{
 	icon_state = "freezerfloor"
 	},
-/area/surface/nt_outpost/store)
+/area/odyssey/store)
 "kH" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/structure/cable{
@@ -3236,7 +3182,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "kP" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -3248,19 +3194,12 @@
 	},
 /turf/simulated/floor/vox,
 /area/vox_station/tradepost)
-"kQ" = (
-/obj/machinery/door/unpowered/shuttle,
-/obj/docking_port/shuttle{
-	dir = 2
-	},
-/turf/simulated/floor/shuttle,
-/area/shuttle/supply)
 "kS" = (
 /obj/structure/closet/crate,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "kU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered,
 /turf/simulated/wall/shuttle/reinforced/panel,
@@ -3347,7 +3286,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "lk" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
@@ -3466,7 +3405,7 @@
 /area/shuttle/odyssey/hallway/aft)
 "lC" = (
 /turf/simulated/floor/server,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "lD" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3564,7 +3503,7 @@
 	},
 /obj/structure/grille/window_spawner/reinforced/full,
 /turf/simulated/floor/plating,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "lZ" = (
 /obj/machinery/vending/medical,
 /turf/simulated/floor{
@@ -3584,14 +3523,14 @@
 	dir = 6;
 	icon_state = "dark"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "me" = (
 /obj/machinery/door/airlock/glass_mining{
 	name = "Cargo Office";
 	req_access_txt = "50"
 	},
 /turf/unsimulated/floor/planetary/path/jungle_plated,
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "mf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -3608,7 +3547,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "mh" = (
 /obj/machinery/media/receiver/boombox/wallmount/muzak{
 	pixel_x = -30
@@ -3670,7 +3609,7 @@
 	},
 /obj/machinery/turret,
 /turf/simulated/floor/plating,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "mq" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
@@ -3679,13 +3618,13 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "mr" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/store)
+/area/odyssey/store)
 "ms" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -3696,7 +3635,7 @@
 	dir = 4;
 	icon_state = "whiteblue"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "mt" = (
 /obj/machinery/door_timer/cell_1{
 	dir = 4;
@@ -3708,7 +3647,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "mx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -3730,7 +3669,7 @@
 /area/shuttle/odyssey/hallway/starboard)
 "mA" = (
 /turf/simulated/wall/r_wall,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "mC" = (
 /obj/machinery/computer/operating,
 /turf/simulated/floor{
@@ -3792,7 +3731,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "mI" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
@@ -3884,7 +3823,7 @@
 	},
 /obj/structure/table,
 /turf/simulated/floor,
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "mW" = (
 /obj/machinery/computer/security,
 /turf/simulated/floor,
@@ -3914,7 +3853,7 @@
 	tag = "icon-warning (NORTHWEST)"
 	},
 /turf/simulated/floor/plating,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "ni" = (
 /obj/structure/closet/crate/freezer/surgery,
 /obj/item/weapon/reagent_containers/blood/OMinus,
@@ -3952,7 +3891,7 @@
 	dir = 8;
 	icon_state = "whiteblue"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "nt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -3984,7 +3923,7 @@
 "nw" = (
 /obj/structure/grille/window_spawner/reinforced/full,
 /turf/unsimulated/floor,
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "nx" = (
 /turf/simulated/wall/shuttle/reinforced/panel,
 /area/shuttle/odyssey/security/holding_cell)
@@ -4158,7 +4097,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "nZ" = (
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
@@ -4274,13 +4213,13 @@
 /turf/simulated/floor{
 	icon_state = "cmo"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "ot" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/unsimulated/floor/planetary/path/jungle_plated,
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "ow" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -4291,7 +4230,7 @@
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "ox" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/visible/blue{
 	dir = 4;
@@ -4300,7 +4239,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "oy" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -4314,12 +4253,6 @@
 	tag = "icon-darkred (WEST)"
 	},
 /area/shuttle/odyssey/security/holding_cell)
-"oz" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/shuttle,
-/area/shuttle/supply)
 "oA" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -4396,7 +4329,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "oP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -4413,7 +4346,7 @@
 	dir = 1;
 	icon_state = "whitepurple"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "oR" = (
 /obj/structure/bed/chair/handrail{
 	dir = 8
@@ -4430,7 +4363,7 @@
 	},
 /obj/item/weapon/pen,
 /turf/simulated/floor/carpet,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "oY" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/layered,
 /obj/structure/closet/crate/trashcart,
@@ -4600,7 +4533,7 @@
 	},
 /obj/machinery/computer/communications,
 /turf/simulated/floor/carpet,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "pF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -4766,7 +4699,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "qh" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -4803,10 +4736,6 @@
 	},
 /turf/unsimulated/floor/planetary/concrete,
 /area/shuttle/trade/start)
-"qk" = (
-/obj/machinery/light,
-/turf/simulated/floor/shuttle,
-/area/shuttle/supply)
 "qn" = (
 /obj/structure/table,
 /turf/simulated/floor{
@@ -4934,7 +4863,7 @@
 	dir = 10;
 	icon_state = "whitegreen"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "qC" = (
 /obj/item/weapon/storage/toolbox/electrical,
 /obj/item/weapon/storage/toolbox/electrical,
@@ -4995,7 +4924,11 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
+"qM" = (
+/obj/machinery/light/small,
+/turf/simulated/floor,
+/area/security/perma)
 "qN" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/storage/box/drinkingglasses{
@@ -5020,7 +4953,7 @@
 /turf/simulated/floor{
 	icon_state = "whitepurple"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "qP" = (
 /obj/machinery/newscaster{
 	pixel_y = -28
@@ -5063,7 +4996,7 @@
 	})
 "qZ" = (
 /turf/unsimulated/floor/planetary/path/jungle_plated,
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "ra" = (
 /obj/structure/closet/secure_closet/warden,
 /obj/machinery/newscaster{
@@ -5083,7 +5016,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "rg" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -5109,12 +5042,19 @@
 	icon_state = "dark"
 	},
 /area/shuttle/odyssey/logistics)
+"ri" = (
+/obj/structure/rack/crate_shelf/centcomm_provided,
+/obj/machinery/light,
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
+/area/odyssey/cargo)
 "rm" = (
 /obj/structure/bed/chair/wood/pew/right{
 	dir = 8
 	},
 /turf/unsimulated/floor/grass,
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "ro" = (
 /obj/structure/catwalk,
 /turf/unsimulated/floor/planetary/concrete,
@@ -5134,7 +5074,7 @@
 	dir = 8;
 	icon_state = "whiteblue"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "ru" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
@@ -5151,13 +5091,13 @@
 	dir = 6;
 	icon_state = "dark"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "rw" = (
 /obj/structure/table/woodentable,
 /obj/machinery/recharger,
 /obj/item/device/flashlight/lamp/green,
 /turf/simulated/floor/carpet,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "ry" = (
 /obj/machinery/atmospherics/unary/vent_pump/on/layered{
 	dir = 4
@@ -5248,7 +5188,7 @@
 	dir = 6;
 	icon_state = "dark"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "rX" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/visible/blue{
 	dir = 9;
@@ -5260,7 +5200,7 @@
 	},
 /obj/structure/grille/window_spawner/reinforced/full,
 /turf/simulated/floor/plating,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "rZ" = (
 /obj/machinery/door/airlock/external{
 	name = "Starboard External Airlock";
@@ -5311,7 +5251,7 @@
 	dir = 6;
 	icon_state = "dark"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "sm" = (
 /obj/structure/bed/chair/shuttle{
 	dir = 8
@@ -5327,7 +5267,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floorgrime"
 	},
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "sq" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -5359,7 +5299,7 @@
 /turf/unsimulated/floor{
 	icon_state = "bar"
 	},
-/area/surface/nt_outpost/store)
+/area/odyssey/store)
 "sw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered,
 /turf/simulated/wall/shuttle/reinforced/panel,
@@ -5370,7 +5310,7 @@
 	dir = 6;
 	icon_state = "dark"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "sy" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil/cyan,
@@ -5439,7 +5379,7 @@
 	},
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "sE" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -5525,7 +5465,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floorgrime"
 	},
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "sX" = (
 /obj/machinery/power/apc{
 	pixel_y = 30;
@@ -5678,7 +5618,7 @@
 	dir = 10;
 	icon_state = "dark vault stripe"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "tu" = (
 /obj/machinery/door/airlock/external{
 	name = "Maintenance";
@@ -5761,9 +5701,6 @@
 	icon_state = "dark"
 	},
 /area/shuttle/odyssey/logistics)
-"tF" = (
-/turf/simulated/floor/shuttle,
-/area/shuttle/supply)
 "tH" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor{
@@ -5826,12 +5763,12 @@
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "tP" = (
 /turf/unsimulated/floor{
 	icon_state = "bar"
 	},
-/area/surface/nt_outpost/store)
+/area/odyssey/store)
 "tQ" = (
 /obj/structure/bed/chair/folding{
 	dir = 4
@@ -5894,7 +5831,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "tY" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/reinforced,
@@ -5902,7 +5839,7 @@
 	dir = 6;
 	icon_state = "whiteblue"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "tZ" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/food/snacks/porktenderloin{
@@ -5963,7 +5900,7 @@
 	dir = 6;
 	icon_state = "dark"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "uo" = (
 /turf/simulated/wall/shuttle/panel/black,
 /area/shuttle/odyssey/quarters/crew)
@@ -6066,7 +6003,7 @@
 /turf/unsimulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/store)
+/area/odyssey/store)
 "uN" = (
 /obj/machinery/door/airlock/glass_medical,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
@@ -6106,13 +6043,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/surface/nt_outpost/admin)
-"uV" = (
-/obj/structure/shuttle/diag_wall/smooth{
-	dir = 8
-	},
-/turf/simulated/floor/shuttle,
-/area/shuttle/supply)
+/area/odyssey/admin)
 "uY" = (
 /obj/item/weapon/stool{
 	pixel_y = 8
@@ -6136,7 +6067,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "vb" = (
 /obj/item/weapon/paper_bin/orange{
 	pixel_x = -3;
@@ -6151,7 +6082,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floorgrime"
 	},
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "vc" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -6160,12 +6091,6 @@
 /area/vox_trading_post/trading_floor{
 	name = "\improper Vox Casino"
 	})
-"vg" = (
-/obj/structure/shuttle/diag_wall/smooth{
-	dir = 4
-	},
-/turf/unsimulated/floor/planetary/concrete,
-/area/shuttle/supply)
 "vi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
 	dir = 4;
@@ -6220,7 +6145,7 @@
 /obj/machinery/computer/ordercomp,
 /obj/machinery/light,
 /turf/unsimulated/floor/planetary/path/jungle_plated,
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "vs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layered,
@@ -6334,7 +6259,7 @@
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "vI" = (
 /obj/structure/railing{
 	dir = 4
@@ -6376,7 +6301,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "vR" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -6461,7 +6386,7 @@
 	dir = 5;
 	icon_state = "whitegreen"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "wa" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -6506,7 +6431,7 @@
 	dir = 4;
 	icon_state = "whitegreen"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "wg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
 	dir = 4;
@@ -6523,7 +6448,7 @@
 	dir = 6;
 	icon_state = "dark"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "wi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -6592,7 +6517,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "ws" = (
 /turf/simulated/wall/shuttle/panel/black,
 /area/shuttle/odyssey/restroom)
@@ -6697,7 +6622,7 @@
 "wG" = (
 /obj/structure/sign/poster/cargo,
 /turf/simulated/wall/invulnerable/r_wall,
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "wH" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -6771,7 +6696,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floorgrime"
 	},
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "wU" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -6854,7 +6779,7 @@
 	dir = 8;
 	icon_state = "whiteblue"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "xc" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -36
@@ -6950,20 +6875,20 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/store)
+/area/odyssey/store)
 "xq" = (
 /obj/machinery/conveyor{
 	id_tag = "QMLoad"
 	},
 /obj/structure/plasticflaps/mining,
 /obj/machinery/door/poddoor{
-	id_tag = "QMLoaddoor2";
+	id_tag = "QMLoaddoor";
 	name = "Supply Dock Loading Door"
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "xs" = (
 /obj/machinery/sweet,
 /obj/machinery/light,
@@ -7028,7 +6953,7 @@
 /obj/machinery/photocopier,
 /obj/machinery/light,
 /turf/simulated/floor/carpet,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "xD" = (
 /obj/structure/rack,
 /obj/machinery/door_control{
@@ -7067,7 +6992,7 @@
 /turf/simulated/floor{
 	icon_state = "whiteblue"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "xJ" = (
 /obj/machinery/docklight{
 	id_tag = "NT Outpost";
@@ -7123,7 +7048,7 @@
 	dir = 4;
 	icon_state = "whitepurple"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "xT" = (
 /obj/machinery/power/apc{
 	pixel_x = -30;
@@ -7279,7 +7204,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/store)
+/area/odyssey/store)
 "yu" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -7296,7 +7221,7 @@
 	dir = 8;
 	icon_state = "whiteblue"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "yw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
@@ -7352,7 +7277,7 @@
 	dir = 5;
 	icon_state = "whitegreen"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "yE" = (
 /obj/structure/bed/chair/office/light{
 	dir = 8
@@ -7360,7 +7285,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "yF" = (
 /obj/structure/table/glass,
 /obj/item/ashtray/glass,
@@ -7415,11 +7340,11 @@
 	dir = 8;
 	icon_state = "whitegreen"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "yS" = (
 /obj/structure/bed/chair/comfy/black,
 /turf/simulated/floor/carpet,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "yW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -7448,7 +7373,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "yZ" = (
 /obj/machinery/computer/library/checkout,
 /obj/structure/table/woodentable,
@@ -7456,7 +7381,7 @@
 	dir = 6;
 	icon_state = "dark"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "zd" = (
 /turf/simulated/floor/wood,
 /area/shuttle/odyssey/quarters/crew)
@@ -7492,7 +7417,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floorgrime"
 	},
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "zm" = (
 /obj/structure/mopbucket,
 /obj/item/weapon/mop,
@@ -7506,10 +7431,6 @@
 	tag = "icon-showroomfloor (NORTH)"
 	},
 /area/shuttle/odyssey/janitor)
-"zo" = (
-/obj/machinery/door/unpowered/shuttle,
-/turf/simulated/floor/shuttle,
-/area/shuttle/supply)
 "zq" = (
 /obj/structure/closet/crate/bin,
 /turf/simulated/floor/wood,
@@ -7533,13 +7454,13 @@
 	dir = 4;
 	icon_state = "whitegreen"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "zu" = (
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "whiteblue"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "zv" = (
 /obj/machinery/door_control{
 	pixel_x = 8;
@@ -7562,7 +7483,7 @@
 	},
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "zx" = (
 /obj/machinery/embedded_controller/radio/access_controller{
 	id_tag = "virology_airlock_control";
@@ -7581,13 +7502,13 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "zy" = (
 /obj/machinery/computer/cloning,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "zz" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -7607,7 +7528,7 @@
 /area/shuttle/odyssey/bridge)
 "zC" = (
 /turf/simulated/wall/invulnerable/r_wall,
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "zD" = (
 /obj/machinery/status_display/odyssey,
 /turf/simulated/wall/shuttle/reinforced/panel,
@@ -7675,7 +7596,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/server/bluegrid,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "zM" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -7842,7 +7763,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floorgrime"
 	},
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "Ac" = (
 /obj/machinery/light{
 	dir = 8
@@ -7871,7 +7792,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "Al" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -7951,20 +7872,13 @@
 /obj/structure/window/reinforced,
 /obj/structure/grille,
 /turf/simulated/floor/plating,
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Aw" = (
 /obj/effect/landmark/start{
 	name = "Captain"
 	},
 /turf/simulated/floor/carpet,
 /area/shuttle/odyssey/quarters/heads)
-"Ay" = (
-/obj/structure/shuttle/window{
-	icon_state = "16"
-	},
-/obj/structure/grille,
-/turf/simulated/floor/shuttle/plating,
-/area/shuttle/supply)
 "Az" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -8036,7 +7950,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor5"
 	},
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "AO" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -8047,7 +7961,7 @@
 	dir = 8;
 	icon_state = "whitegreen"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "AP" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 5
@@ -8070,7 +7984,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "AS" = (
 /turf/simulated/wall/shuttle/panel/black,
 /area/shuttle/odyssey/hallway/starboard)
@@ -8128,7 +8042,7 @@
 	pixel_y = -2
 	},
 /turf/simulated/wall/r_wall,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "Bo" = (
 /obj/machinery/atmospherics/unary/vent_pump/on/layered{
 	dir = 8
@@ -8197,7 +8111,7 @@
 /obj/item/weapon/book/manual/security_space_law,
 /obj/structure/table/woodentable,
 /turf/simulated/floor/carpet,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "BA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layered{
 	dir = 8;
@@ -8349,7 +8263,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "Cb" = (
 /obj/machinery/computer/communications/odyssey,
 /turf/simulated/floor{
@@ -8359,7 +8273,7 @@
 /area/shuttle/odyssey/bridge)
 "Cc" = (
 /turf/simulated/wall,
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Cd" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layered{
 	dir = 1;
@@ -8469,7 +8383,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "Cs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -8481,7 +8395,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "Cw" = (
 /obj/machinery/atmospherics/unary/cold_sink/freezer{
 	current_temperature = 80;
@@ -8502,7 +8416,7 @@
 	icon_state = "warning"
 	},
 /turf/simulated/floor/plating,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "Cx" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layered{
 	dir = 1
@@ -8534,17 +8448,18 @@
 /area/shuttle/trade/start)
 "CD" = (
 /obj/structure/ore_box,
+/obj/machinery/light,
 /turf/unsimulated/floor{
 	icon_state = "floorgrime"
 	},
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "CF" = (
 /obj/machinery/computer/diseasesplicer,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "whitegreen"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "CI" = (
 /turf/simulated/wall/shuttle/reinforced/panel,
 /area/shuttle/odyssey/engineering/gas_storage/port)
@@ -8741,7 +8656,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Dw" = (
 /obj/effect/decal/warning_stripes/pathmarkers{
 	icon_state = "maintguide";
@@ -8766,7 +8681,7 @@
 /turf/simulated/floor{
 	icon_state = "cmo"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "DA" = (
 /obj/structure/rack,
 /obj/item/device/modkit/gold_rig,
@@ -8800,7 +8715,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "DD" = (
 /obj/machinery/biogenerator,
 /turf/simulated/floor{
@@ -8888,7 +8803,7 @@
 /turf/unsimulated/floor{
 	icon_state = "freezerfloor"
 	},
-/area/surface/nt_outpost/store)
+/area/odyssey/store)
 "DN" = (
 /obj/structure/closet/secure_closet/freezer/kitchen/mining,
 /turf/simulated/floor{
@@ -8905,7 +8820,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "DT" = (
 /obj/item/device/radio/intercom{
 	pixel_y = 30
@@ -8972,7 +8887,7 @@
 	dir = 6;
 	icon_state = "dark"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "Ec" = (
 /obj/machinery/computer/crew,
 /turf/simulated/floor{
@@ -9023,12 +8938,6 @@
 	},
 /turf/simulated/floor/plated_catwalk/dark,
 /area/shuttle/odyssey/hallway/port)
-"Em" = (
-/obj/structure/shuttle/diag_wall/smooth{
-	dir = 8
-	},
-/turf/unsimulated/floor/planetary/concrete,
-/area/shuttle/supply)
 "Eo" = (
 /obj/machinery/status_display/odyssey,
 /turf/simulated/wall/shuttle/panel/black,
@@ -9063,7 +8972,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "EB" = (
 /obj/machinery/vending/hydronutrients,
 /turf/simulated/floor{
@@ -9154,7 +9063,7 @@
 	dir = 5;
 	icon_state = "warnwhite"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "ET" = (
 /obj/effect/decal/warning_stripes{
 	dir = 8;
@@ -9164,7 +9073,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "EU" = (
 /turf/simulated/floor{
 	icon_state = "rampbottom";
@@ -9176,7 +9085,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "EW" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -9216,20 +9125,13 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/store)
+/area/odyssey/store)
 "Fg" = (
 /obj/machinery/mech_bay_recharge_floor{
 	icon_state = "recharge_floor_asteroid"
 	},
 /turf/unsimulated/floor/planetary/path/jungle_plated,
-/area/surface/nt_outpost/mineral_processing)
-"Fi" = (
-/obj/structure/shuttle/window{
-	icon_state = "9"
-	},
-/obj/structure/grille,
-/turf/simulated/floor/shuttle/plating,
-/area/shuttle/supply)
+/area/odyssey/mineral_processing)
 "Fl" = (
 /obj/structure/table,
 /obj/item/critter_cage/with_mouse{
@@ -9238,12 +9140,12 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Fn" = (
 /turf/unsimulated/floor{
 	icon_state = "floorgrime"
 	},
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "Fp" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/folder/black{
@@ -9269,7 +9171,7 @@
 	dir = 4;
 	icon_state = "whiteblue"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Fq" = (
 /obj/structure/wc/sink{
 	pixel_y = 28
@@ -9325,7 +9227,7 @@
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "FA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layered,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered,
@@ -9357,13 +9259,13 @@
 "FH" = (
 /obj/structure/grille/window_spawner/reinforced/full,
 /turf/simulated/floor/plating,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "FI" = (
 /obj/machinery/mineral/mint,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "FK" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 8
@@ -9393,7 +9295,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/store)
+/area/odyssey/store)
 "FP" = (
 /obj/effect/landmark/start{
 	name = "Head of Personnel"
@@ -9406,7 +9308,7 @@
 	dir = 1;
 	icon_state = "whitegreen"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "FS" = (
 /obj/structure/table,
 /obj/item/weapon/folder/blue,
@@ -9455,7 +9357,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/server,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "FZ" = (
 /obj/structure/railing,
 /obj/machinery/computer/shuttle_control/odyssey_transfer,
@@ -9516,7 +9418,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Gm" = (
 /obj/machinery/r_n_d/fabricator/mechanic_fab/autolathe,
 /obj/structure/sign/directions/medical{
@@ -9606,7 +9508,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "GE" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -9663,7 +9565,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor5"
 	},
-/area/surface/nt_outpost/store)
+/area/odyssey/store)
 "GN" = (
 /obj/item/device/radio/intercom{
 	pixel_x = -30
@@ -9687,7 +9589,7 @@
 	dir = 8;
 	icon_state = "wood"
 	},
-/area/surface/nt_outpost/store)
+/area/odyssey/store)
 "GS" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -9768,7 +9670,7 @@
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Hg" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -9800,10 +9702,6 @@
 	},
 /turf/simulated/floor,
 /area/shuttle/odyssey/hallway/central)
-"Hl" = (
-/obj/structure/shuttle/diag_wall/smooth,
-/turf/simulated/floor/shuttle,
-/area/shuttle/supply)
 "Ho" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -9834,19 +9732,19 @@
 /turf/simulated/floor{
 	icon_state = "cmo"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Ht" = (
 /obj/machinery/crate_weigher,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "Hu" = (
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "warnwhite"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Hv" = (
 /turf/simulated/wall/r_wall,
 /area/tcomms/chamber)
@@ -9860,7 +9758,7 @@
 /turf/unsimulated/floor{
 	icon_state = "bar"
 	},
-/area/surface/nt_outpost/store)
+/area/odyssey/store)
 "HB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layered{
 	dir = 5;
@@ -9911,7 +9809,7 @@
 	dir = 8;
 	icon_state = "whiteblue"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "HK" = (
 /obj/machinery/vending/sale,
 /turf/simulated/wall,
@@ -9937,7 +9835,7 @@
 	dir = 6;
 	icon_state = "dark"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "HP" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/structure/hanging_lantern{
@@ -10031,7 +9929,7 @@
 	dir = 6;
 	icon_state = "dark"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "Ii" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -10073,14 +9971,14 @@
 /area/shuttle/odyssey/engineering/gas_storage/starboard)
 "Io" = (
 /turf/simulated/wall/r_wall,
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Iq" = (
 /turf/unsimulated/floor/planetary/concrete,
 /area/surface/nt_outpost)
 "Is" = (
 /obj/machinery/computer/labor,
 /turf/simulated/floor/carpet,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "It" = (
 /obj/machinery/vaporizer,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -10134,7 +10032,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "IG" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -10157,7 +10055,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "II" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -10225,7 +10123,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "IR" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -10259,7 +10157,7 @@
 	dir = 8;
 	icon_state = "wood"
 	},
-/area/surface/nt_outpost/store)
+/area/odyssey/store)
 "IW" = (
 /obj/machinery/power/battery/smes,
 /obj/structure/cable{
@@ -10355,7 +10253,7 @@
 	dir = 5;
 	icon_state = "whitegreen"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Jj" = (
 /obj/machinery/alarm/vox{
 	dir = 8;
@@ -10391,7 +10289,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Jq" = (
 /turf/simulated/wall,
 /area/vox_station/tradepost)
@@ -10429,7 +10327,7 @@
 	dir = 4;
 	icon_state = "whiteblue"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Jw" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
@@ -10438,7 +10336,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "Jx" = (
 /obj/structure/railing/wood/glass{
 	dir = 1
@@ -10528,7 +10426,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "JN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -10603,7 +10501,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "Ka" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/unary/vent_scrubber/layered{
@@ -10642,7 +10540,7 @@
 	dir = 1;
 	icon_state = "whitepurple"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Kf" = (
 /obj/structure/bed/chair/folding{
 	dir = 8
@@ -10703,7 +10601,7 @@
 "Kq" = (
 /obj/machinery/vending/cart,
 /turf/simulated/floor/carpet,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "Ks" = (
 /obj/structure/hanging_lantern{
 	dir = 1
@@ -10722,7 +10620,7 @@
 	dir = 4;
 	icon_state = "whitegreen"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Kw" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	default_scrubbed_gases = list( "carbon_dioxide", "plasma", "oxygen" );
@@ -10756,7 +10654,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/store)
+/area/odyssey/store)
 "KA" = (
 /obj/machinery/docklight{
 	id_tag = "NTEV Odyssey Crew Transfer Shuttle Landing Zone";
@@ -10787,7 +10685,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "KI" = (
 /obj/machinery/door/airlock/medical{
 	autoclose = 0;
@@ -10803,7 +10701,7 @@
 	dir = 1;
 	icon_state = "whitegreencorner"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "KJ" = (
 /obj/machinery/door/airlock/glass,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layered,
@@ -10843,7 +10741,7 @@
 	dir = 5;
 	icon_state = "whitepurple"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "KT" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/hidden/blue{
 	dir = 4
@@ -10854,7 +10752,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "KW" = (
 /obj/structure/wc/sink/kitchen{
 	pixel_y = 30
@@ -10880,7 +10778,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/store)
+/area/odyssey/store)
 "Lb" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -10945,7 +10843,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "Lg" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -11023,7 +10921,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "Ly" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layered{
 	dir = 8;
@@ -11108,13 +11006,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on/layered,
 /turf/simulated/floor/plating,
 /area/shuttle/odyssey/engineering/engine_room)
-"LH" = (
-/obj/structure/shuttle/window{
-	icon_state = "8"
-	},
-/obj/structure/grille,
-/turf/simulated/floor/shuttle/plating,
-/area/shuttle/supply)
 "LI" = (
 /obj/machinery/conveyor{
 	id_tag = "QMLoad2"
@@ -11127,7 +11018,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "LK" = (
 /obj/structure/railing{
 	dir = 1
@@ -11265,7 +11156,7 @@
 	dir = 8;
 	icon_state = "wood"
 	},
-/area/surface/nt_outpost/store)
+/area/odyssey/store)
 "Mc" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -11438,19 +11329,19 @@
 /area/shuttle/odyssey/engineering/gas_storage/starboard)
 "Mx" = (
 /turf/simulated/wall,
-/area/surface/nt_outpost/store)
+/area/odyssey/store)
 "Mz" = (
 /obj/structure/grille/window_spawner/reinforced/full,
 /turf/unsimulated/floor{
 	icon_state = "floor5"
 	},
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "MC" = (
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "dark vault stripe"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "MF" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -11469,7 +11360,7 @@
 /turf/simulated/floor{
 	icon_state = "whitegreen"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "MJ" = (
 /obj/machinery/door/airlock/glass_command{
 	req_access_txt = "19"
@@ -11539,7 +11430,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "MV" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -11618,14 +11509,14 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "Ng" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/unsimulated/floor{
 	dir = 8;
 	icon_state = "wood"
 	},
-/area/surface/nt_outpost/store)
+/area/odyssey/store)
 "Nk" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -11661,14 +11552,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/store)
-"Nt" = (
-/obj/structure/shuttle/window{
-	icon_state = "14"
-	},
-/obj/structure/grille,
-/turf/simulated/floor/shuttle/plating,
-/area/shuttle/supply)
+/area/odyssey/store)
 "Nu" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -11762,7 +11646,7 @@
 	dir = 6;
 	icon_state = "dark"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "ND" = (
 /obj/effect/decal/warning_stripes{
 	dir = 6;
@@ -11806,7 +11690,7 @@
 	tag = "icon-warning (WEST)"
 	},
 /turf/simulated/floor/plating,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "NK" = (
 /obj/machinery/computer/smelting{
 	smelter_tag = "mining_smelter"
@@ -11814,7 +11698,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floorgrime"
 	},
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "NL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
 	dir = 9;
@@ -11878,7 +11762,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Oc" = (
 /obj/machinery/power/solar/panel/tracker,
 /obj/structure/cable/yellow,
@@ -11918,11 +11802,11 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "Or" = (
 /obj/machinery/account_database,
 /turf/simulated/floor/carpet,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "Ou" = (
 /turf/simulated/wall/shuttle/panel/black,
 /area/shuttle/odyssey/hallway/fore/lobby)
@@ -11942,7 +11826,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "OD" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/simulated/floor{
@@ -11988,9 +11872,6 @@
 	icon_state = "floorgrime"
 	},
 /area/security/perma)
-"OL" = (
-/turf/simulated/wall/shuttle,
-/area/shuttle/supply)
 "OM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor/vox{
@@ -12023,7 +11904,7 @@
 	dir = 6;
 	icon_state = "dark"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "OQ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layered,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layered{
@@ -12087,7 +11968,7 @@
 	dir = 8
 	},
 /turf/unsimulated/floor/grass,
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "OY" = (
 /obj/machinery/microwave{
 	pixel_x = -1;
@@ -12103,12 +11984,6 @@
 	icon_state = "floorgrime"
 	},
 /area/security/perma)
-"OZ" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 4
-	},
-/turf/unsimulated/floor/planetary/concrete,
-/area/shuttle/supply)
 "Pa" = (
 /obj/structure/rack/crate_shelf/centcomm_provided,
 /obj/structure/vendomatpack/security,
@@ -12133,7 +12008,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/server/bluegrid,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "Pd" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/reagent_containers/food/condiment/enzyme{
@@ -12152,6 +12027,9 @@
 	},
 /obj/item/weapon/reagent_containers/food/condiment/saltshaker{
 	pixel_x = -3
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
@@ -12183,7 +12061,7 @@
 	dir = 8;
 	icon_state = "whitegreen"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Pj" = (
 /obj/machinery/computer/secure_data,
 /obj/structure/window/reinforced,
@@ -12283,14 +12161,14 @@
 	dir = 4;
 	icon_state = "whitegreen"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Ps" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "whitegreen"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Pt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
 	dir = 4;
@@ -12316,7 +12194,7 @@
 	dir = 6;
 	icon_state = "dark"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "Pv" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -12372,7 +12250,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floorgrime"
 	},
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "PH" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -12380,7 +12258,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "PI" = (
 /obj/machinery/seed_extractor,
 /turf/simulated/floor/vox,
@@ -12423,7 +12301,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor5"
 	},
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "PQ" = (
 /obj/structure/table,
 /obj/item/weapon/stock_parts/subspace/ansible,
@@ -12440,7 +12318,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "PR" = (
 /obj/structure/table,
 /obj/item/weapon/storage/belt/slim,
@@ -12484,7 +12362,7 @@
 	dir = 1;
 	icon_state = "whitegreen"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "PU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layered{
 	dir = 9;
@@ -12517,7 +12395,7 @@
 	dir = 8;
 	icon_state = "whiteblue"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "PY" = (
 /obj/structure/bed/chair/shuttle/blue{
 	dir = 4;
@@ -12565,7 +12443,7 @@
 /turf/simulated/floor{
 	icon_state = "whiteblue"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Qj" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8;
@@ -12681,7 +12559,7 @@
 /turf/unsimulated/floor{
 	icon_state = "freezerfloor"
 	},
-/area/surface/nt_outpost/store)
+/area/odyssey/store)
 "Qx" = (
 /obj/machinery/atmospherics/unary/vent_pump/on/layered{
 	dir = 1
@@ -12729,7 +12607,7 @@
 /turf/unsimulated/floor{
 	icon_state = "freezerfloor"
 	},
-/area/surface/nt_outpost/store)
+/area/odyssey/store)
 "QB" = (
 /obj/machinery/light{
 	dir = 1
@@ -12739,7 +12617,7 @@
 	dir = 6;
 	icon_state = "dark"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "QC" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/visible/blue{
 	dir = 10
@@ -12750,7 +12628,7 @@
 	},
 /obj/structure/grille/window_spawner/reinforced/full,
 /turf/simulated/floor/plating,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "QD" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layered{
@@ -12768,7 +12646,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/server,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "QH" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/decal/warning_stripes{
@@ -12785,13 +12663,13 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "QJ" = (
 /obj/machinery/atmospherics/unary/cryo_cell,
 /turf/simulated/floor{
 	icon_state = "cmo"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "QL" = (
 /obj/machinery/door/airlock/glass_medical{
 	name = "Outpost Clinic"
@@ -12799,7 +12677,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "QN" = (
 /obj/structure/table,
 /obj/item/weapon/paper_bin/purple{
@@ -12814,7 +12692,7 @@
 /turf/unsimulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/store)
+/area/odyssey/store)
 "QO" = (
 /obj/structure/bed/chair/shuttle{
 	dir = 4;
@@ -12851,7 +12729,7 @@
 	dir = 6;
 	icon_state = "dark"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "QR" = (
 /obj/structure/mirror{
 	pixel_x = 28
@@ -12896,7 +12774,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Ra" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/vox{
@@ -12910,7 +12788,7 @@
 /turf/simulated/floor{
 	icon_state = "cmo"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Rc" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4;
@@ -12923,7 +12801,7 @@
 "Rd" = (
 /obj/structure/sign/biohazard,
 /turf/simulated/wall/r_wall,
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Rg" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -12987,7 +12865,7 @@
 "Rm" = (
 /obj/machinery/r_n_d/server/robotics,
 /turf/simulated/floor/server/bluegrid,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "Rn" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -13015,11 +12893,11 @@
 	dir = 6;
 	icon_state = "dark"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "Rp" = (
 /obj/structure/grille/window_spawner/reinforced/full,
 /turf/unsimulated/floor/planetary/path/jungle_plated,
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "Rr" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
@@ -13098,7 +12976,7 @@
 /turf/simulated/floor{
 	icon_state = "cmo"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "RB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -13129,7 +13007,7 @@
 	dir = 6;
 	icon_state = "warnwhite"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "RG" = (
 /obj/machinery/light{
 	dir = 1
@@ -13140,7 +13018,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "RH" = (
 /obj/effect/decal/warning_stripes{
 	dir = 8;
@@ -13150,7 +13028,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "RI" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating/vox,
@@ -13243,7 +13121,7 @@
 	dir = 6;
 	icon_state = "dark"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "Sa" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8
@@ -13266,7 +13144,7 @@
 	dir = 1;
 	icon_state = "whitegreen"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Sd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -13405,13 +13283,13 @@
 /turf/unsimulated/floor{
 	icon_state = "bar"
 	},
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "Sx" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 4
 	},
 /turf/simulated/floor/carpet,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "Sy" = (
 /obj/structure/table,
 /obj/machinery/door/window{
@@ -13420,7 +13298,7 @@
 /turf/unsimulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/store)
+/area/odyssey/store)
 "Sz" = (
 /obj/machinery/smartfridge/chemistry,
 /turf/simulated/floor/vox{
@@ -13450,14 +13328,7 @@
 /turf/simulated/floor{
 	icon_state = "whiteblue"
 	},
-/area/surface/nt_outpost/clinic)
-"SK" = (
-/obj/structure/shuttle/window{
-	icon_state = "15"
-	},
-/obj/structure/grille,
-/turf/simulated/floor/shuttle/plating,
-/area/shuttle/supply)
+/area/odyssey/clinic)
 "SL" = (
 /obj/structure/railing{
 	dir = 1
@@ -13513,7 +13384,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "SS" = (
 /obj/structure/shuttle/diag_wall/diy/smooth/black{
 	dir = 1;
@@ -13552,7 +13423,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "Tb" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/food/drinks/drinkingglass,
@@ -13565,7 +13436,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "Td" = (
 /obj/machinery/door/airlock,
 /obj/structure/cable{
@@ -13608,7 +13479,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Tp" = (
 /obj/effect/decal/warning_stripes{
 	dir = 10;
@@ -13629,7 +13500,7 @@
 /turf/unsimulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/store)
+/area/odyssey/store)
 "Tr" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/simulated/floor/plating,
@@ -13669,7 +13540,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "Tv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layered{
 	dir = 6;
@@ -13737,7 +13608,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "TK" = (
 /obj/structure/fence/corner{
 	dir = 1
@@ -13776,7 +13647,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "TW" = (
 /obj/structure/railing{
 	dir = 1
@@ -13798,7 +13669,7 @@
 	dir = 4;
 	icon_state = "warnwhite"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Ub" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layered,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered,
@@ -13827,7 +13698,7 @@
 	dir = 1;
 	icon_state = "whitegreen"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Ug" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layered{
 	dir = 10;
@@ -14036,7 +13907,7 @@
 /turf/simulated/floor{
 	icon_state = "dark vault stripe"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "UJ" = (
 /obj/structure/closet/crate/bin,
 /obj/structure/window/reinforced{
@@ -14129,7 +14000,7 @@
 	dir = 6;
 	icon_state = "dark"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "Vb" = (
 /obj/machinery/door/airlock,
 /obj/structure/cable{
@@ -14195,7 +14066,7 @@
 /turf/unsimulated/floor{
 	icon_state = "bar"
 	},
-/area/surface/nt_outpost/store)
+/area/odyssey/store)
 "Vi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layered{
 	dir = 3;
@@ -14238,13 +14109,13 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Vn" = (
 /obj/machinery/light,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "Vo" = (
 /obj/item/weapon/caution/cone{
 	pixel_x = 8;
@@ -14424,6 +14295,15 @@
 	icon_state = "bar"
 	},
 /area/shuttle/odyssey/cafeteria)
+"VR" = (
+/obj/structure/rack/crate_shelf/centcomm_provided,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
+/area/odyssey/cargo)
 "VU" = (
 /obj/structure/bed/chair/shuttle,
 /turf/simulated/floor/shuttle,
@@ -14476,7 +14356,7 @@
 /area/shuttle/odyssey/engineering/engine_room)
 "Wb" = (
 /turf/simulated/wall,
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "Wc" = (
 /turf/simulated/wall/shuttle/panel/black,
 /area/shuttle/odyssey/engineering/gas_storage/port)
@@ -14512,7 +14392,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "Wl" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -14535,6 +14415,9 @@
 	dir = 8
 	},
 /obj/structure/curtain/open/privacy,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -14598,11 +14481,11 @@
 /turf/simulated/floor{
 	icon_state = "cmo"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Wt" = (
 /obj/machinery/computer/mech_bay_power_console/autolink_west,
 /turf/unsimulated/floor/planetary/path/jungle_plated,
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "Wv" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -14646,7 +14529,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "WE" = (
 /obj/structure/hanging_lantern,
 /turf/unsimulated/floor/planetary/path/jungle_plated,
@@ -14694,13 +14577,7 @@
 	dir = 8;
 	icon_state = "whiteblue"
 	},
-/area/surface/nt_outpost/clinic)
-"WJ" = (
-/obj/structure/shuttle/diag_wall/smooth{
-	dir = 1
-	},
-/turf/unsimulated/floor/planetary/concrete,
-/area/shuttle/supply)
+/area/odyssey/clinic)
 "WO" = (
 /obj/machinery/computer/security_alerts,
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -14738,7 +14615,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "WU" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -14793,7 +14670,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "Xa" = (
 /obj/structure/bed/chair,
 /obj/effect/landmark/start{
@@ -14820,7 +14697,7 @@
 	icon_state = "whitebluecorner";
 	dir = 8
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Xd" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -14897,7 +14774,7 @@
 /turf/simulated/floor{
 	icon_state = "cmo"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Xp" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	initialize_directions = 11
@@ -14973,7 +14850,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "XG" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "unloading"
@@ -14984,13 +14861,13 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "XH" = (
 /obj/machinery/disposal/compactor,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "XJ" = (
 /obj/machinery/door/mineral/wood,
 /turf/simulated/floor/plating,
@@ -15017,7 +14894,7 @@
 	name = "SERVER ROOM"
 	},
 /turf/simulated/wall/r_wall,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "XO" = (
 /obj/item/toy/gasha/skub,
 /obj/machinery/firealarm{
@@ -15059,7 +14936,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/carpet,
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "XT" = (
 /obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
 	frequency = 1331;
@@ -15101,7 +14978,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "Ya" = (
 /obj/machinery/computer/card,
 /obj/structure/railing{
@@ -15331,7 +15208,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "YH" = (
 /obj/structure/bed/chair/comfy/black,
 /turf/simulated/floor{
@@ -15345,7 +15222,7 @@
 /turf/simulated/floor{
 	icon_state = "cmo"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "YJ" = (
 /obj/structure/table,
 /obj/machinery/smartfridge/mini,
@@ -15384,18 +15261,18 @@
 /area/shuttle/odyssey/cafeteria)
 "YT" = (
 /obj/machinery/conveyor_switch/oneway{
-	id_tag = "QMLoad3"
+	id_tag = "QMLoad2"
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/surface/nt_outpost/cargo)
+/area/odyssey/cargo)
 "YU" = (
 /obj/structure/bed/chair/vehicle/wheelchair,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "YV" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -15449,7 +15326,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor/plating,
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Zm" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -15502,7 +15379,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "Zr" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -15532,7 +15409,7 @@
 /turf/unsimulated/floor{
 	icon_state = "floorgrime"
 	},
-/area/surface/nt_outpost/mineral_processing)
+/area/odyssey/mineral_processing)
 "Zw" = (
 /obj/abstract/map/spawner/robot/clean,
 /turf/simulated/floor/wood,
@@ -15569,7 +15446,7 @@
 	dir = 6;
 	icon_state = "dark"
 	},
-/area/surface/nt_outpost/admin)
+/area/odyssey/admin)
 "ZC" = (
 /turf/simulated/floor/carpet,
 /area/shuttle/trade/start)
@@ -15605,7 +15482,7 @@
 	dir = 10;
 	icon_state = "whiteblue"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "ZK" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "loading_area";
@@ -15650,7 +15527,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/surface/nt_outpost/clinic)
+/area/odyssey/clinic)
 "ZX" = (
 /obj/structure/sign/poster{
 	pixel_y = 30
@@ -41017,7 +40894,7 @@ mL
 sS
 mL
 mL
-mL
+qM
 sg
 Vt
 Sq
@@ -41289,13 +41166,13 @@ Bc
 Bc
 Bc
 nl
-Em
-OL
-Ay
-LH
-SK
-OL
-go
+Iq
+Iq
+Iq
+Iq
+Iq
+Iq
+Iq
 Iq
 Iq
 Mz
@@ -41591,13 +41468,13 @@ Bc
 Bc
 Bc
 nl
-OL
-tF
-tF
-tF
-tF
-tF
-OL
+Iq
+Iq
+Iq
+Iq
+Iq
+Iq
+Iq
 Iq
 Iq
 Mz
@@ -41617,7 +41494,7 @@ Wh
 RB
 uY
 Sp
-mL
+qM
 sg
 Pm
 zR
@@ -41893,13 +41770,13 @@ Bc
 Bc
 Bc
 nl
-OL
-tF
-tF
-tF
-tF
-qk
-OL
+Iq
+Iq
+Iq
+Iq
+Iq
+Iq
+Iq
 Iq
 Iq
 Mz
@@ -42195,13 +42072,13 @@ Bc
 Bc
 Bc
 nl
-OL
-oz
-tF
-tF
-tF
-tF
-hw
+Iq
+Iq
+Iq
+Iq
+Iq
+Iq
+Iq
 ja
 ja
 xq
@@ -42497,13 +42374,13 @@ Bc
 Bc
 Bc
 nl
-Nt
-tF
-tF
-tF
-tF
-tF
-kQ
+Iq
+Iq
+Iq
+Iq
+Iq
+Iq
+Iq
 ss
 Iq
 PP
@@ -42799,13 +42676,13 @@ Bc
 Bc
 Bc
 nE
-Fi
-tF
-tF
-tF
-tF
-fH
-OL
+Iq
+Iq
+Iq
+Iq
+Iq
+Iq
+Iq
 Iq
 vk
 AN
@@ -43101,13 +42978,13 @@ Bc
 Bc
 Bc
 nl
-iq
-tF
-tF
-tF
-tF
-tF
-zo
+Iq
+Iq
+Iq
+Iq
+Iq
+Iq
+Iq
 Iq
 Iq
 PP
@@ -43403,13 +43280,13 @@ Bc
 Bc
 Bc
 nl
-OL
-oz
-tF
-tF
-tF
-tF
-ij
+Iq
+Iq
+Iq
+Iq
+Iq
+Iq
+Iq
 vW
 vW
 LI
@@ -43705,13 +43582,13 @@ Bc
 Bc
 Bc
 nl
-OL
-tF
-tF
-tF
-tF
-qk
-OL
+Iq
+Iq
+Iq
+Iq
+Iq
+Iq
+Iq
 Iq
 Iq
 Mz
@@ -44007,13 +43884,13 @@ Mf
 Bc
 Bc
 nl
-OL
-Hl
-tF
-tF
-tF
-uV
-OL
+Iq
+Iq
+Iq
+Iq
+Iq
+Iq
+Iq
 Iq
 Iq
 Mz
@@ -44309,13 +44186,13 @@ Mf
 Bc
 Bc
 nl
-WJ
-OL
-eD
-eD
-eD
-OL
-vg
+Iq
+Iq
+Iq
+Iq
+Iq
+Iq
+Iq
 Iq
 Iq
 Mz
@@ -44612,11 +44489,11 @@ Bc
 Bc
 nl
 Iq
-OZ
-OZ
-OZ
-OZ
-OZ
+Iq
+Iq
+Iq
+Iq
+Iq
 Iq
 Iq
 Iq
@@ -44923,12 +44800,12 @@ Iq
 Iq
 Iq
 ba
-TF
+VR
 WD
 TF
 TF
 WD
-TF
+ri
 ba
 Bc
 sg

--- a/maps/odyssey.dmm
+++ b/maps/odyssey.dmm
@@ -3623,7 +3623,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/computer/crew,
+/obj/machinery/computer/crew/odyssey,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whiteblue"
@@ -5456,7 +5456,7 @@
 	icon_state = "0-2";
 	pixel_y = 1
 	},
-/obj/structure/ore_box,
+/obj/structure/bed/chair/handrail,
 /turf/simulated/floor{
 	icon_state = "darkyellow";
 	tag = "icon-darkyellow (EAST)";
@@ -7152,7 +7152,7 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
 	},
-/obj/structure/dispenser,
+/obj/structure/ore_box,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -8867,7 +8867,7 @@
 	},
 /area/odyssey/admin)
 "Ec" = (
-/obj/machinery/computer/crew,
+/obj/machinery/computer/crew/odyssey,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark_navy";
@@ -12888,14 +12888,6 @@
 	name = "Bridge Lockdown";
 	id_tag = "bridge blast";
 	pixel_y = 8
-	},
-/obj/machinery/access_button{
-	pixel_x = -9;
-	pixel_y = -1;
-	name = "ROSA Control";
-	master_tag = "odyssey_rosa";
-	command = "toggle";
-	master_active = 0
 	},
 /turf/simulated/floor{
 	dir = 4;

--- a/maps/odyssey.dmm
+++ b/maps/odyssey.dmm
@@ -3560,7 +3560,7 @@
 /area/shuttle/odyssey/hallway/aft)
 "mi" = (
 /obj/machinery/atmospherics/miner/surface{
-	anchored = TRUE
+	anchored = 1
 	},
 /turf/simulated/floor/engine/airless,
 /area/shuttle/odyssey/engineering/gas_storage/starboard)

--- a/maps/odyssey.dmm
+++ b/maps/odyssey.dmm
@@ -2935,6 +2935,7 @@
 /obj/machinery/newscaster{
 	pixel_y = -28
 	},
+/obj/item/device/megaphone,
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "dark_navy";
@@ -4747,7 +4748,7 @@
 /area/vox_station/tradepost)
 "qp" = (
 /obj/machinery/gas_extractor{
-	anchored = TRUE
+	anchored = 1
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -13315,8 +13316,7 @@
 	},
 /area/shuttle/odyssey/engineering/engine_room)
 "SO" = (
-/obj/structure/table,
-/obj/item/device/megaphone,
+/obj/machinery/telecomms/relay/planetary/ship,
 /turf/simulated/floor{
 	dir = 12;
 	icon_state = "dark_navy";

--- a/maps/odyssey.dmm
+++ b/maps/odyssey.dmm
@@ -840,7 +840,7 @@
 "cz" = (
 /obj/machinery/conveyor{
 	dir = 10;
-	id_tag = "secdisposal"
+	id_tag = "mining_internal"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -961,18 +961,6 @@
 /turf/unsimulated/floor/planetary/path/jungle_plated,
 /area/surface/nt_outpost)
 "cT" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	canSpawnMice = 0;
-	external_pressure_bound = 0;
-	frequency = 1441;
-	icon_state = "in";
-	id_tag = "miner_out";
-	initialize_directions = 1;
-	internal_pressure_bound = 4000;
-	on = 1;
-	pressure_checks = 2;
-	pump_direction = 0
-	},
 /obj/machinery/air_sensor{
 	frequency = 1441;
 	id_tag = "miner_sensor";
@@ -980,6 +968,18 @@
 	metrics_monitored = list("pressure", "temperature", "oxygen", "plasma", "nitrogen", "carbon_dioxide","cryotheum","radon")
 	},
 /obj/machinery/light/small,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	canSpawnMice = 0;
+	dir = 1;
+	external_pressure_bound = 0;
+	frequency = 1441;
+	icon_state = "in";
+	id_tag = "miner_out";
+	internal_pressure_bound = 2000;
+	on = 1;
+	pressure_checks = 2;
+	pump_direction = 0
+	},
 /turf/simulated/floor/engine/airless,
 /area/shuttle/odyssey/engineering/gas_storage/starboard)
 "cU" = (
@@ -1546,8 +1546,7 @@
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
-	pump_direction = 0;
-	dir = 1
+	pump_direction = 0
 	},
 /turf/simulated/floor/engine/airless,
 /area/shuttle/odyssey/engineering/gas_storage/port)
@@ -3448,7 +3447,7 @@
 /obj/machinery/computer/med_data/laptop,
 /obj/machinery/requests_console{
 	announcementConsole = 1;
-	department = "Infirmary";
+	department = "Medbay";
 	departmentType = 2;
 	name = "Infirmary RC";
 	pixel_y = 30
@@ -3560,7 +3559,9 @@
 	},
 /area/shuttle/odyssey/hallway/aft)
 "mi" = (
-/obj/machinery/atmospherics/miner/surface,
+/obj/machinery/atmospherics/miner/surface{
+	anchored = TRUE
+	},
 /turf/simulated/floor/engine/airless,
 /area/shuttle/odyssey/engineering/gas_storage/starboard)
 "mj" = (
@@ -3602,14 +3603,6 @@
 	tag = "icon-dark_navy (NORTHEAST)"
 	},
 /area/shuttle/odyssey/bridge)
-"mp" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "all";
-	tag = "icon-all"
-	},
-/obj/machinery/turret,
-/turf/simulated/floor/plating,
-/area/odyssey/admin)
 "mq" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
@@ -3739,14 +3732,14 @@
 	pixel_x = 16;
 	metrics_monitored = list("pressure", "temperature", "oxygen", "plasma", "nitrogen", "carbon_dioxide","cryotheum","radon")
 	},
-/obj/machinery/atmospherics/unary/vent_pump{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	canSpawnMice = 0;
+	dir = 1;
 	external_pressure_bound = 0;
 	frequency = 1441;
 	icon_state = "in";
 	id_tag = "air_out";
-	initialize_directions = 1;
-	internal_pressure_bound = 4000;
+	internal_pressure_bound = 2000;
 	on = 1;
 	pressure_checks = 2;
 	pump_direction = 0
@@ -4156,7 +4149,7 @@
 /obj/machinery/recharger,
 /obj/machinery/requests_console{
 	announcementConsole = 1;
-	department = "Logistics";
+	department = "Cargo Bay";
 	departmentType = 2;
 	name = "Logistics RC";
 	pixel_y = 30
@@ -4753,7 +4746,9 @@
 /turf/simulated/floor/vox,
 /area/vox_station/tradepost)
 "qp" = (
-/obj/machinery/gas_extractor,
+/obj/machinery/gas_extractor{
+	anchored = TRUE
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -5171,24 +5166,6 @@
 	icon_state = "dark"
 	},
 /area/shuttle/odyssey/hallway/aft)
-"rS" = (
-/obj/machinery/turretid{
-	ailock = 1;
-	control_area = /area/turret_protected/tcomms_control_room;
-	desc = "A firewall prevents AIs from interacting with this device.";
-	name = "Telecomms Control Room turret control";
-	req_access = null;
-	req_access_txt = "61";
-	pixel_y = -29
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "dark"
-	},
-/area/odyssey/admin)
 "rX" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/visible/blue{
 	dir = 9;
@@ -5262,7 +5239,9 @@
 /turf/simulated/floor/shuttle,
 /area/shuttle/odyssey_transfer)
 "sn" = (
-/obj/machinery/mineral/processing_unit,
+/obj/machinery/mineral/processing_unit{
+	id_tag = "mining_smelter"
+	},
 /obj/structure/railing,
 /turf/unsimulated/floor{
 	icon_state = "floorgrime"
@@ -5883,11 +5862,11 @@
 /turf/simulated/floor,
 /area/shuttle/odyssey/security)
 "ug" = (
-/obj/machinery/media/jukebox,
 /obj/structure/sign/directions/security{
 	pixel_x = 32;
 	dir = 4
 	},
+/obj/machinery/media/jukebox/dj,
 /turf/simulated/floor{
 	icon_state = "bar"
 	},
@@ -7369,7 +7348,6 @@
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
-/obj/structure/closet/crate/bin,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -8814,7 +8792,7 @@
 "DS" = (
 /obj/machinery/conveyor{
 	dir = 4;
-	id_tag = "mining_mint"
+	id_tag = "mining_internal"
 	},
 /obj/structure/railing,
 /turf/unsimulated/floor{
@@ -9408,8 +9386,7 @@
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
-	pump_direction = 0;
-	dir = 1
+	pump_direction = 0
 	},
 /turf/simulated/floor/engine/airless,
 /area/shuttle/odyssey/engineering/gas_storage/port)
@@ -10286,6 +10263,14 @@
 	dir = 1
 	},
 /obj/structure/flora/pottedplant/random,
+/obj/machinery/embedded_controller/radio/access_controller{
+	id_tag = "virology_airlock_control";
+	name = "Virology Access Console";
+	pixel_x = -6;
+	pixel_y = 23;
+	tag_exterior_door = "virology_airlock_exterior";
+	tag_interior_door = "virology_airlock_interior"
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -11638,15 +11623,6 @@
 	},
 /turf/simulated/floor/plating/vox,
 /area/vox_station/tradepost)
-"NC" = (
-/obj/machinery/door/window{
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "dark"
-	},
-/area/odyssey/admin)
 "ND" = (
 /obj/effect/decal/warning_stripes{
 	dir = 6;
@@ -14844,8 +14820,7 @@
 /area/shuttle/odyssey/engineering/engine_room)
 "XF" = (
 /obj/machinery/conveyor{
-	dir = 1;
-	id_tag = "QMLoad3"
+	id_tag = "mining_internal"
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -15345,7 +15320,7 @@
 /obj/structure/bedsheetbin,
 /obj/machinery/requests_console{
 	announcementConsole = 1;
-	department = "Janitor";
+	department = "Janitorial";
 	departmentType = 5;
 	name = "Janitor RC";
 	pixel_y = 30
@@ -26042,7 +26017,7 @@ Bc
 Bc
 Bc
 mA
-hI
+mv
 Wi
 ru
 HM
@@ -26344,7 +26319,7 @@ Bc
 Bc
 Bc
 mA
-JM
+hI
 Wi
 eE
 lY
@@ -26646,12 +26621,12 @@ Bc
 Bc
 Bc
 mA
-RG
+JM
 cH
 RH
 mH
 yY
-rS
+wh
 mA
 uk
 Ro
@@ -26948,12 +26923,12 @@ Bc
 Bc
 Bc
 mA
-mp
+RG
 mv
 mv
 ox
 Wi
-NC
+Ih
 QI
 Ih
 Ih

--- a/maps/odyssey/areas.dm
+++ b/maps/odyssey/areas.dm
@@ -112,23 +112,28 @@
 	icon_state = "bluenew"
 	requires_power = 0
 
-/area/surface/nt_outpost/admin
+/area/odyssey
+	name = "\improper Odyssey"
+	icon_state = "odyssey"
+	requires_power = 0
+
+/area/odyssey/admin
 	name = "\improper Outpost Administration"
 	icon_state = "conference"
 
-/area/surface/nt_outpost/cargo
+/area/odyssey/cargo
 	name = "\improper Outpost Cargo"
 	icon_state = "cargo_bay"
 
-/area/surface/nt_outpost/clinic
+/area/odyssey/clinic
 	name = "\improper Outpost Clinic"
 	icon_state = "virology"
 
-/area/surface/nt_outpost/store
+/area/odyssey/store
 	name = "\improper Outpost Store"
 	icon_state = "blue"
 
-/area/surface/nt_outpost/mineral_processing
+/area/odyssey/mineral_processing
 	name = "\improper Mineral Processing"
 	icon_state = "mining_production"
 

--- a/maps/odyssey/events.dm
+++ b/maps/odyssey/events.dm
@@ -1,89 +1,343 @@
-#define ODYSSEY_STATE_HYPERSPACE (1<<0)
-#define ODYSSEY_STATE_DEEPSPACE  (1<<1)
+/datum/event/micro_meteors
+	announceWhen = 1
+	endWhen = 5
 
-/*
- * Odyssey Map Events
- *
- * Roll-based events that fire when the shuttle enters hyperspace or deep space.
- * Independent from the standard event scheduler (/datum/event).
- */
+/datum/event/micro_meteors/can_start()
+	return 20
 
-/datum/odyssey_event
-	var/name = "Odyssey Event"
-	var/required_roll = 0       // Minimum roll (1-100) to qualify
-	var/state_flags = 0         // Bitfield: ODYSSEY_STATE_HYPERSPACE, ODYSSEY_STATE_DEEPSPACE
-	var/announce_message = ""   // Warning sent to crew before impact
-	var/announce_delay = 5 SECONDS // Delay between announcement and execution
+/datum/event/micro_meteors/announce()
+	captain_announce("Sensors detect incoming micro-debris field. Brace for impact.")
 
-/datum/odyssey_event/proc/can_fire(datum/shuttle/odyssey/shuttle)
-	return TRUE
+/datum/event/micro_meteors/start()
+	if(!map || !map.ship_shuttle)
+		return
+	var/datum/shuttle/odyssey/S = map.ship_shuttle
+	if(!istype(S))
+		return
+	var/count = rand(4, 8)
+	for(var/i = 1 to count)
+		var/meteor_type = /obj/item/projectile/meteor/small/microdebris
+		if(prob(25))
+			meteor_type = /obj/item/projectile/meteor/small
+		S.spawn_vz_meteor(meteor_type)
+		sleep(rand(3, 5))
 
-/datum/odyssey_event/proc/announce(datum/shuttle/odyssey/shuttle)
-	if(announce_message)
-		captain_announce(announce_message)
+/datum/event/gib_storm
+	announceWhen = 1
+	endWhen = 5
 
-/datum/odyssey_event/proc/execute(datum/shuttle/odyssey/shuttle)
-	return
+/datum/event/gib_storm/can_start()
+	return 40
 
-/datum/odyssey_event/proc/fire(datum/shuttle/odyssey/shuttle)
-	announce(shuttle)
-	spawn(announce_delay)
-		execute(shuttle)
+/datum/event/gib_storm/announce()
+	captain_announce("Warning: Unidentified organic matter on collision course.")
 
-/datum/shuttle/odyssey
-	var/list/possible_events = list()
-	var/odyssey_event_active = FALSE
-	var/obj/docking_port/destination/event_trigger_port = null
+/datum/event/gib_storm/start()
+	if(!map || !map.ship_shuttle)
+		return
+	var/datum/shuttle/odyssey/S = map.ship_shuttle
+	if(!istype(S))
+		return
+	var/count = rand(8, 15)
+	for(var/i = 1 to count)
+		S.spawn_vz_meteor(/obj/item/projectile/meteor/gib)
+		sleep(rand(2, 4))
 
-/datum/shuttle/odyssey/proc/get_odyssey_state()
-	if(!current_port)
-		return 0
-	var/datum/virtual_z/vz = current_port.get_virtual_z()
+/datum/event/solar_flare
+	announceWhen = 1
+	endWhen = 5
+
+/datum/event/solar_flare/can_start()
+	return 10
+
+/datum/event/solar_flare/announce()
+	captain_announce("Solar flare detected. Electrical systems may be affected.")
+
+/datum/event/solar_flare/start()
+	if(!map || !map.ship_shuttle)
+		return
+	var/datum/shuttle/odyssey/S = map.ship_shuttle
+	if(!istype(S))
+		return
+	var/duration = rand(1 MINUTES, 2 MINUTES)
+	var/list/affected_apcs = list()
+
+	for(var/obj/machinery/power/apc/A in S.shuttle_contents())
+		if(A.cell)
+			A.cell.charge = 0
+		A.chargemode = 0
+		A.operating = 0
+		A.update()
+		A.update_icon()
+		affected_apcs += A
+
+	spawn(duration)
+		for(var/obj/machinery/power/apc/A in affected_apcs)
+			if(A && !A.gcDestroyed)
+				A.chargemode = 1
+				A.operating = 1
+				A.update()
+				A.update_icon()
+		captain_announce("Electrical systems have stabilized. Power is being restored.")
+
+/datum/event/odyssey_carp_swarm
+	announceWhen = 1
+	endWhen = 5
+
+/datum/event/odyssey_carp_swarm/can_start()
+	return 15
+
+/datum/event/odyssey_carp_swarm/announce()
+	captain_announce("Biosensors detect hostile fauna approaching the ship.")
+
+/datum/event/odyssey_carp_swarm/start()
+	if(!map || !map.ship_shuttle)
+		return
+	var/datum/shuttle/odyssey/S = map.ship_shuttle
+	if(!istype(S) || !S.current_port)
+		return
+	var/datum/virtual_z/vz = S.current_port.get_virtual_z()
 	if(!vz)
+		return
+
+	var/count = rand(4, 8)
+
+	// Find space turfs near the shuttle
+	var/list/shuttle_turfs = list()
+	for(var/turf/T in S.shuttle_contents())
+		shuttle_turfs += T
+	if(!shuttle_turfs.len)
+		return
+
+	var/turf/center = shuttle_turfs[round(shuttle_turfs.len / 2) + 1]
+	var/list/space_turfs = list()
+	for(var/turf/space/SP in range(15, center))
+		if(!(SP in shuttle_turfs))
+			space_turfs += SP
+
+	if(!space_turfs.len)
+		return
+
+	for(var/i = 1 to count)
+		var/turf/T = pick(space_turfs)
+		new /mob/living/simple_animal/hostile/carp(T)
+
+//////////////////////////////////////////////
+//  Odyssey overrides of vanilla events     //
+//////////////////////////////////////////////
+
+/datum/event/radiation_storm/odyssey
+
+/datum/event/disease_outbreak/odyssey
+
+/datum/event/disease_outbreak/odyssey/can_start(var/list/active_with_role)
+	if(!map.recently_on_planet())
 		return 0
-	if(vz.level_type == VZ_TRANSIT)
-		return ODYSSEY_STATE_HYPERSPACE
-	if(vz.level_type == VZ_PARKING)
-		return ODYSSEY_STATE_DEEPSPACE
+	return 20
+
+/datum/event/disease_outbreak/odyssey/announce()
+	captain_announce("Medical reports signs of an unidentified pathogen — likely picked up during the last dirtside excursion.")
+
+/datum/event/viral_infection/odyssey
+
+/datum/event/viral_infection/odyssey/can_start(var/list/active_with_role)
+	if(!map.recently_on_planet())
+		return 0
+	if(active_with_role["Medical"] > 1)
+		return 40
 	return 0
 
-/datum/shuttle/odyssey/proc/start_event_loop()
-	if(odyssey_event_active)
+/datum/event/viral_infection/odyssey/announce()
+	biohazard_alert(level)
+	captain_announce("Medical isolates a minor pathogen traced to the crew's last planetary excursion.")
+
+/datum/event/viral_outbreak/odyssey
+
+/datum/event/viral_outbreak/odyssey/can_start(var/list/active_with_role)
+	if(!map.recently_on_planet())
+		return 0
+	if(active_with_role["Medical"] > 1)
+		return 25
+	return 0
+
+/datum/event/viral_outbreak/odyssey/announce()
+	biohazard_alert(level)
+	captain_announce("Medical warns of a significant biological contaminant brought aboard during the last dirtside excursion.")
+
+/datum/event/ancientpod/odyssey
+
+/datum/event/ancientpod/odyssey/start()
+	var/turf/spawn_turf = pick_odyssey_planet_floor()
+	if(!spawn_turf)
+		// Fall back to vanilla behavior if no valid planet turf
+		..()
 		return
-	var/state = get_odyssey_state()
-	if(!state)
+	var/obj/machinery/cryopod/pod = new /obj/machinery/cryopod(spawn_turf)
+	pod.ThrowAtStation()
+
+/proc/pick_odyssey_planet_floor()
+	// Pick a random non-hidden planet, then a random floor turf that isn't lava or water.
+	var/list/candidate_planets = list()
+	for(var/datum/planet_type/P in SSmapping.planets)
+		if(P.hidden || !P.v)
+			continue
+		candidate_planets += P
+	if(!candidate_planets.len)
+		return null
+
+	var/datum/planet_type/chosen = pick(candidate_planets)
+	var/datum/virtual_z/vz = chosen.v
+	var/z_level = vz.z()
+
+	var/list/valid_turfs = list()
+	for(var/x = vz.x_min to vz.x_max)
+		for(var/y = vz.y_min to vz.y_max)
+			var/turf/T = locate(x, y, z_level)
+			if(!T)
+				continue
+			if(!istype(T, /turf/unsimulated/floor/planetary) && !istype(T, /turf/simulated/floor))
+				continue
+			if(istype(T, /turf/unsimulated/floor/planetary/lava))
+				continue
+			if(istype(T, /turf/unsimulated/floor/planetary/water))
+				continue
+			if(istype(T, /turf/simulated/floor/beach/water))
+				continue
+			valid_turfs += T
+
+	if(!valid_turfs.len)
+		return null
+	return pick(valid_turfs)
+
+/datum/event/grid_check/odyssey
+	announceWhen = 1
+	endWhen = 3
+
+/datum/event/grid_check/odyssey/setup()
+	endWhen = 3
+
+/datum/event/grid_check/odyssey/announce()
+	captain_announce("Solar microflare detected — brief power ripple expected.")
+
+/datum/event/grid_check/odyssey/start()
+	if(!map || !map.ship_shuttle)
 		return
-	odyssey_event_active = TRUE
-	event_trigger_port = current_port
-	var/first_delay = rand(30 SECONDS, 5 MINUTES)
-	spawn(first_delay)
-		event_roll_loop()
+	var/datum/shuttle/odyssey/S = map.ship_shuttle
+	if(!istype(S))
+		return
+	var/list/affected_apcs = list()
+	for(var/obj/machinery/power/apc/A in S.shuttle_contents())
+		if(A.cell)
+			A.old_charge = A.cell.charge
+			A.cell.charge = 0
+		A.operating = 0
+		A.update()
+		A.update_icon()
+		affected_apcs += A
 
-/datum/shuttle/odyssey/proc/stop_event_loop()
-	odyssey_event_active = FALSE
-	event_trigger_port = null
+	spawn(10 SECONDS)
+		for(var/obj/machinery/power/apc/A in affected_apcs)
+			if(A && !A.gcDestroyed)
+				if(A.cell && A.old_charge)
+					A.cell.charge = A.old_charge
+				A.operating = 1
+				A.chargemode = 1
+				A.update()
+				A.update_icon()
 
-/datum/shuttle/odyssey/proc/event_roll_loop()
-	if(!odyssey_event_active || current_port != event_trigger_port)
-		stop_event_loop()
+/datum/event/grid_check/odyssey/end()
+	return
+
+/datum/event/immovable_rod/odyssey
+
+/datum/event/immovable_rod/odyssey/can_start(var/list/active_with_role)
+	if(active_with_role["Any"] > 3)
+		return 15
+	return 0
+
+/datum/event/rogue_drone/odyssey
+
+/datum/event/rogue_drone/odyssey/start()
+	if(!map || !map.ship_shuttle)
+		return
+	var/datum/shuttle/odyssey/S = map.ship_shuttle
+	if(!istype(S))
 		return
 
-	var/roll = rand(1, 100)
-	var/state = get_odyssey_state()
-	var/list/eligible = list()
+	var/list/shuttle_turfs = list()
+	for(var/turf/T in S.shuttle_contents())
+		shuttle_turfs += T
+	if(!shuttle_turfs.len)
+		return
+	var/turf/center = shuttle_turfs[round(shuttle_turfs.len / 2) + 1]
+	var/list/space_turfs = list()
+	for(var/turf/space/SP in range(15, center))
+		if(!(SP in shuttle_turfs))
+			space_turfs += SP
+	if(!space_turfs.len)
+		return
 
-	for(var/datum/odyssey_event/E in possible_events)
-		if(E.required_roll <= roll && (E.state_flags & state) && E.can_fire(src))
-			eligible += E
+	var/num = prob(25) ? 0 : rand(2, 6)
+	for(var/i = 0, i < num, i++)
+		var/mob/living/simple_animal/hostile/retaliate/malf_drone/D = new(pick(space_turfs))
+		D.from_event = src
+		drones_list.Add(D)
+		if(prob(25))
+			D.disabled = rand(15, 60)
 
-	if(eligible.len)
-		var/datum/odyssey_event/picked = pick(eligible)
-		picked.fire(src)
+/datum/event/brand_intelligence/odyssey
 
-	// Subsequent rolls: 5-15 minute delay
-	var/next_delay = rand(5 MINUTES, 15 MINUTES)
-	spawn(next_delay)
-		event_roll_loop()
+/datum/event/brand_intelligence/odyssey/start()
+	if(!map || !map.ship_shuttle)
+		kill()
+		return
+	var/datum/shuttle/odyssey/S = map.ship_shuttle
+	if(!istype(S))
+		kill()
+		return
+
+	for(var/obj/machinery/vending/V in S.shuttle_contents())
+		vendingMachines.Add(V)
+
+	if(!vendingMachines.len)
+		kill()
+		return
+
+	originMachine = pick(vendingMachines)
+	vendingMachines.Remove(originMachine)
+	originMachine.shut_up = 0
+	originMachine.shoot_inventory = 1
+
+/datum/event/old_vendotron_teleport/odyssey
+
+/datum/event/old_vendotron_teleport/odyssey/vendSpawnDecide()
+	var/static/list/canReplace = list(
+		/obj/machinery/vending/coffee,
+		/obj/machinery/vending/snack,
+		/obj/machinery/vending/cola,
+		/obj/machinery/vending/cigarette,
+		/obj/machinery/vending/discount,
+		/obj/machinery/vending/groans,
+		/obj/machinery/vending/nuka,
+		/obj/machinery/vending/sovietsoda,
+		/obj/machinery/vending/zamsnax,
+	)
+	if(!map || !map.ship_shuttle)
+		announceWhen = -1
+		endWhen = 0
+		return
+	var/datum/shuttle/odyssey/S = map.ship_shuttle
+	var/list/possibleVends = list()
+	for(var/obj/machinery/vending/aVendor in S.shuttle_contents())
+		if(!is_type_in_list(aVendor, canReplace))
+			continue
+		possibleVends.Add(aVendor)
+	if(!possibleVends.len)
+		message_admins("Old Vendotron event (odyssey) failed — no shuttle vendors to replace.")
+		announceWhen = -1
+		endWhen = 0
+		return
+	return pick(possibleVends)
 
 /// Spawn a meteor projectile from the edge of the shuttle's current virtual z-level aimed at the shuttle
 /datum/shuttle/odyssey/proc/spawn_vz_meteor(meteor_type)
@@ -122,95 +376,6 @@
 	if(start && target)
 		return new meteor_type(start, target)
 	return null
-
-/datum/odyssey_event/micro_meteors
-	name = "Micro Meteors"
-	required_roll = 65
-	state_flags = ODYSSEY_STATE_HYPERSPACE
-	announce_message = "Sensors detect incoming micro-debris field. Brace for impact."
-
-/datum/odyssey_event/micro_meteors/execute(datum/shuttle/odyssey/shuttle)
-	var/count = rand(2, 4)
-	for(var/i = 1 to count)
-		var/meaty_type = /obj/item/projectile/meteor/small/microdebris
-		if(prob(25))
-			meaty_type = /obj/item/projectile/meteor/small
-		shuttle.spawn_vz_meteor(meaty_type)
-		sleep(rand(3, 5))
-
-/datum/odyssey_event/gib_storm
-	name = "Gib Storm"
-	required_roll = 35
-	state_flags = ODYSSEY_STATE_HYPERSPACE
-	announce_message = "Warning: Unidentified organic matter on collision course."
-
-/datum/odyssey_event/gib_storm/execute(datum/shuttle/odyssey/shuttle)
-	var/count = rand(8, 15)
-	for(var/i = 1 to count)
-		shuttle.spawn_vz_meteor(/obj/item/projectile/meteor/gib)
-		sleep(rand(2, 4))
-
-/datum/odyssey_event/solar_flare
-	name = "Solar Flare"
-	required_roll = 50
-	state_flags = ODYSSEY_STATE_HYPERSPACE | ODYSSEY_STATE_DEEPSPACE
-	announce_message = "Solar flare detected. Electrical systems may be affected."
-
-/datum/odyssey_event/solar_flare/execute(datum/shuttle/odyssey/shuttle)
-	var/duration = rand(1 MINUTES, 3 MINUTES)
-	var/list/affected_apcs = list()
-
-	for(var/obj/machinery/power/apc/A in shuttle.shuttle_contents())
-		if(A.cell)
-			A.cell.charge = 0
-		A.chargemode = 0
-		A.operating = 0
-		A.update()
-		A.update_icon()
-		affected_apcs += A
-
-	spawn(duration)
-		for(var/obj/machinery/power/apc/A in affected_apcs)
-			if(A && !A.gcDestroyed)
-				A.chargemode = 1
-				A.operating = 1
-				A.update()
-				A.update_icon()
-		captain_announce("Electrical systems have stabilized. Power is being restored.")
-
-/datum/odyssey_event/carp_swarm
-	name = "Carp Swarm"
-	required_roll = 40
-	state_flags = ODYSSEY_STATE_DEEPSPACE
-	announce_message = "Biosensors detect hostile fauna approaching the ship."
-
-/datum/odyssey_event/carp_swarm/execute(datum/shuttle/odyssey/shuttle)
-	var/datum/virtual_z/vz = shuttle.current_port.get_virtual_z()
-	if(!vz)
-		return
-
-	var/count = rand(4, 8)
-
-	// Find space turfs near the shuttle
-	var/list/shuttle_turfs = list()
-	for(var/turf/T in shuttle.shuttle_contents())
-		shuttle_turfs += T
-	if(!shuttle_turfs.len)
-		return
-
-	// Use a central shuttle turf as reference point
-	var/turf/center = shuttle_turfs[round(shuttle_turfs.len / 2) + 1]
-	var/list/space_turfs = list()
-	for(var/turf/space/S in range(15, center))
-		if(!(S in shuttle_turfs))
-			space_turfs += S
-
-	if(!space_turfs.len)
-		return
-
-	for(var/i = 1 to count)
-		var/turf/T = pick(space_turfs)
-		new /mob/living/simple_animal/hostile/carp(T)
 
 //////////////////////////////////////////////
 //                                          //
@@ -277,6 +442,3 @@
 		captain_announce("Unidentified life signs detected aboard the NTEV Odyssey.")
 
 	return new_xeno
-
-#undef ODYSSEY_STATE_HYPERSPACE
-#undef ODYSSEY_STATE_DEEPSPACE

--- a/maps/odyssey/events.dm
+++ b/maps/odyssey/events.dm
@@ -339,6 +339,31 @@
 		return
 	return pick(possibleVends)
 
+/datum/event/hog/odyssey
+
+/datum/event/hog/odyssey/start()
+	if(!map || !map.ship_shuttle)
+		message_admins("Aborted hog event (odyssey). No ship shuttle.")
+		return
+	var/datum/shuttle/odyssey/S = map.ship_shuttle
+	if(!istype(S))
+		message_admins("Aborted hog event (odyssey). Ship shuttle is not odyssey.")
+		return
+
+	var/list/turf/simulated/floor/turfs = list()
+	for(var/turf/simulated/floor/F in S.shuttle_contents())
+		if(!is_blocked_turf(F))
+			turfs += F
+	if(turfs.len < 2)
+		message_admins("Aborted hog event (odyssey). Not enough open shuttle turfs.")
+		return
+
+	command_alert(/datum/command_alert/hog)
+	var/turf/spawn_turf = pick_n_take(turfs)
+	var/mob/living/simple_animal/rampagingspacehog/ourhog = new(spawn_turf)
+	message_admins("<span class='notice'>Event: hog spawned in at [ourhog.loc] <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[ourhog.x];Y=[ourhog.y];Z=[ourhog.z]'>(JMP)</a></span>")
+	ourhog.homes += turfs
+
 /// Spawn a meteor projectile from the edge of the shuttle's current virtual z-level aimed at the shuttle
 /datum/shuttle/odyssey/proc/spawn_vz_meteor(meteor_type)
 	var/datum/virtual_z/vz = current_port.get_virtual_z()

--- a/maps/odyssey/events.dm
+++ b/maps/odyssey/events.dm
@@ -161,7 +161,6 @@
 	var/list/affected_apcs = list()
 
 	for(var/obj/machinery/power/apc/A in shuttle.shuttle_contents())
-		A.overload_lighting()
 		if(A.cell)
 			A.cell.charge = 0
 		A.chargemode = 0

--- a/maps/odyssey/fixedvaults.dm
+++ b/maps/odyssey/fixedvaults.dm
@@ -13,6 +13,24 @@
             centcomm_account_db = db
             break
 
+    // /area/shuttle/supply lives in this fixedvault instead of the main map, so
+    // cargo_shuttle.New() (a global var initializer, runs before fixedvaults load)
+    // couldn't resolve its linked_area and the shuttle was never added to the global
+    // shuttles list. Back-fill it here so setup_shuttles() can initialize it and
+    // populate dock_station / dock_centcom.
+    if(cargo_shuttle && !cargo_shuttle.linked_area)
+        for(var/area/A in world)
+            if(istype(A, /area/shuttle/supply))
+                cargo_shuttle.linked_areas |= A
+        for(var/area/A in cargo_shuttle.linked_areas)
+            if(A.contents.len)
+                cargo_shuttle.linked_area = A
+                break
+        if(!cargo_shuttle.linked_area && cargo_shuttle.linked_areas.len)
+            cargo_shuttle.linked_area = cargo_shuttle.linked_areas[1]
+        if(cargo_shuttle.linked_area)
+            shuttles |= cargo_shuttle
+
 /datum/map_element/fixedvault/derelict
     name = "derelict space station"
     file_path = "maps/odyssey/derelict.dmm"

--- a/maps/odyssey/jobs.dm
+++ b/maps/odyssey/jobs.dm
@@ -1,7 +1,9 @@
 /datum/job/hop/New()
 	..()
 	title = "First Mate"
+	head_position = 1
+	command_positions |= list(title)
 
-/datum/job/chief_engineer/New()
+/datum/job/assistant/New()
 	..()
-	title = "Navigator"
+	title = "Deckhand"

--- a/maps/odyssey/shuttles.dm
+++ b/maps/odyssey/shuttles.dm
@@ -271,6 +271,7 @@ var/global/datum/shuttle/odyssey_transfer/odyssey_transfer_shuttle = new(startin
 
 /obj/machinery/computer/communications/odyssey
 	circuit = "/obj/item/weapon/circuitboard/communications/odyssey"
+	ignore_station_z_check = TRUE
 
 /obj/machinery/computer/communications/odyssey/proc/trigger_bluespace_jump()
 	if(!emergency_shuttle || emergency_shuttle.online || emergency_shuttle.departed || emergency_shuttle.shutdown)

--- a/maps/odyssey/shuttles.dm
+++ b/maps/odyssey/shuttles.dm
@@ -22,6 +22,7 @@ var/global/datum/shuttle/odyssey_transfer/odyssey_transfer_shuttle = new(startin
 	var/obj/docking_port/destination/outpost_dock
 	var/transit_end_time = 0
 	var/transit_destination_name = ""
+	var/last_planet_dock_time = 0 //world.time of last time the shuttle docked at or departed a VZ_PLANET port.
 
 	req_access = list(access_captain)
 
@@ -69,13 +70,8 @@ var/global/datum/shuttle/odyssey_transfer/odyssey_transfer_shuttle = new(startin
 
 	update_outpost_power()
 
-	// Initialize Odyssey events
-	possible_events = list(
-		new /datum/odyssey_event/micro_meteors,
-		new /datum/odyssey_event/gib_storm,
-		new /datum/odyssey_event/solar_flare,
-		new /datum/odyssey_event/carp_swarm
-	)
+	if(map)
+		map.ship_shuttle = src
 
 /datum/shuttle/odyssey/proc/update_outpost_power()
 	var/at_outpost = outpost_dock && current_port == outpost_dock
@@ -89,8 +85,10 @@ var/global/datum/shuttle/odyssey_transfer/odyssey_transfer_shuttle = new(startin
 	for(var/turf/T in shuttle_contents())
 		for(var/obj/effect/beach_water/unsimmed/W in T.vis_contents)
 			T.vis_contents -= W
-	// Start the Odyssey event loop if in hyperspace or deep space
-	start_event_loop()
+	if(current_port)
+		var/datum/virtual_z/vz = current_port.get_virtual_z()
+		if(vz && vz.level_type == VZ_PLANET)
+			last_planet_dock_time = world.time
 
 /datum/shuttle/odyssey/get_pre_flight_delay()
 	// Skip countdown when already in hyperspace
@@ -121,7 +119,10 @@ var/global/datum/shuttle/odyssey_transfer/odyssey_transfer_shuttle = new(startin
 	return ..()
 
 /datum/shuttle/odyssey/pre_flight()
-	stop_event_loop()
+	if(current_port)
+		var/datum/virtual_z/vz = current_port.get_virtual_z()
+		if(vz && vz.level_type == VZ_PLANET)
+			last_planet_dock_time = world.time
 	if(!destination_port)
 		return
 	if(transit_port && get_transit_delay() && destination_port != transit_port)

--- a/maps/odyssey/shuttles.dm
+++ b/maps/odyssey/shuttles.dm
@@ -19,6 +19,7 @@ var/global/datum/shuttle/odyssey_transfer/odyssey_transfer_shuttle = new(startin
 	stable = 0
 	var/bluespace_jump_state = JUMP_NONE
 	var/obj/docking_port/destination/dock_centcom
+	var/obj/docking_port/destination/outpost_dock
 	var/transit_end_time = 0
 	var/transit_destination_name = ""
 
@@ -26,7 +27,7 @@ var/global/datum/shuttle/odyssey_transfer/odyssey_transfer_shuttle = new(startin
 
 /datum/shuttle/odyssey/initialize()
 	.=..()
-	add_dock(/obj/docking_port/destination/odyssey/outpost)
+	outpost_dock = add_dock(/obj/docking_port/destination/odyssey/outpost)
 	add_dock(/obj/docking_port/destination/odyssey/deep_space)
 	add_dock(/obj/docking_port/destination/odyssey/dj_sat)
 	add_dock(/obj/docking_port/destination/odyssey/derelict)
@@ -66,10 +67,7 @@ var/global/datum/shuttle/odyssey_transfer/odyssey_transfer_shuttle = new(startin
 			vz.teleJammed = VZ_TELEPORTATION_ALLOWED
 			vz.update_settings()
 
-	// If starting at outpost, enable external power on SMES units
-	if(istype(current_port, /obj/docking_port/destination/odyssey/outpost))
-		for(var/obj/machinery/power/battery/smes/S in shuttle_contents())
-			S.external_power_supply = TRUE
+	update_outpost_power()
 
 	// Initialize Odyssey events
 	possible_events = list(
@@ -79,11 +77,14 @@ var/global/datum/shuttle/odyssey_transfer/odyssey_transfer_shuttle = new(startin
 		new /datum/odyssey_event/carp_swarm
 	)
 
-/datum/shuttle/odyssey/after_flight()
-	..()
-	var/at_outpost = istype(current_port, /obj/docking_port/destination/odyssey/outpost)
+/datum/shuttle/odyssey/proc/update_outpost_power()
+	var/at_outpost = outpost_dock && current_port == outpost_dock
 	for(var/obj/machinery/power/battery/smes/S in shuttle_contents())
 		S.external_power_supply = at_outpost
+
+/datum/shuttle/odyssey/after_flight()
+	..()
+	update_outpost_power()
 	// Clean up lingering beach water effects on shuttle turfs after landing
 	for(var/turf/T in shuttle_contents())
 		for(var/obj/effect/beach_water/unsimmed/W in T.vis_contents)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
See CL. 

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Closes several issues and addresses numerous bugs.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Called the Supply Shuttle and sent it back, confirmed it moved to/from the outpost correctly.
Verified each fix is in place and doesn't impact non-Odyssey maps.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed the Supply Shuttle being non-functional on Odyssey due to a variety of reasons.
 * bugfix: Fixed the incorrectly-configured buttons and conveyor belts in the NT Outpost Cargo Bay.
 * bugfix: Fixed NT Outpost buildings showing weather indoors.
 * bugfix: Fixed ROSA panels getting losing sync with their control button.
 * bugfix: Fixed First Mate not being included as a Head of Staff in the latejoin menu.
 * bugfix: Added a button to access Virology at the NT Outpost.
 * bugfix: Anchored the gas extractors in Odyssey so that they properly link with the miner and console.
 * bugfix: Shuttles should no longer spawn right next to the transition region in encounter areas.
 * bugfix: The CMC no longer fails to detect people on a shuttle.
 * bugfix: Weather visual, audio, and physical (damaging) effects will always clear when entering a shuttle from a planet.
 * bugfix: GPSes will now work on a shuttle if it could normally operate outside of the shuttle on the current vLevel the shuttle occupies.
 * bugfix: Added a unique Comms Console to Odyssey which allows use regardless of vLevel.
 * bugfix: Fixed incorrect phone mappings preventing certain phones to show up in "unknown" departments.
 * bugfix: Fixed inconsistent comms in Odyssey; the ship now has its own relay.
 * bugfix: Fixed the conveyor belts in the ore processing room at the NT Outpost not functioning properly.
 * bugfix: References to the Emergency Shuttle will no longer be announced in NTEV Odyssey.
 * tweak: The Odyssey solar flare event will no longer break all of the lights on the shuttle.
 * tweak: Non-human mobs will now be deleted entirely when a shuttle lands on them instead of gibbing them and making a mess on the shuttle.
 * tweak: Renamed "Assistant" to "Deckhand" on Odyssey.
 * tweak: Added some lights to some dark regions in the NT Outpost.
 * tweak: Added a unique CMC for Odyssey which always shows the location of crewmembers with suit sensors on in the vLevel the console is currently occupying.
 * tweak: Wired the unique Odyssey events into the existing events controller.