### PR TITLE
pAI module: Mesons

### DIFF
--- a/__DEFINES/pai_software.dm
+++ b/__DEFINES/pai_software.dm
@@ -14,6 +14,7 @@
 #define SOFT_AS "atmosphere sensor"
 #define SOFT_PS "pai positioning system"
 #define SOFT_HM "holomap viewer"
+#define SOFT_ME "meson augmentation"
 #define SOFT_UN "uninstall"
 #define SOFT_BY	"buy"
 

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -33,6 +33,7 @@
 
 	var/secHUD = FALSE			// Toggles whether the Security HUD is active or not
 	var/medHUD = FALSE			// Toggles whether the Medical  HUD is active or not
+	var/mesons = FALSE			// Toggles whether we have the mesons active or not
 	var/lighted = FALSE			// Toggles whether light is active or not
 	var/loudspeak = FALSE		// Toggles megaphone mode
 
@@ -391,3 +392,10 @@
 	..()
 	if(loudspeak)
 		speech.message_classes.Add("megaphone")
+
+/mob/living/silicon/pai/handle_regular_hud_updates() //thanks dilt
+  ..()
+  see_in_dark = initial(see_in_dark)
+  change_sight(removing = SEE_MOBS|SEE_TURFS|SEE_OBJS)
+  see_invisible = initial(see_invisible)
+  handle_vision_effect_updates()

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -14,6 +14,7 @@
 															SOFT_MS = 30, //records + HUD
 															SOFT_SS = 30, //records + HUD
 															SOFT_AS = 5,
+															SOFT_ME = 5,
 															SOFT_PS = 10,
 															SOFT_HM = 25
 
@@ -72,6 +73,8 @@
 				left_part = softwareHolomap()
 			if(SOFT_VE)
 				left_part = softwareVolumeEnhancer()
+			if(SOFT_ME)
+				left_part = softwareMesons()
 
 	//usr << browse_rsc('windowbak.png')		// This has been moved to the mob's Login() proc
 
@@ -303,6 +306,15 @@
 		if(SOFT_VE)
 			if(href_list["toggle"])
 				loudspeak = !loudspeak
+		if(SOFT_ME)
+			if(href_list["toggle"])
+				mesons = !mesons
+			if(mesons)
+				apply_hud_by_type(/datum/visioneffect/meson)
+				handle_regular_hud_updates()
+			if(!mesons)
+				remove_hud_by_type(/datum/visioneffect/meson)
+				handle_regular_hud_updates()
 		if(SOFT_UN)
 			if(href_list["cancel"])
 				uninstallprogress = -1
@@ -333,6 +345,9 @@
 							secHUD = FALSE
 						if(target==SOFT_VE)
 							loudspeak = initial(loudspeak)
+						if(target==SOFT_ME)
+							remove_hud_by_type(/datum/visioneffect/meson)
+							mesons = initial(mesons)
 						software.Remove(target)
 					uninstallprogress = -1
 				else
@@ -400,6 +415,8 @@
 			dat += "<a href='byond://?src=\ref[src];software=[SOFT_PS];sub=0'>pAI Positioning System</a> <br>"
 		if(s == SOFT_HM)
 			dat += "<a href='byond://?src=\ref[src];software=[SOFT_HM];sub=0'>Holomap Viewer</a> <br>"
+		if(s == SOFT_ME)
+			dat += "<a href='byond://?src=\ref[src];software=[SOFT_ME];sub=0'>Mesons Augmentation</a> <br>"
 	dat += {"<br>
 		<br>
 		<a href='byond://?src=\ref[src];software=[SOFT_BY];sub=0'>Download additional software</a>"}
@@ -793,4 +810,11 @@ Target Machine: "}
 	var/dat = "<h3>Volume Enhancer</h3>"
 	dat += "Volume increase via targeted speaker overvoltage.<br><br>"
 	dat += "Volume enhancement [ (loudspeak) ? "<font color=#55FF55>en" : "<font color=#FF5555>dis" ]abled.</font><br> <a href='byond://?src=\ref[src];software=[SOFT_VE];sub=0;toggle=1'>Toggle Megaphone</a><br>"
+	return dat
+
+//Mesons
+/mob/living/silicon/pai/proc/softwareMesons()
+	var/dat = "<h3>Meson Firmware</h3>"
+	dat += "Low-intensity p-ray emitter for high resolution area mapping.<br><br>"
+	dat += "Meson firmware [ (mesons) ? "<font color=#55FF55>en" : "<font color=#FF5555>dis" ]abled.</font><br> <a href='byond://?src=\ref[src];software=[SOFT_ME];sub=0;toggle=1'>Toggle Mesons</a><br>"
 	return dat

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -14,7 +14,7 @@
 															SOFT_MS = 30, //records + HUD
 															SOFT_SS = 30, //records + HUD
 															SOFT_AS = 5,
-															SOFT_ME = 5,
+															SOFT_ME = 10,
 															SOFT_PS = 10,
 															SOFT_HM = 25
 


### PR DESCRIPTION
## What this does
Lets pAIs buy a toggleable mesons upgrade for 10 RAM. This upgrade does NOT extend to your user, nor does it give you xray, behaving just like normal mesons do. Cheap because it's pAI-facing only, though I can raise the price if needed.

## Why it's good
Lets pAIs actually see some shit when helping miners in the roid, explorers in the expeditions, or engineers (often forgetful about turning the lights on).
## How it was tested
Became pAI. Installed mesons module. Toggled it on and off, worked fine.
Uninstalled it while on, it reverted properly to pre-install.
Reinstalled it, toggled it on and off, worked fine, again.
:cl:
 * rscadd: pAIs can now buy a mesons module for 10 RAM. This module does NOT extend to your user, only giving you the bare basic meson vision.