### PR TITLE
Mass "your the" (and relevant areas) fix

### DIFF
--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -550,7 +550,7 @@
 					if(!G.is_open_container())
 						continue
 
-					to_chat(user, "<span class='notice'>You recover the reagents from the microwave inside your [G]!</span>")
+					to_chat(user, "<span class='notice'>You recover the reagents from the microwave inside your [G.name]!</span>")
 					reagents.trans_to(G, reagents.total_volume)
 					recovered_reagents = TRUE
 					break

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -544,7 +544,7 @@
 			var/mob/user = usr
 			var/recovered_reagents = FALSE
 			if (user && Adjacent(user))
-				for(var/obj/item/weapon/reagent_containers/glass/G in (user.get_active_hand() + user.get_inactive_hand()))
+				for(var/obj/item/weapon/reagent_containers/glass/G in user.held_items)
 					if(!G.reagents)
 						continue
 					if(!G.is_open_container())

--- a/code/game/objects/items/ashtray.dm
+++ b/code/game/objects/items/ashtray.dm
@@ -29,7 +29,7 @@
 			var/obj/item/clothing/mask/cigarette/pipe/P = W
 			P.lit = 0
 			P.smoketime = 0
-			to_chat(user, "<span class='notice'>You tap your [P] over the [src], emptying the remaining tobbaco and ashes into it.</span>")
+			to_chat(user, "<span class='notice'>You tap your [P.name] over the [src], emptying the remaining tobbaco and ashes into it.</span>")
 			P.update_brightness()
 			add_fingerprint(user)
 			return

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -538,7 +538,7 @@ var/global/msg_id = 0
 
 	if (ismob(loc))
 		var/mob/M = loc
-		M.show_message("<span class='warning'>Your [src] explodes!</span>", 1)
+		M.show_message("<span class='warning'>Your [src.name] explodes!</span>", 1)
 
 	if(T)
 		try_hotspot_expose(700,SMALL_FLAME,0)

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -48,7 +48,7 @@
 		return
 
 	if(loaded_food)
-		to_chat(user, "<span class='notice'>There's already [loaded_food] on your [src].</span>")
+		to_chat(user, "<span class='notice'>There's already [loaded_food] on your [src.name].</span>")
 		return
 
 	if(snack.wrapped)

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -570,7 +570,7 @@
 					var/obj/item/clothing/to_thank = H.head
 					if(!to_thank || (istype(to_thank) && H.glasses && H.glasses.eyeprot > to_thank.eyeprot))
 						to_thank = H.glasses
-					eye_msg(user, 0, "<span class='notice'>Your [to_thank] protects you the welder's glow.</span>")
+					eye_msg(user, 0, "<span class='notice'>Your [to_thank.name] protects you the welder's glow.</span>")
 			else
 				switch(safety)
 					if(1)
@@ -583,7 +583,7 @@
 						var/obj/item/clothing/to_blame = H.head //blame the hat
 						if(!to_blame || (istype(to_blame) && H.glasses && H.glasses.eyeprot < to_blame.eyeprot)) //if we don't have a hat, the issue is the glasses. Otherwise, if the glasses are worse, blame the glasses
 							to_blame = H.glasses
-						eye_msg(user, 2, "<span class='warning'>Your [to_blame] intensifies the welder's glow. Your eyes itch and burn severely.</span>", 	"<span class='warning'>Somebody's cutting onions.</span>")
+						eye_msg(user, 2, "<span class='warning'>Your [to_blame.name] intensifies the welder's glow. Your eyes itch and burn severely.</span>", 	"<span class='warning'>Somebody's cutting onions.</span>")
 						E.damage += rand(12, 16)
 
 				if (E.damage >= E.min_broken_damage)

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -570,7 +570,7 @@
 					var/obj/item/clothing/to_thank = H.head
 					if(!to_thank || (istype(to_thank) && H.glasses && H.glasses.eyeprot > to_thank.eyeprot))
 						to_thank = H.glasses
-					eye_msg(user, 0, "<span class='notice'>Your [to_thank.name] protects you the welder's glow.</span>")
+					eye_msg(user, 0, "<span class='notice'>Your [to_thank.name] protects you from the welder's glow.</span>")
 			else
 				switch(safety)
 					if(1)

