### PR TITLE
WATTS ARE A UNIT OF POWER, NOT ENERGY

### DIFF
--- a/nano/templates/shield_capacitor.tmpl
+++ b/nano/templates/shield_capacitor.tmpl
@@ -33,13 +33,13 @@ Used In File(s): /code/modules/power/ShieldGen/shield_capacitor.dm
     <div class="item">
         <div class="itemLabelWide">Charge:</div>
         <div class="itemContents">
-            {{:helper.displayBar(data.charge, data.min_charge, data.max_charge, (data.charge >= data.max_charge/2) ? 'good' : (data.charge >= data.max_charge/4) ? 'average' : 'bad', data.charge + '/' + data.max_charge + ' kilowatts (' + data.charge_percentage + '%)')}}
+            {{:helper.displayBar(data.charge, data.min_charge, data.max_charge, (data.charge >= data.max_charge/2) ? 'good' : (data.charge >= data.max_charge/4) ? 'average' : 'bad', data.charge + '/' + data.max_charge + ' kilojoules (' + data.charge_percentage + '%)')}}
         </div>
     </div>
     <div class="item">
         <div class="itemLabelWide">Charge rate:</div>
         <div class="itemContents">
-                {{:helper.displayBar(data.charge_rate, data.min_charge_rate, data.max_charge_rate, (data.charge_rate >= data.max_charge_rate/2) ? 'good' : (data.charge_rate >= data.max_charge_rate/4) ? 'average' : 'bad', data.charge_rate + '/' + data.max_charge_rate + ' kilowatts/sec')}}
+                {{:helper.displayBar(data.charge_rate, data.min_charge_rate, data.max_charge_rate, (data.charge_rate >= data.max_charge_rate/2) ? 'good' : (data.charge_rate >= data.max_charge_rate/4) ? 'average' : 'bad', data.charge_rate + '/' + data.max_charge_rate + ' kilowatts')}}
                 <div style="clear: both; padding-top: 4px;">
                     {{:helper.link('MIN', null, {'adjust_charge_rate' : -data.max_charge_rate}, (data.charge_rate > data.min_charge_rate) ? null : 'disabled')}}
                     {{:helper.link('SET', null, {'set_charge_rate' : 1})}}


### PR DESCRIPTION
[ui]

## What this does
<img width="493" height="285" alt="Capture" src="https://github.com/user-attachments/assets/244acc97-35d9-4933-9f5a-b6094972a96e" />


## Why it's good
AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA FIX IT FIX IT FIX IT FIX IT

## How it was tested
see image

## Changelog
:cl:
 * spellcheck: Fixed shield capacitors using watts as a unit of energy
