### PR TITLE
lets pais middle shift click to point

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -280,7 +280,10 @@
 		return
 	var/list/modifiers = params2list(params)
 	if(modifiers["middle"])
-		MiddleClickOn(A)
+		if(modifiers["shift"])
+			MiddleShiftClickOn(A)
+		else
+			MiddleClickOn(A)
 		return
 	if(modifiers["shift"])
 		ShiftClickOn(A)


### PR DESCRIPTION
See title. They can already point, this just adds the shortcut. Closes #39162. Closes #31613. Closes #22113.
:cl:
 * bugfix: pAIs can now middle shift click to point like all other mobs.