--- a/code/game/objects/structures/coatrack.dm
+++ b/code/game/objects/structures/coatrack.dm
@@ -77,13 +77,13 @@
 /obj/structure/coatrack/attackby(obj/item/C, mob/user)
 	if (istype(C, /obj/item/clothing/suit) && !suit && is_type_in_list(C, allowed_suits))
 		if(user.drop_item(C, src))
-			to_chat(user, "<span class='notice'>You place your [C] on \the [src]</span>")
+			to_chat(user, "<span class='notice'>You place your [C.name] on \the [src]</span>")
 			playsound(src, "rustle", 50, 1, -5)
 			suit = C
 			update_icon()
 	else if (istype(C, /obj/item/clothing/head) && !hat && is_type_in_list(C, allowed_hats))
 		if(user.drop_item(C, src))
-			to_chat(user, "<span class='notice'>You place your [C] on \the [src]</span>")
+			to_chat(user, "<span class='notice'>You place your [C.name] on \the [src]</span>")
 			playsound(src, "rustle", 50, 1, -5)
 			hat = C
 			update_icon()

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -228,8 +228,8 @@
 			"<span class='notice'>You begin [PK.drill_verb] straight into \the [src].</span>")
 			PK.playtoolsound(src, 100)
 			if(do_after(user, src, (MINE_DURATION * PK.toolspeed) * 10))
-				user.visible_message("<span class='notice'>[user]'s [PK] tears though the last of \the [src], leaving nothing but a girder.</span>", \
-				"<span class='notice'>Your [PK] tears though the last of \the [src], leaving nothing but a girder.</span>")
+				user.visible_message("<span class='notice'>[user]'s [PK.name] tears though the last of \the [src], leaving nothing but a girder.</span>", \
+				"<span class='notice'>Your [PK.name] tears though the last of \the [src], leaving nothing but a girder.</span>")
 				dismantle()
 	else
 		to_chat(user, "<span class='notice'>You can't reach, close it first!</span>")

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -527,7 +527,7 @@
 							"<span class='notice'>You start [PK.drill_verb] \the [src] with \the [PK].</span>")
 		if(do_after(user, src,30))
 			user.visible_message("<span class='warning'>[user] destroys \the [src]!</span>",
-								"<span class='notice'>Your [PK] tears through the last of \the [src]!</span>")
+								"<span class='notice'>Your [PK.name] tears through the last of \the [src]!</span>")
 			new /obj/effect/decal/remains/human(loc)
 			qdel(src)
 

--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -38,7 +38,7 @@
 
 /obj/structure/sign/attackby(obj/item/tool as obj, mob/user as mob)	//deconstruction
 	if(tool.is_screwdriver(user) && !istype(src, /obj/structure/sign/double))
-		to_chat(user, "You unfasten the sign with your [tool].")
+		to_chat(user, "You unfasten the sign with your [tool.name].")
 		var/obj/item/sign/S = new(src.loc)
 		S.name = name
 		S.desc = desc
@@ -78,7 +78,7 @@
 		S.name = name
 		S.desc = desc
 		S.icon_state = sign_state
-		to_chat(user, "You fasten \the [S] with your [tool].")
+		to_chat(user, "You fasten \the [S] with your [tool.name].")
 		qdel(src)
 		return
 	else

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -184,7 +184,7 @@ var/list/one_way_windows
 		health += diff
 		healthcheck(user, FALSE)
 
-		user.visible_message("<span class='notice'>[user] repairs \the [src] with their [S]!</span>", "<span class='notice'>You repair \the [src] with your [S].</span>")
+		user.visible_message("<span class='notice'>[user] repairs \the [src] with their [S]!</span>", "<span class='notice'>You repair \the [src] with your [S.name].</span>")
 
 	else // No diff, but we didn't exit earlier, so mode must be reinforce
 		var/extra_health = health - initial(health)
@@ -194,7 +194,7 @@ var/list/one_way_windows
 		diff = min(S.get_amount() / SILICATE_PER_REINFORCE, (initial(health) * MAX_WINDOW_HEALTH_MULTIPLIER) - (initial(health) + extra_health))
 		health += diff
 		healthcheck(user)
