### PR TITLE
pAI newscaster

### DIFF
--- a/__DEFINES/pai_software.dm
+++ b/__DEFINES/pai_software.dm
@@ -3,6 +3,7 @@
 #define SOFT_FL "flashlight"
 #define SOFT_RT "redundant threading"
 #define SOFT_RS "remote signaller"
+#define SOFT_NW "newscaster"
 #define SOFT_WJ "wirejack"
 #define SOFT_CS "chem synth"
 #define SOFT_FS "food synth"

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -50,6 +50,8 @@
 
 	var/obj/item/device/gps/pai/pps_device = null //Our GPS device.
 
+	var/obj/machinery/newscaster/painews //our copy of the Newscaster
+
 	var/obj/item/device/station_map/holomap_device = null // Our holomap device.
 	var/holo_target = "show_map" // Our holomap target.
 
@@ -118,6 +120,8 @@
 	add_language(LANGUAGE_GALACTIC_COMMON, 1)
 	add_language(LANGUAGE_TRADEBAND, 1)
 	add_language(LANGUAGE_GUTTER, 1)
+
+	painews = new(src)
 
 	verbs.Remove(/mob/living/silicon/verb/state_laws)
 	..()

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -187,6 +187,9 @@
 						return 0
 				spawn CheckDNA(M, src)
 
+		if(SOFT_NW)
+			painews.attack_hand(src)
+
 		if(SOFT_DM)
 			if(!isnull(pda))
 				var/datum/pda_app/messenger/app = locate(/datum/pda_app/messenger) in pda.applications
@@ -352,6 +355,8 @@
 			dat += "<a href='byond://?src=\ref[src];software=[SOFT_CM];sub=0'>Crew Manifest</a> <br>"
 		if(s == SOFT_DM)
 			dat += "<a href='byond://?src=\ref[src];software=[SOFT_DM];sub=0'>Digital Messenger</a> <br>"
+		if(s == SOFT_NW)
+			dat += "<a href='byond://?src=\ref[src];software=[SOFT_NW];sub=0'>Newscaster</a> <br>"
 		if(s == SOFT_RS)
 			dat += "<a href='byond://?src=\ref[src];software=[SOFT_RS];sub=0'>Remote Signaller</a> <br>"
 		if(s == SOFT_AS)


### PR DESCRIPTION
## What this does
pAIs can now access the newscaster system with an internal native newscaster module.
Closes #39160.
## Why it's good
You can now engage with the news, and post some news blog if you want. You can't post images, since you have no access to the AI camera system.
## How it was tested
Spawned as pAI, opened the newscaster module, created a new channel, posted stuff, worked fine, could check all other channels properly.
:cl:
 * rscadd: pAIs now have access to a native newscaster module, letting them engage with the news. They cannot post images, since they don't have cameras.