### PR TITLE
Heatmap fixes and improvements

### DIFF
--- a/code/datums/shuttle.dm
+++ b/code/datums/shuttle.dm
@@ -1028,6 +1028,10 @@
 				L -= old_turf
 				L += new_turf
 
+		//For heatmaps
+		new_turf.player_entries = old_turf.player_entries
+		old_turf.player_entries = 0
+
 		//Add the new turf to the list of turfs to update
 		turfs_to_update += new_turf
 

--- a/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
+++ b/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
@@ -427,4 +427,5 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 					var/final_factor = tile.player_entries*divisor_factor
 					canvas.DrawBox(rgb(min(final_factor*4,255),min(final_factor*2,255),final_factor,255), i, r)
 	canvas.Crop(lowest_x,lowest_y,highest_x,highest_y)
+	log_debug("Heatmap generated for [zLevel]. Lowest x: [lowest_x]. Lowest y: [lowest_y]. Highest x: [highest_x]. Highest y: [highest_y].")
 	return canvas

--- a/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
+++ b/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
@@ -413,17 +413,18 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	for(var/i = 1 to ((2 * world.view + 1)*WORLD_ICON_SIZE))
 		for(var/r = 1 to ((2 * world.view + 1)*WORLD_ICON_SIZE))
 			var/turf/tile = locate(i, r, zLevel)
-			var/v_or_z = tile.v
-			if(!v_or_z)
-				v_or_z = zLevel
-			if(tile && !istype(tile,get_base_turf(v_or_z)))
-				if(!lowest_x)
-					lowest_x = i
-				if(!lowest_y)
-					lowest_y = r
-				highest_x = i
-				highest_y = r
-				var/final_factor = tile.player_entries*divisor_factor
-				canvas.DrawBox(rgb(min(final_factor*4,255),min(final_factor*2,255),final_factor,255), i, r)
+			if(tile)
+				var/v_or_z = tile.v
+				if(!v_or_z)
+					v_or_z = zLevel
+				if(!istype(tile,get_base_turf(v_or_z)))
+					if(!lowest_x)
+						lowest_x = i
+					if(!lowest_y)
+						lowest_y = r
+					highest_x = i
+					highest_y = r
+					var/final_factor = tile.player_entries*divisor_factor
+					canvas.DrawBox(rgb(min(final_factor*4,255),min(final_factor*2,255),final_factor,255), i, r)
 	canvas.Crop(lowest_x,lowest_y,highest_x,highest_y)
 	return canvas

--- a/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
+++ b/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
@@ -406,8 +406,8 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	var/icon/canvas = icon('icons/480x480.dmi', "blank")
 	var/divisor_factor = 255/highest_player_entry
 
-	var/lowest_x = 0
-	var/lowest_y = 0
+	var/lowest_x = world.maxx
+	var/lowest_y = world.maxy
 	var/highest_x = 0
 	var/highest_y = 0
 	for(var/i = 1 to ((2 * world.view + 1)*WORLD_ICON_SIZE))
@@ -418,10 +418,8 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 				if(!v_or_z)
 					v_or_z = zLevel
 				if(!istype(tile,get_base_turf(v_or_z)))
-					if(!lowest_x)
-						lowest_x = i
-					if(!lowest_y)
-						lowest_y = r
+					lowest_x = min(lowest_x,i)
+					lowest_y = min(lowest_y,r)
 					highest_x = max(highest_x,i)
 					highest_y = max(highest_y,r)
 					var/final_factor = tile.player_entries*divisor_factor

--- a/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
+++ b/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
@@ -340,7 +340,7 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	dat += "<B><U>RATING:</U></B> [score.rating]<br><br>"
 
 	dat += "<b>STATION HEATMAP:</b><br>"
-	var/list/zs_to_draw = GetConnectedZlevels(1)
+	var/list/zs_to_draw = GetConnectedZlevels(map.zMainStation)
 	for(var/z in zs_to_draw)
 		dat += "<img src='data:image/png;base64,[icon2base64(draw_heatmap(z))]'/><br>"
 	dat += "<br>"
@@ -397,12 +397,12 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	src.award_desc = award_desc
 
 /proc/draw_heatmap(zLevel = 1)
+	set background=1
 	if(!highest_player_entry)
 		return
 	if (zLevel > world.maxz)
 		return
 
-	set background=1
 	var/icon/canvas = icon('icons/480x480.dmi', "blank")
 	var/divisor_factor = 255/highest_player_entry
 
@@ -413,7 +413,10 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	for(var/i = 1 to ((2 * world.view + 1)*WORLD_ICON_SIZE))
 		for(var/r = 1 to ((2 * world.view + 1)*WORLD_ICON_SIZE))
 			var/turf/tile = locate(i, r, zLevel)
-			if(tile && !istype(tile,get_base_turf()))
+			var/v_or_z = tile.v
+			if(!v_or_z)
+				v_or_z = zLevel
+			if(tile && !istype(tile,get_base_turf(v_or_z)))
 				if(!lowest_x)
 					lowest_x = i
 				if(!lowest_y)

