### PR TITLE
pAI Security Module upgrade

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -96,6 +96,14 @@
 		"Sleep Toxin" = STOXIN,
 	)
 
+	var/list/synthable_combat_chems = list(
+		"Hyperzine" = HYPERZINE,
+		"Synaptizine" = SYNAPTIZINE,
+		"Biofoam" = BIOFOAM,
+		"Equalizone" = EQUALIZONE,
+		"Brawndo" = SPORTDRINK
+	)
+
 /mob/living/silicon/pai/New(var/obj/item/device/paicard)
 	change_sight(removing = BLIND)
 	canmove = FALSE

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -252,7 +252,13 @@
 				else if(chargeloop(SOFT_CS))
 					var/mob/M = get_holder_of_type(loc, /mob)
 					if(M) //Sanity
-						M.reagents.add_reagent(href_list["chem"], 15)
+						var/amount = 15
+						var/chem = href_list["chem"]
+						if(chem == HYPERZINE) //i wanted a list but this works well enough
+							amount = 14.9
+						if(chem == SYNAPTIZINE)
+							amount = 1
+						M.reagents.add_reagent(chem, amount)
 						playsound(loc, 'sound/effects/bubbles.ogg', 50, 1)
 				else
 					to_chat(src, "<span class='warning'>Charge interrupted.</span>")
@@ -691,9 +697,12 @@ Target Machine: "}
 			dat += "<br>Medical Supplement Chemicals:<br>"
 			for(var/chem in synthable_medical_chems)
 				dat += "<a href='byond://?src=\ref[src];software=[SOFT_CS];sub=0;chem=[synthable_medical_chems[chem]]'>[chem]</a> <br>"
+		if(SOFT_SS in software)
+			dat += "<br>Combat Supplement Chemicals:<br>"
+			for(var/chem in synthable_combat_chems)
+				dat += "<a href='byond://?src=\ref[src];software=[SOFT_CS];sub=0;chem=[synthable_combat_chems[chem]]'>[chem]</a> <br>"
 	else
-		dat += "Charging... [charge]u ready.<br><br>Deploying at 15u."
-	return dat
+		dat += "Charging... [round(charge*100/15)]% ready.<br><br>Deploying..."
 
 /mob/living/silicon/pai/proc/softwareFood()
 	var/dat = "<h3>Nutrition Synthesizer</h3>"


### PR DESCRIPTION
## What this does
The chem synthesizer module now gets access to a list of "combat chemicals" if the security module is installed (much like unlocking medicines if the med module is on), letting them dispense Hyperzine, Synaptizine, Biofoam, Equalizone and Brawndo.
Hyperzine and Synaptizine get dispensed in 14.9u and 1u doses respectively.
Since synaptizine is toxic, it also requires constant monitoring/upkeep by the pAI, making it a double edged sword when used.
Also tweaks the text of the wait screen slightly to account for it making non-15u doses now.
## Why it's good
The security module has always been overshadowed by the medical one, the utility of being able to produce medicine and scan your user is way more useful than being able to see sec records (nobody bothers) or wanted level (very situational), this change hopefully makes them closer in value. 
## How it was tested
Spawned a pAI, grabbed it as a human, moved mind into the pAI, bought the sec and chem modules, dosed synaptizine, it came out in 1u doses.
:cl:
 * rscadd: The pAI Security Module now unlocks a special list of chems for the Chem Synthesizer module: Hyperzine, Synaptizine, Biofoam, Equalizone and Brawndo. Hyperzine and Synaptizine get administered in 14.9 and 1u doses respectively.