### PR TITLE
Makes the sun subsystem compatible with virtual zlevels

### DIFF
--- a/code/controllers/subsystem/daynightcycle.dm
+++ b/code/controllers/subsystem/daynightcycle.dm
@@ -141,6 +141,36 @@ On the map dm file, redefine the following:
 			continue
 		T.set_light(next_light_range, light_power, vz.current_timeOfDay, lowpriority)
 
+// Power multiplier for solar panels on VZ_PLANET vLevels, indexed by current_timeOfDay.
+/proc/solar_tod_power(tod)
+	switch(tod)
+		if(TOD_MORNING)
+			return 0.3
+		if(TOD_SUNRISE)
+			return 0.7
+		if(TOD_DAYTIME)
+			return 1.0
+		if(TOD_AFTERNOON)
+			return 0.85
+		if(TOD_SUNSET)
+			return 0.5
+		if(TOD_NIGHTTIME)
+			return 0.05
+	return 1.0
+
+// True if the turf is registered (or eligible to be registered) for the day/night cycle.
+/proc/turf_has_open_sky(turf/T)
+	if(!T)
+		return FALSE
+	var/area/A = get_area(T)
+	if(isopensurface(A))
+		return TRUE
+	for(var/cdir in cardinal)
+		var/turf/adj = get_step(T, cdir)
+		if(adj && istype(get_area(adj), /area/surface))
+			return TRUE
+	return FALSE
+
 // Force lighting change on a list of turfs (used mainly for when shuttles leave)
 /datum/subsystem/daynightcycle/proc/update_turf_lighting(var/list/turf/turfs, var/datum/virtual_z/vz = null)
 	if(!turfs.len || !vz)

--- a/code/datums/sun.dm
+++ b/code/datums/sun.dm
@@ -87,6 +87,21 @@ var/global/datum/sun/sun
 		S.update_icon()
 		return
 
+	var/datum/virtual_z/vz = S.get_virtual_z()
+	// Planet panels use TOD-based power (handled in update_solar_exposure).
+	// Protected vLevels (centcomm, away missions, etc) skip occlusion entirely.
+	if(vz && (vz.level_type == VZ_PLANET || vz.level_type == VZ_PROTECTED))
+		S.obscured = 0
+		S.update_solar_exposure()
+		S.update_icon()
+		return
+
+	// Trace exits at the panel's vLevel boundary, not the world boundary otherwise opaque vLevel border turfs always shadow panels in vLevels that don't touch a true world edge.
+	var/bx_min = vz ? vz.x_min : 1
+	var/bx_max = vz ? vz.x_max : world.maxx
+	var/by_min = vz ? vz.y_min : 1
+	var/by_max = vz ? vz.y_max : world.maxy
+
 	var/ax = S.x //Start at the solar panel.
 	var/ay = S.y
 	var/i
@@ -101,7 +116,7 @@ var/global/datum/sun/sun
 		if(isnull(T))
 			warning("Occlusion's locate returned null. [S] at ([S?.x],[S?.y],[S?.z]). ax: [ax], ay: [ay], dx: [dx], dy: [dy]")
 			break
-		if(T.x == 1 || T.x == world.maxx || T.y == 1 || T.y == world.maxy) // Not obscured if we reach the edge.
+		if(T.x <= bx_min || T.x >= bx_max || T.y <= by_min || T.y >= by_max) // Not obscured if we reach the vLevel edge.
 			break
 		if(T.opacity) //Opaque objects block light.
 			S.obscured = 1

--- a/code/modules/power/solars/panel.dm
+++ b/code/modules/power/solars/panel.dm
@@ -267,9 +267,26 @@
 	if(!sun)
 		obscured = 1
 
-	if(SSDayNight?.overwrite_solars && (src.get_virtual_z() in daynight_v_lvls) )
+	var/datum/virtual_z/vz = src.get_virtual_z()
+
+	if(SSDayNight?.overwrite_solars && (vz in daynight_v_lvls) )
+		// Junglestation override
 		use_daynight_ss=TRUE
 		obscured=0
+	else if(vz?.level_type == VZ_PLANET)
+		// On planet vLevels, power is purely a function of time-of-day and weather: no orientation or occlusion.
+		// Panels must still be on (or adjacent to) an open surface so no power if buried in a cave or roofed building.
+		if(!turf_has_open_sky(get_turf(src)))
+			obscured = 1
+			sunfrac = 0
+			plane = ABOVE_HUMAN_PLANE
+			layer = LIGHT_FIXTURE_LAYER
+			return
+		obscured = 0
+		plane = ABOVE_LIGHTING_PLANE
+		layer = ABOVE_LIGHTING_LAYER
+		sunfrac = solar_tod_power(vz.current_timeOfDay) * vz.weather_mod
+		return
 
 	if(obscured)
 		sunfrac = 0


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Updates the sun tracking subsystem so that solar panels will work properly with Virtual zLevels. Occlusion will now be calculated using the edges of the vLevel instead of the zLevel edges (which often produced nonsense results leading to solar panels simply not working in any location in NTEV Odyssey.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Bugfix

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
- Verified the solar panels in the NTEV Odyssey map's outpost functioned properly.
- Verified solar panel output varied with time of day.
- Verified solar panels do not generate power in caves or buildings.
- Verified power output is scaled by weather effects.
- Verified Junglestation doesn't break because of this change.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed the sun tracking subsystem not working on virtual zlevels, resulting in solar panels failing to produce power in Odyssey.