### PR TITLE
Makes station heatmaps compatible with NTEV Odyssey

### DIFF
--- a/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
+++ b/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
@@ -1,5 +1,9 @@
 var/global/datum/controller/gameticker/scoreboard/score = new()
 
+// Pre-rendered heatmap HTML captured before round end.
+// When present, the scoreboard uses this instead of re-rendering from current turf state.
+var/global/heatmap_snapshot = ""
+
 /datum/controller/gameticker/scoreboard
 	var/crewscore 			= 0 //This is the overall var/score for the whole round
 
@@ -340,9 +344,12 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	dat += "<B><U>RATING:</U></B> [score.rating]<br><br>"
 
 	dat += "<b>STATION HEATMAP:</b><br>"
-	var/list/zs_to_draw = GetConnectedZlevels(map.zMainStation)
-	for(var/z in zs_to_draw)
-		dat += string_heatmap(z)
+	if(heatmap_snapshot)
+		dat += heatmap_snapshot
+	else
+		var/list/zs_to_draw = GetConnectedZlevels(map.zMainStation)
+		for(var/z in zs_to_draw)
+			dat += string_heatmap(z)
 	dat += "<br>"
 
 	var/datum/persistence_task/highscores/leaderboard = score.money_leaderboard
@@ -396,38 +403,65 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	src.award_name = award_name
 	src.award_desc = award_desc
 
-/proc/draw_heatmap(zLevel = 1)
-	set background=1
+/proc/draw_heatmap(input = 1) // Accepts a Z num or a datum/virtual_z.
+	set background = 1
 	if(!highest_player_entry)
 		return
-	if (zLevel > world.maxz)
+
+	var/datum/virtual_z/VZ
+	var/zLevel
+	var/x_min = 1
+	var/y_min = 1
+	var/x_max
+	var/y_max
+	if(istype(input, /datum/virtual_z))
+		VZ = input
+		zLevel = VZ.z()
+		x_min = max(1, VZ.x_min)
+		y_min = max(1, VZ.y_min)
+		x_max = min(world.maxx, VZ.x_max)
+		y_max = min(world.maxy, VZ.y_max)
+	else if(isnum(input))
+		zLevel = input
+		x_max = (2 * world.view + 1) * WORLD_ICON_SIZE
+		y_max = (2 * world.view + 1) * WORLD_ICON_SIZE
+	else
+		return
+	if(zLevel > world.maxz)
 		return
 
 	var/icon/canvas = icon('icons/480x480.dmi', "blank")
-	var/divisor_factor = 255/highest_player_entry
+	var/divisor_factor = 255 / highest_player_entry
 
 	var/lowest_x = world.maxx
 	var/lowest_y = world.maxy
 	var/highest_x = 0
 	var/highest_y = 0
-	for(var/i = 1 to ((2 * world.view + 1)*WORLD_ICON_SIZE))
-		for(var/r = 1 to ((2 * world.view + 1)*WORLD_ICON_SIZE))
+	for(var/i = x_min to x_max)
+		for(var/r = y_min to y_max)
 			var/turf/tile = locate(i, r, zLevel)
-			if(tile)
-				var/v_or_z = tile.v
-				if(!v_or_z)
-					v_or_z = zLevel
-				if(!istype(tile,get_base_turf(v_or_z)))
-					lowest_x = min(lowest_x,i)
-					lowest_y = min(lowest_y,r)
-					highest_x = max(highest_x,i)
-					highest_y = max(highest_y,r)
-					var/final_factor = tile.player_entries*divisor_factor
-					canvas.DrawBox(rgb(min(final_factor*4,255),min(final_factor*2,255),final_factor,255), i, r)
-	canvas.Crop(lowest_x,lowest_y,highest_x,highest_y)
-	log_debug("Heatmap generated for z-level [zLevel]. Lowest x: [lowest_x]. Lowest y: [lowest_y]. Highest x: [highest_x]. Highest y: [highest_y].")
-	return highest_x || highest_y ? canvas : null
+			if(!tile)
+				continue
+			// When restricted to a vLevel, ignore turfs from neighbouring vLevels sharing the same zLevel.
+			if(VZ && tile.v != VZ)
+				continue
+			var/v_or_z = tile.v
+			if(!v_or_z)
+				v_or_z = zLevel
+			if(istype(tile, get_base_turf(v_or_z)))
+				continue
+			lowest_x = min(lowest_x, i)
+			lowest_y = min(lowest_y, r)
+			highest_x = max(highest_x, i)
+			highest_y = max(highest_y, r)
+			var/final_factor = tile.player_entries * divisor_factor
+			canvas.DrawBox(rgb(min(final_factor*4,255), min(final_factor*2,255), final_factor, 255), i, r)
+	if(!(highest_x || highest_y))
+		return null
+	canvas.Crop(lowest_x, lowest_y, highest_x, highest_y)
+	log_debug("Heatmap generated for [VZ ? "vLevel '[VZ.name]' (id [VZ.id]) on z-level [zLevel]" : "z-level [zLevel]"]. Lowest x: [lowest_x]. Lowest y: [lowest_y]. Highest x: [highest_x]. Highest y: [highest_y].")
+	return canvas
 
-/proc/string_heatmap(zLevel = 1)
-	var/icon/I = draw_heatmap(zLevel)
+/proc/string_heatmap(input = 1)
+	var/icon/I = draw_heatmap(input)
 	return I ? "<img src='data:image/png;base64,[icon2base64(I)]'/><br>" : ""

--- a/maps/odyssey/shuttles.dm
+++ b/maps/odyssey/shuttles.dm
@@ -592,6 +592,11 @@ var/global/datum/shuttle/odyssey_transfer/odyssey_transfer_shuttle = new(startin
 			if(ticker)
 				ticker.mode.ShuttleDocked(2)
 
+			// Get the heatmap before the shuttle moves to Centcomm to remove noise
+			var/datum/virtual_z/current_vz = odyssey_shuttle.current_port?.get_virtual_z()
+			if(current_vz)
+				heatmap_snapshot = string_heatmap(current_vz)
+
 			// Move Odyssey to centcom dock
 			odyssey_shuttle.open_all_doors()
 			if(!odyssey_shuttle.move_to_dock(odyssey_shuttle.dock_centcom, 0, odyssey_shuttle.dir))


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Crops the station heatmap to just the Odyssey shuttle.
<img width="147" height="65" alt="image" src="https://github.com/user-attachments/assets/790cc18e-de7e-44b5-8a75-a0d3a0ee14fe" />

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Reduces noise in the heatmap.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Ran around the shuttle then completed a Bluespace jump. Verified the output looked correct.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: The roundend heatmap will only show the shuttle when playing on NTEV Odyssey.