### PR TITLE
Fixes wall<>rwall smoothing

### DIFF
--- a/code/game/smoothwall.dm
+++ b/code/game/smoothwall.dm
@@ -51,12 +51,16 @@
 		return 0
 	return is_type_in_list(A, canSmoothWith()) && !(cannotSmoothWith() && (is_type_in_list(A, cannotSmoothWith())))
 
+// METAL AND PLASTEEL COUNT AS THE SAME MINERAL HERE SO REGULAR WALLS AND REINFORCED WALLS KEEP SMOOTHING TOGETHER
 /turf/simulated/wall/isSmoothableNeighbor(atom/A)
 	if(!A)
 		return 0
 	if(istype(A, /turf/simulated/wall))
 		var/turf/simulated/wall/W = A
-		return src.mineral == W.mineral && !(cannotSmoothWith() && is_type_in_list(A, cannotSmoothWith()))
+		var/mineral_match = src.mineral == W.mineral
+		if(!mineral_match && (src.mineral == "metal" || src.mineral == "plasteel") && (W.mineral == "metal" || W.mineral == "plasteel"))
+			mineral_match = TRUE
+		return mineral_match && !(cannotSmoothWith() && is_type_in_list(A, cannotSmoothWith()))
 	return is_type_in_list(A, canSmoothWith()) && !(cannotSmoothWith() && (is_type_in_list(A, cannotSmoothWith())))
 
 


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Fixes a bug introduced in #39141 which resulted in regular and reinforced walls failing to smooth together by allowing plasteel and metal walls to smooth.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Looks better.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Noted a broken smoothing location before the fix and verified it was smoothing again after the fix.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed broken wall smoothing between regular and r-walls.