### PR TITLE
Fixes pAI Food/ChemSynth Spam

### DIFF
--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -249,7 +249,7 @@
 			if(href_list["chem"])
 				if(!get_holder_of_type(loc, /mob))
 					to_chat(src, "<span class='warning'>You must have a carrier to inject with chemicals!</span>")
-				else if(chargeloop(SOFT_CS))
+				else if(!charge && chargeloop(SOFT_CS))
 					var/mob/M = get_holder_of_type(loc, /mob)
 					if(M) //Sanity
 						M.reagents.add_reagent(href_list["chem"], 15)
@@ -257,7 +257,7 @@
 				else
 					to_chat(src, "<span class='warning'>Charge interrupted.</span>")
 		if(SOFT_FS)
-			if(href_list["food"] && chargeloop(SOFT_FS))
+			if(href_list["food"] && !charge && chargeloop(SOFT_FS))
 				var/foodType = href_list["food"]
 				var/found = FALSE
 				for (var/name in synthable_default_food)


### PR DESCRIPTION


## What this does
This removes an href exploit that lets a pAI avoid the 15 second cooldown to spawn food or chemicals. This works by adding a check to see if the pAI is already charging. Ideally, this code should be refactored, but this is a band-aid fix.

## Why it's good
No more need to make polyacid to clean up several minutes of pAI funny antics.

## How it was tested
<img width="705" height="511" alt="image" src="https://github.com/user-attachments/assets/55be09c1-9b1f-4dbc-8710-14bdba9929b4" />
Reproduced the href exploit, patched it, tested it again.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Can no longer spam pAI buttons to make food or chemicals faster than 15 seconds.