### PR TITLE
pAI Expedition Tracker module

### DIFF
--- a/__DEFINES/pai_software.dm
+++ b/__DEFINES/pai_software.dm
@@ -13,6 +13,7 @@
 #define SOFT_SS "security supplement"
 #define SOFT_AS "atmosphere sensor"
 #define SOFT_PS "pai positioning system"
+#define SOFT_XS "pai expedition tracker"
 #define SOFT_HM "holomap viewer"
 #define SOFT_UN "uninstall"
 #define SOFT_BY	"buy"

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -50,6 +50,8 @@
 	var/obj/item/radio/integrated/signal/sradio // AI's signaller
 
 	var/obj/item/device/gps/pai/pps_device = null //Our GPS device.
+	var/obj/item/device/gps/planetary/pai/xps_device = null //our planetary expedition tracker
+	var/sharedfirmware = FALSE
 
 	var/obj/machinery/newscaster/painews //our copy of the Newscaster
 

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -15,6 +15,7 @@
 															SOFT_SS = 30, //records + HUD
 															SOFT_AS = 5,
 															SOFT_PS = 10,
+															SOFT_XS = 10,
 															SOFT_HM = 25
 
 															)

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -288,6 +288,18 @@
 			if(!pps_device)
 				pps_device = new(src)
 			pps_device.attack_self(src)
+			if(!sharedfirmware && xps_device)
+				sharedfirmware = TRUE
+				ram += 10
+				to_chat(src, "Shared software dependencies with the expedition tracker, RAM cost refunded.")
+		if(SOFT_XS)
+			if(!xps_device)
+				xps_device = new(src)
+			xps_device.attack_self(src)
+			if(!sharedfirmware && pps_device)
+				sharedfirmware = TRUE
+				ram += 10
+				to_chat(src, "Shared software dependencies with the pAI position tracker, RAM cost refunded.")
 		if(SOFT_HM)
 			if(href_list["switch_target"])
 				if(holo_target == initial(holo_target))
@@ -321,6 +333,15 @@
 						if(target==SOFT_PS)
 							qdel(pps_device)
 							pps_device = null
+							if(sharedfirmware)
+								ram -= cost
+							sharedfirmware = FALSE
+						if(target==SOFT_XS)
+							qdel(xps_device)
+							xps_device = null
+							if(sharedfirmware)
+								ram -= cost
+							sharedfirmware = FALSE
 						if(target==SOFT_HM)
 							qdel(holomap_device)
 							holomap_device = null
@@ -398,6 +419,8 @@
 	for(var/s in software)
 		if(s == SOFT_PS)
 			dat += "<a href='byond://?src=\ref[src];software=[SOFT_PS];sub=0'>pAI Positioning System</a> <br>"
+		if(s == SOFT_XS)
+			dat += "<a href='byond://?src=\ref[src];software=[SOFT_XS];sub=0'>pAI Expedition Tracker</a> <br>"
 		if(s == SOFT_HM)
 			dat += "<a href='byond://?src=\ref[src];software=[SOFT_HM];sub=0'>Holomap Viewer</a> <br>"
 	dat += {"<br>

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -605,3 +605,9 @@ var/list/nums_to_hl_num = list("1" = 'sound/items/one.wav', "2" = 'sound/items/t
 		to_chat(usr, "<span class='notice'>Distress beacon cancelled.</span>")
 		return TRUE
 	return FALSE
+
+/obj/item/device/gps/planetary/pai
+	base_name = "pAI expedition tracker"
+	base_tag = "PAIEX"
+	builtin = TRUE
+	transmitting = TRUE

--- a/code/modules/tgui/states/default.dm
+++ b/code/modules/tgui/states/default.dm
@@ -48,7 +48,7 @@ var/datum/ui_state/default/default_state = new
 
 /mob/living/silicon/pai/default_can_use_topic(src_object)
 	// pAIs can only use themselves and the owner's radio.
-	if((src_object == src || src_object == radio || src_object == pps_device) && !stat)
+	if((src_object == src || src_object == radio || src_object == pps_device || src_object == xps_device) && !stat)
 		return UI_INTERACTIVE
 	else
 		return min(..(), UI_UPDATE)


### PR DESCRIPTION
## What this does
pAIs can buy a pAI expedition tracker module for 10 RAM. Naturally, this only works properly while on an expedition, either through the expedition shuttle, or the NTEV Odyssey map.
Buying both the GPS and XPS will refund 10 RAM, since they share dependencies. This "free" 10 ram is then taken back when uninstalling either of these, so no free RAM exploit.
I made them two separate modules instead of one cause having both while unnecessary is just clutter, and you can use a tracker while stationside to see the coords of someone planetside, for example.
## Why it's good
Lets a pAI assist their users with coordinates/tracking while on planetary expeditions.
## How it was tested
Spawned as pAI, installed the XPS module, opened it, got a regular expedition tracker UI window.
Installed the GPS module, opened it, got the ram refunded.
Uninstalled both, ended up with 100 ram again.
Closes #39201
:cl:
 * rscadd: pAIs can buy the pAI expedition tracker module for 10 RAM. If both the XPS and GPS are installed and used, 10 RAM is refunded since they share dependencies. Uninstalling both will put you back at 100 RAM like normal.