--- a/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
+++ b/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
@@ -427,5 +427,5 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 					var/final_factor = tile.player_entries*divisor_factor
 					canvas.DrawBox(rgb(min(final_factor*4,255),min(final_factor*2,255),final_factor,255), i, r)
 	canvas.Crop(lowest_x,lowest_y,highest_x,highest_y)
-	log_debug("Heatmap generated for [zLevel]. Lowest x: [lowest_x]. Lowest y: [lowest_y]. Highest x: [highest_x]. Highest y: [highest_y].")
+	log_debug("Heatmap generated for z-level [zLevel]. Lowest x: [lowest_x]. Lowest y: [lowest_y]. Highest x: [highest_x]. Highest y: [highest_y].")
 	return canvas

--- a/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
+++ b/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
@@ -422,8 +422,8 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 						lowest_x = i
 					if(!lowest_y)
 						lowest_y = r
-					highest_x = i
-					highest_y = r
+					highest_x = max(highest_x,i)
+					highest_y = max(highest_y,r)
 					var/final_factor = tile.player_entries*divisor_factor
 					canvas.DrawBox(rgb(min(final_factor*4,255),min(final_factor*2,255),final_factor,255), i, r)
 	canvas.Crop(lowest_x,lowest_y,highest_x,highest_y)

--- a/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
+++ b/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
@@ -342,7 +342,7 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	dat += "<b>STATION HEATMAP:</b><br>"
 	var/list/zs_to_draw = GetConnectedZlevels(map.zMainStation)
 	for(var/z in zs_to_draw)
-		dat += "<img src='data:image/png;base64,[icon2base64(draw_heatmap(z))]'/><br>"
+		dat += string_heatmap(z)
 	dat += "<br>"
 
 	var/datum/persistence_task/highscores/leaderboard = score.money_leaderboard
@@ -426,4 +426,8 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 					canvas.DrawBox(rgb(min(final_factor*4,255),min(final_factor*2,255),final_factor,255), i, r)
 	canvas.Crop(lowest_x,lowest_y,highest_x,highest_y)
 	log_debug("Heatmap generated for z-level [zLevel]. Lowest x: [lowest_x]. Lowest y: [lowest_y]. Highest x: [highest_x]. Highest y: [highest_y].")
-	return canvas
+	return highest_x || highest_y ? canvas : null
+
+/proc/string_heatmap(zLevel = 1)
+	var/icon/I = draw_heatmap(zLevel)
+	return I ? "<img src='data:image/png;base64,[icon2base64(I)]'/><br>" : ""

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -92,6 +92,7 @@ var/list/admin_verbs_admin = list(
 	/datum/admins/proc/ashInvokedEmotions,	/*Ashes all paper from the invoke emotion spell. An emergency purge.*/
 	/client/proc/toggle_admin_examine,
 	/client/proc/beasts_panel,	/* Lists all forgotten beasts generated, along with their characteristics */
+	/client/proc/show_heatmaps,
 	/datum/admins/proc/procedural_generation_panel
 )
 var/list/admin_verbs_ban = list(
@@ -1441,3 +1442,14 @@ fieldset {width:140px;}
 		holder.beasts_panel()
 		log_admin("[key_name(usr)] checked the Megabeast Panel.")
 	feedback_add_details("admin_verb","BST")
+
+/client/proc/show_heatmaps()
+	set name = "Show station heatmaps"
+	set category = "Admin"
+	var/dat = ""
+	for(var/zrender in 1 to world.maxz)
+		dat += "<img src='data:image/png;base64,[icon2base64(draw_heatmap(zrender))]'/><br>"
+	var/datum/browser/B = new /datum/browser/clean(usr, "heatmap", "Station heatmaps")
+	B.set_content(dat)
+	B.open()
+	feedback_add_details("admin_verb","HMP")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1448,7 +1448,7 @@ fieldset {width:140px;}
 	set category = "Admin"
 	var/dat = ""
 	for(var/zrender in 1 to world.maxz)
-		dat += "<img src='data:image/png;base64,[icon2base64(draw_heatmap(zrender))]'/><br>"
+		dat += string_heatmap(zrender)
 	var/datum/browser/B = new /datum/browser/clean(usr, "heatmap", "Station heatmaps")
 	B.set_content(dat)
 	B.open()


### PR DESCRIPTION
[bugfix][tweak]

## What this does
Stops the compile warning by putting waitfor at the start of the proc.
Makes them actually render the z level of the main station. (not much change since it was always 1 in nearly all cases)
Changes the base turf to check the virtual z's base turf first.
Makes shuttles bring heatmap player entries with them, erasing whatever was on the destination beforehand.
Makes an admin verb to view them all.

## Why it's good
Reports of them not rendering properly on some maps.

## How it was tested
Loading up odyssey, moving around, ending the round.

## Changelog
:cl:
 * bugfix: Station heatmaps now properly crop more accurate minimum and maximum bounds.
 * tweak: Station heatmaps now properly account for shuttles, virtual z levels, and the actual main station z level now.
 * rscadd: Admins now have a verb to view all station z-level heatmaps for themselves.