### PR TITLE
makes CO2 and lack of oxygen more deadly.

### DIFF
--- a/__DEFINES/carbon_defines.dm
+++ b/__DEFINES/carbon_defines.dm
@@ -1,5 +1,5 @@
 //NOTE: Breathing happens once per FOUR TICKS, unless the last breath fails. In which case it happens once per ONE TICK! So oxyloss healing is done once per 4 ticks while oxyloss damage is applied once per tick!
-#define HUMAN_MAX_OXYLOSS 1 //Defines how much oxyloss humans can get per tick. A tile with no air at all (such as space) applies this value, otherwise it's a percentage of it.
+#define HUMAN_MAX_OXYLOSS 7 //Defines how much oxyloss humans can get per tick. A tile with no air at all (such as space) applies this value, otherwise it's a percentage of it.
 #define HUMAN_CRIT_MAX_OXYLOSS ((SSmob.wait / 10) / 3) //The amount of damage you'll get when in critical condition. We want this to be a 5 minute deal = 300s. There are 100HP to get through, so (1/3)*last_tick_duration per second. Breaths however only happen every 4 ticks.
 
 #define HEAT_DAMAGE_LEVEL_1 2 //Amount of damage applied when your body temperature just passes the 360.15k safety point

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -785,3 +785,22 @@
 		if(internal)
 			return internal.remove_air_volume(volume_needed)
 	return null
+
+
+/mob/living/carbon/Life()
+	..()
+	if(stat!=DEAD && health>0) //no special effects in crit or if dead.
+		var/suffocation_fraction=oxyloss/maxHealth
+		if(suffocation_fraction>0.1 && prob(suffocation_fraction*25))
+			to_chat(src,"<span class='notice'>[pick("You feel light-headed.","You feel dizzy.","Your head hurts.")]</span>")
+		if(suffocation_fraction>0.5 && prob(suffocation_fraction*150) && !knockdown )
+			var/t=rand(1,4)
+			Knockdown(t)
+			Stun(rand(0,t))
+			src.visible_message("<span class='notice'>[src] [pick("stumbles to the ground","falls over")]!</span>","<span class='warning'>You [pick("feel too weak to stand","fall to the ground")]!</span>")
+		if(suffocation_fraction>0.33 && prob(10) )
+			brainloss+=1
+		if(suffocation_fraction>0.2)
+			eye_blurry+=suffocation_fraction*2
+		if(suffocation_fraction>0.5)
+			eye_blind+=suffocation_fraction*1

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -793,7 +793,7 @@
 		var/suffocation_fraction=oxyloss/maxHealth
 		if(suffocation_fraction>0.1 && prob(suffocation_fraction*25))
 			to_chat(src,"<span class='notice'>[pick("You feel light-headed.","You feel dizzy.","Your head hurts.")]</span>")
-		if(suffocation_fraction>0.5 && prob(suffocation_fraction*150) && !knockdown )
+		if(suffocation_fraction>0.4 && prob(suffocation_fraction*150) && !knockdown )
 			var/t=rand(1,4)
 			Knockdown(t)
 			Stun(rand(0,t))
@@ -802,5 +802,5 @@
 			brainloss+=1
 		if(suffocation_fraction>0.2)
 			eye_blurry+=suffocation_fraction*2
-		if(suffocation_fraction>0.5)
-			eye_blind+=suffocation_fraction*1
+		if(suffocation_fraction>0.4)
+			eye_blind+=suffocation_fraction

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -791,13 +791,13 @@
 	..()
 	if(stat!=DEAD && health>0) //no special effects in crit or if dead.
 		var/suffocation_fraction=oxyloss/maxHealth
-		if(suffocation_fraction>0.1 && prob(suffocation_fraction*25))
-			to_chat(src,"<span class='notice'>[pick("You feel light-headed.","You feel dizzy.","Your head hurts.")]</span>")
 		if(suffocation_fraction>0.33 && prob(suffocation_fraction*150) && !knockdown )
 			var/t=rand(1,4)
 			Knockdown(t)
 			Stun(rand(0,t))
 			src.visible_message("<span class='notice'>[src] [pick("stumbles to the ground","falls over")]!</span>","<span class='warning'>You [pick("feel too weak to stand","fall to the ground")]!</span>")
