### PR TITLE
fixes jungle mobs causing a lot of hard deletes

### DIFF
--- a/code/modules/mob/living/complex_animal/base.dm
+++ b/code/modules/mob/living/complex_animal/base.dm
@@ -77,6 +77,15 @@
 		gender="male"
 	territory=locate(x,y,z) //store turf where we were born/created
 
+/mob/living/simple_animal/complex/Destroy()
+	territory=null
+	cache_objects_in_view=null
+	cache_objects_in_extended_area=null
+	for(var/mob/living/simple_animal/complex/C in family) //we will be referenced by our family, so clear us from that.
+		C.family -=src
+	family=null
+	..()
+
 
 /mob/living/simple_animal/complex/proc/allow_msg()
 	for(var/mob/m in range(src,11)) //only do emotes/say things if a player is nearby. this is to reduce log spam and make obsgang not want to die, even though they should just play the game.

--- a/code/modules/mob/living/complex_animal/base.dm
+++ b/code/modules/mob/living/complex_animal/base.dm
@@ -81,6 +81,7 @@
 	territory=null
 	cache_objects_in_view=null
 	cache_objects_in_extended_area=null
+	target=null
 	for(var/mob/living/simple_animal/complex/C in family) //we will be referenced by our family, so clear us from that.
 		C.family -=src
 	family=null


### PR DESCRIPTION
[bugfix] [performance] [jungle]

## What this does
adds cleanup code when jungle mobs are qdel'd to remove references to make the garbage collector less angry

## Why it's good
reduces lag

## How it was tested
wasn't

## Changelog
:cl:
 * tweak: fixes jungle mobs doing a lot of hard deletes, for better performance.
