### PR TITLE
Fixes Telecomms in many maps

### DIFF
--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -377,7 +377,19 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	flick("receiver_receive", src)
 
 /obj/machinery/telecomms/receiver/proc/check_receive_level(datum/signal/signal)
-	// A signal can only enter the network via a relay whose own vlevel matches the signal's origin.
+	// Signals originating in the receiver's own virtual z-level are accepted directly.
+	var/datum/virtual_z/receiver_vz = get_virtual_z()
+	if(receiver_vz)
+		var/datum/virtual_z/signal_vz = signal.data["source_virtual_z"]
+		if(!signal_vz)
+			var/mob/source_mob = signal.data["mob"]
+			if(source_mob)
+				signal_vz = source_mob.get_virtual_z()
+		if(signal_vz == receiver_vz)
+			return 1
+	else if(signal.data["level"] == listening_level)
+		return 1
+	// Otherwise the signal must enter the network via a relay whose vlevel matches the signal's origin.
 	for(var/obj/machinery/telecomms/hub/H in links)
 		for(var/obj/machinery/telecomms/relay/R in H.links)
 			if(!R.can_receive(signal))


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Fixes a bug introduced in #39159 which breaks telecomms on any map which doesn't have a relay on vz1 such as Waystation.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Comms are generally nice to have.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Loaded Waystation and verified comms were working once more.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed comms not working on certain maps.