-		user.visible_message("<span class='notice'>[user] reinforced \the [src] with their [S]!</span>", "<span class='notice'>You reinforce \the [src] with your [S].</span>")
+		user.visible_message("<span class='notice'>[user] reinforced \the [src] with their [S]!</span>", "<span class='notice'>You reinforce \the [src] with your [S.name].</span>")
 
 	playsound(src, 'sound/effects/refill.ogg', 10, 1, -6)
 	S.remove_silicate(diff * SILICATE_PER_DAMAGE)

--- a/code/game/turfs/simulated/floor_glass.dm
+++ b/code/game/turfs/simulated/floor_glass.dm
@@ -323,7 +323,7 @@
 		health += diff
 		healthcheck(user, FALSE)
 
-		user.visible_message("<span class='notice'>[user] repairs \the [src] with their [S]!</span>", "<span class='notice'>You repair \the [src] with your [S].</span>")
+		user.visible_message("<span class='notice'>[user] repairs \the [src] with their [S]!</span>", "<span class='notice'>You repair \the [src] with your [S.name].</span>")
 
 	else // No diff, but we didn't exit earlier, so mode must be reinforce
 		var/extra_health = health - initial(health)
@@ -333,7 +333,7 @@
 		diff = min(S.get_amount() / SILICATE_PER_REINFORCE, (initial(health) * MAX_WINDOW_HEALTH_MULTIPLIER) - (initial(health) + extra_health))
 		health += diff
 		healthcheck(user)
-		user.visible_message("<span class='notice'>[user] reinforced \the [src] with their [S]!</span>", "<span class='notice'>You reinforce \the [src] with your [S].</span>")
+		user.visible_message("<span class='notice'>[user] reinforced \the [src] with their [S]!</span>", "<span class='notice'>You reinforce \the [src] with your [S.name].</span>")
 
 	playsound(src, 'sound/effects/refill.ogg', 10, 1, -6)
 	S.remove_silicate(diff * SILICATE_PER_DAMAGE)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -356,7 +356,7 @@
 		PK.playtoolsound(src, 100)
 		if(do_after(user, src, (MINE_DURATION * PK.toolspeed) * 10))
 			user.visible_message("<span class='notice'>[user]'s [PK] tears though the last of \the [src], leaving nothing but a girder.</span>", \
-			"<span class='notice'>Your [PK] tears though the last of \the [src], leaving nothing but a girder.</span>")
+			"<span class='notice'>Your [PK.name] tears though the last of \the [src], leaving nothing but a girder.</span>")
 			dismantle_wall()
 
 			var/pdiff = performWallPressureCheck(src)

--- a/code/game/turfs/simulated/walls_reinforced.dm
+++ b/code/game/turfs/simulated/walls_reinforced.dm
@@ -348,7 +348,7 @@
 		PK.playtoolsound(src, 100)
 		if(do_after(user, src, (MINE_DURATION * PK.toolspeed) * 50))
 			user.visible_message("<span class='notice'>[user]'s [PK] tears though the last of \the [src], leaving nothing but a girder.</span>", \
-			"<span class='notice'>Your [PK] tears though the last of \the [src], leaving nothing but a girder.</span>")
+			"<span class='notice'>Your [PK.name] tears though the last of \the [src], leaving nothing but a girder.</span>")
 			var/pdiff = performWallPressureCheck(src)
 			if(pdiff)
 				investigation_log(I_ATMOS, "with a pdiff of [pdiff] has been drilled through by [user.real_name] ([formatPlayerPanel(user, user.ckey)]) at [formatJumpTo(get_turf(src))]!")

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -253,7 +253,7 @@
 		src.item_state = "xcomarmor2_sleeveless"
 		to_chat(usr, "You roll up your sleeves.")
 	else
-		to_chat(usr, "You roll up some imaginary sleeves on your [src].")
+		to_chat(usr, "You roll up some imaginary sleeves on your [src.name].")
 		return
 	usr.update_inv_wear_suit()
 

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -288,7 +288,7 @@
 			src.icon_state = "ia_jacket_open"
 			to_chat(usr, "You unbutton the jacket.")
 		else
