### PR TITLE
Make "Compile All Maps" actually compile almost all the maps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ env:
   BYOND_MINOR: 1659
 
   #This can be declared here because build.py will ignore it if DM_UNIT_TESTS is true.
-  ALL_MAPS: tgstation metaclub defficiency packedstation roidstation test_tiny test_vault snaxi tgstation-sec tgstation-snow LampreyStation xoq synergy bagelstation lowfatbagel Dorfstation waystation line horizon wheelstation
+  ALL_MAPS: Dorfstation LampreyStation bagelstation defficiency horizon junglestation line lowfatbagel metaclub odyssey packedstation roidstation snaxi synergy test_tiny test_vault tgstation tgstation-sec tgstation-snow waystation wheelstation xoq
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
## What this does
make the CI step "Compile All Maps" compile Odyssey and Jungle as well as all the other maps except a couple of dumb test ones

also alphabetise the list for shits and giggles

## Why it's good
CI doesnt check these maps and it should be

## How it was tested
look at the CI

## Changelog
no user facing change