+		else if(suffocation_fraction>0.1 && prob(suffocation_fraction*25))
+			to_chat(src,"<span class='notice'>[pick("You feel light-headed.","You feel dizzy.","Your head hurts.")]</span>")
 		if(suffocation_fraction>0.33 && prob(10) )
 			brainloss+=1
 		if(suffocation_fraction>0.15)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -800,7 +800,7 @@
 			src.visible_message("<span class='notice'>[src] [pick("stumbles to the ground","falls over")]!</span>","<span class='warning'>You [pick("feel too weak to stand","fall to the ground")]!</span>")
 		if(suffocation_fraction>0.33 && prob(10) )
 			brainloss+=1
-		if(suffocation_fraction>0.2)
-			eye_blurry+=suffocation_fraction*2
-		if(suffocation_fraction>0.4)
+		if(suffocation_fraction>0.15)
+			eye_blurry+=suffocation_fraction
+		if(suffocation_fraction>0.33)
 			eye_blind+=suffocation_fraction

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -793,7 +793,7 @@
 		var/suffocation_fraction=oxyloss/maxHealth
 		if(suffocation_fraction>0.1 && prob(suffocation_fraction*25))
 			to_chat(src,"<span class='notice'>[pick("You feel light-headed.","You feel dizzy.","Your head hurts.")]</span>")
-		if(suffocation_fraction>0.4 && prob(suffocation_fraction*150) && !knockdown )
+		if(suffocation_fraction>0.33 && prob(suffocation_fraction*150) && !knockdown )
 			var/t=rand(1,4)
 			Knockdown(t)
 			Stun(rand(0,t))
@@ -801,6 +801,6 @@
 		if(suffocation_fraction>0.33 && prob(10) )
 			brainloss+=1
 		if(suffocation_fraction>0.15)
-			eye_blurry+=suffocation_fraction
+			eye_blurry+=suffocation_fraction*2
 		if(suffocation_fraction>0.33)
-			eye_blind+=suffocation_fraction
+			eye_blind+=suffocation_fraction*2

--- a/code/modules/organs/internal/lungs/lung_gasses.dm
+++ b/code/modules/organs/internal/lungs/lung_gasses.dm
@@ -107,10 +107,11 @@
 		if(!H.co2overloadtime) // If it's the first breath with too much CO2 in it, lets start a counter, then have them pass out after 12s or so.
 			H.co2overloadtime = world.time
 		else if(world.time - H.co2overloadtime > 120)
-			H.Paralyse(3)
-			H.adjustOxyLoss(1) // Lets hurt em a little, let them know we mean business
+			//H.Paralyse(3)
+			H.adjustOxyLoss(8) // Lets hurt em a little, let them know we mean business
+			//keep in mind that carbons regenerate 5 oxyloss every tick.
 			if(world.time - H.co2overloadtime > 600) // They've been in here 60s now, lets start to kill them for their own good!
-				H.adjustOxyLoss(3)
+				H.adjustOxyLoss(4)
 		if(prob(20)) // Lets give them some chance to know somethings not right though I guess.
 			H.audible_cough()
 	else


### PR DESCRIPTION
[balance]

## What this does
increases damage having no oxygen does to you, from 1 to 7 per tick
makes CO2 actually deal lasting damage, ramping up to 7 per tick.
makes CO2 no longer perpetually stunlock you with high concentrations.
makes oxygen loss damage apply more effects, including:
* dimming and blurring of vision
* knocking down the user
* brain damage
these additional effects do not occur while in crit or while dead.

lack of oxygen:

https://github.com/user-attachments/assets/a4b89e8f-cf59-47e3-b4ec-33a191727e4f

CO2 poisoning:


https://github.com/user-attachments/assets/72641ada-9706-4915-8dfc-622132c28d10


## Why it's good
it felt weird that, with how brutal ZAS can be, having no oxygen really isn't that big of a problem. surely making an already unforgiving atmos system even more CBT is a good thing, right?
makes the effects of CO2 a bit more interesting, since the effects of it probably broke at some point as the comments show that it was intended to result in death (it currently does not)

## How it was tested
see videos

## Changelog
:cl:
 * tweak: Made lack of oxygen (oxyloss/suffocation damage) more potent, and carry with it more effects. 
 * tweak: Reworked CO2 poisoning a bit to tie into suffocation damage more.