-			to_chat(usr, "You attempt to button-up the velcro on your [src], before promptly realising how retarded you are.")
+			to_chat(usr, "You attempt to button-up the velcro on your [src.name], before promptly realising how retarded you are.")
 			return
 	usr.update_inv_wear_suit()	//so our overlays update
 
@@ -372,6 +372,6 @@
 			src.icon_state = "ia_jacket_open"
 			to_chat(usr, "You unbutton the jacket.")
 		else
-			to_chat(usr, "You attempt to button-up the velcro on your [src], before promptly realising how retarded you are.")
+			to_chat(usr, "You attempt to button-up the velcro on your [src.name], before promptly realising how retarded you are.")
 			return
 	usr.update_inv_wear_suit()	//so our overlays update

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -532,7 +532,7 @@ var/list/tag_suits_list = list()
 		src.item_state = "suitjacket_blue_open"
 		to_chat(usr, "You unbutton the suit jacket.")
 	else
-		to_chat(usr, "You button-up some imaginary buttons on your [src].")
+		to_chat(usr, "You button-up some imaginary buttons on your [src.name].")
 		return
 	usr.update_inv_wear_suit()
 

--- a/code/modules/detectivework/footprints_and_rag.dm
+++ b/code/modules/detectivework/footprints_and_rag.dm
@@ -81,7 +81,7 @@
 				else
 					current_target = M
 					user.visible_message("<span class='notice'>[user] uses \a [src] to stem the bleeding on [M]'s [targetorgan.display_name].</span>", \
-					"<span class='notice'>You use your [src] to stem the bleeding on [M]'s [targetorgan.display_name].</span>")
+					"<span class='notice'>You use your [src.name] to stem the bleeding on [M]'s [targetorgan.display_name].</span>")
 					qdel(src)
 			else
 				to_chat(user, "<span class='notice'>[M]'s [targetorgan.display_name] is cut wide open, you'll need more than a rag!</span>")

--- a/code/modules/dna/genes/goon_powers.dm
+++ b/code/modules/dna/genes/goon_powers.dm
@@ -173,10 +173,10 @@
 					handle_suit = 1
 					if(H.internal)
 						H.visible_message("<span class='warning'>A cloud of fine ice crystals engulfs [H]!</span>",
-											"<span class='notice'>A cloud of fine ice crystals cover your [H.head]'s visor.</span>")
+											"<span class='notice'>A cloud of fine ice crystals cover your [H.head.name]'s visor.</span>")
 					else
 						H.visible_message("<span class='warning'>A cloud of fine ice crystals engulfs [H]!</span>",
-											"<span class='warning'>A cloud of fine ice crystals cover your [H.head]'s visor and make it into your air vents!</span>")
+											"<span class='warning'>A cloud of fine ice crystals cover your [H.head.name]'s visor and make it into your air vents!</span>")
 						H.bodytemperature = max(T0C + 31, H.bodytemperature - 3)
 						H.adjustFireLoss(5)
 		if(!handle_suit)

