### PR TITLE
Makes pulse rifles stronger on windows and fences

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -166,7 +166,9 @@
 		return FALSE
 
 /obj/machinery/door/window/bullet_act(var/obj/item/projectile/Proj)
-	if(Proj.damage)
+	if(Proj.destroy)
+		ex_act(1)
+	else if(Proj.damage)
 		take_damage(round(Proj.damage / 2))
 	return ..()
 

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -243,6 +243,12 @@
 			return 0
 	return 0
 
+/obj/structure/fence/bullet_act(var/obj/item/projectile/Proj)
+	if(Proj.destroy)
+		new /obj/item/stack/rods(loc,1)
+		qdel(src)
+	return ..()
+
 /obj/structure/fence/ex_act(severity)
 	switch(severity)
 		if(1.0)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -201,7 +201,9 @@ var/list/one_way_windows
 	return 1
 
 /obj/structure/window/bullet_act(var/obj/item/projectile/Proj)
-
+	if(Proj.destroy)
+		ex_act(1)
+		return ..()
 	adjustHealthLoss(Proj.damage,Proj)
 	. = ..()
 	healthcheck(Proj.firer)


### PR DESCRIPTION
[balance]

## What this does
Closes #39199.

## Why it's good
[consistency]

## How it was tested
Spawning the relevant objects and firing a pulse rifle at them.

## Changelog
:cl:
 * tweak: Pulse rifles now instantly destroy windows, fences and window doors.