### PR TITLE
Emag Flashing

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -92,6 +92,7 @@
 
 	var/nticks=0
 	var/disable_config_sync = FALSE
+	var/flash_animation = FLASH_ID_ANIM
 
 /obj/item/weapon/card/emag/New(var/loc, var/disable_tuning=1)
 	..(loc)
@@ -183,6 +184,13 @@
 		var/zone = ran_zone(user.zone_sel.selecting, 100)
 		var/datum/organ/external/organ = target_living.get_organ(zone)
 		target_living.emag_act(user, organ, src)
+
+/obj/item/weapon/card/emag/attack_self(var/mob/user)
+	if(isliving(user) && !user.incapacitated())
+		user.delayNextAttack(0.5 SECONDS)
+		add_fingerprint(user)
+		user.visible_message("<span class='warning'>[user] displays \the [src] like an absolute madman.</span>","<span class='warning'>You proudly display \the [src].</span>")
+		flash_object_animation(user, src, flash_animation)
 
 /mob/living/carbon/human/emag_check(obj/item/weapon/card/emag/E, mob/user) //handled above!
 	return FALSE


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Extends #38230 to emags

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Brave and confident Syndicate operators can already wear emags; why not allow them to proudly show it off?

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Smacked that mf Z key while holding an emag
<img width="141" height="120" alt="image" src="https://github.com/user-attachments/assets/68a70ce8-4aeb-4694-b626-a6ed75d00291" />


## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Emags can now be flashed like IDs.