--- a/code/modules/media/jukebox.dm
+++ b/code/modules/media/jukebox.dm
@@ -988,7 +988,7 @@ var/global/list/loopModeNames=list(
 /obj/machinery/media/jukebox/superjuke/attackby(obj/item/W, mob/user)
 	// NO FUN ALLOWED.  Emag list is included, anyway.
 	if(isEmag(W))
-		to_chat(user, "<span class='warning'>Your [W] refuses to touch \the [src]!</span>")
+		to_chat(user, "<span class='warning'>Your [W.name] refuses to touch \the [src]!</span>")
 		return
 	..()
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -2249,7 +2249,7 @@ var/datum/record_organ //This is just a dummy proc, not storing any variables he
 	if (istype(gloves, /obj/item/clothing/gloves/hunter))
 		for(var/obj/item/I in held_items)
 			if (istype(I, /obj/item/weapon/gun/hookshot/whip))
-				to_chat(src, "<span class='notice'>You hold your grip onto your [I]</span>")
+				to_chat(src, "<span class='notice'>You hold your grip onto your [I.name]</span>")
 			else
 				drop_item(I, Target, force_drop = force_drop)
 	else

--- a/code/modules/power/antimatter/control.dm
+++ b/code/modules/power/antimatter/control.dm
@@ -227,7 +227,7 @@
 		shake(1, 3)
 		user.delayNextAttack(8)
 		visible_message("<span class='warning'>\The [user] hits \the [src] with \a [W]!</span>", \
-					"<span class='warning'>You hit \the [src] with your [W]!</span>", \
+					"<span class='warning'>You hit \the [src] with your [W.name]!</span>", \
 					"You hear something metallic being hit.")
 		stability -= W.force/2
 		check_stability()

--- a/code/modules/power/antimatter/shielding.dm
+++ b/code/modules/power/antimatter/shielding.dm
@@ -210,7 +210,7 @@
 		shake(1, 3)
 		user.delayNextAttack(8)
 		visible_message("<span class='warning'>\The [user] hits \the [src] with \a [W]!</span>", \
-					"<span class='warning'>You hit \the [src] with your [W]!</span>", \
+					"<span class='warning'>You hit \the [src] with your [W.name]!</span>", \
 					"You hear something metallic being hit.")
 		stability -= W.force/2
 		check_stability()

--- a/code/modules/power/solars/panel.dm
+++ b/code/modules/power/solars/panel.dm
@@ -383,7 +383,7 @@
 	health += diff
 	healthcheck(user, FALSE)
 
-	user.visible_message("<span class='notice'>[user] repairs \the [src] with their [S]!</span>", "<span class='notice'>You repair \the [src] with your [S].</span>")
+	user.visible_message("<span class='notice'>[user] repairs \the [src] with their [S]!</span>", "<span class='notice'>You repair \the [src] with your [S.name].</span>")
 
 	playsound(src, 'sound/effects/refill.ogg', 10, 1, -6) //Probably will never hear this!
 	S.remove_silicate(diff * SILICATE_PER_DAMAGE)

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -106,7 +106,7 @@
 			process_temperature()
 			if(clumsy_check(user))
 				user.ignite()
-				user.visible_message("<span class='danger'>[user] tried to spray a plume of fire from \his [src] but ignited himself!</span>","<span class='danger'>You try to spray a plume of fire from your [src] but only ignite yourself!</span>")
+				user.visible_message("<span class='danger'>[user] tried to spray a plume of fire from \his [src] but ignited himself!</span>","<span class='danger'>You try to spray a plume of fire from your [src.name] but only ignite yourself!</span>")
 				return
 			if(!user.get_item_by_slot(slot_gloves) && prob(10))
 				to_chat(user,"<span class='danger'>The heat from the spray bottle burns your hand!</span>")
@@ -125,7 +125,7 @@
 			spawn()
 				projectile.OnFired()
 				projectile.process()
-			user.visible_message("<span class='danger'>[user] sprays a plume of fire from \his [src]!</span>","<span class='danger'>You spray a plume of fire from your [src]!</span>")
+			user.visible_message("<span class='danger'>[user] sprays a plume of fire from \his [src]!</span>","<span class='danger'>You spray a plume of fire from your [src.name]!</span>")
 			update_icon()
 			playsound(user, 'sound/weapons/flamethrower.ogg', 50, 1)
 			return

--- a/maps/RandomZLevels/hive.dm
+++ b/maps/RandomZLevels/hive.dm
@@ -838,7 +838,7 @@ var/list/hive_pylons = list()
 		L.apply_effect(stunforce, STUTTER)
 
 		if(L)
-			to_chat(L, "<span class='userdanger'>As you approach \the [source], your [src] explodes in a burst of energy, knocking you back. Phew, that was close.</span>")
+			to_chat(L, "<span class='userdanger'>As you approach \the [source], your [src.name] explodes in a burst of energy, knocking you back. Phew, that was close.</span>")
 
 	if(!infinite)
 		.=..()


### PR DESCRIPTION
[bugfix][grammar][thanksbyond]

## What this does
Closes #39115.

## How it was tested
Using relevant items with the erroneous messages.

## Changelog
:cl:
 * spellcheck: Many items no longer have an erroneous "the" after the word "your" in output messages relating to them.
 * bugfix: Disposing chemicals from microwaves now properly puts them in held beakers.