### PR TITLE
Fixes blueprints not being able to expand shuttles

### DIFF
--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -545,8 +545,6 @@ these cannot rename rooms that are in by default BUT can rename rooms that are c
 /obj/item/blueprints/proc/check_tile_is_border(var/turf/T2,var/dir)
 	if (istype(T2, /turf/space))
 		return BORDER_SPACE //omg hull breach we all going to die here
-	if (isshuttleturf(T2))
-		return BORDER_SPACE
 	var/areatype = get_area_type(T2.loc)
 	if (areatype != AREA_SPACE && areatype != AREA_CONSTRUCT)
 		return BORDER_BETWEEN //found something part of a non-buildable area, like a preexisting structure


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Removes a check which made it impossible to actually add rooms to a shuttle.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
The feature I added specifically to enable this doesn't work without this fix. Closes #39210.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
- Built a new room attached to a shuttle using shuttle walls and successfully added it to the Odyssey.
- Sent the shuttle to a location with the new room attached and verified it moved with the shuttle.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed blueprints failing to expand shuttles.