### PR TITLE
Fixes Invisible Stun Batons

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -2,7 +2,7 @@
 	name = "stun baton"
 	desc = "A stun baton for incapacitating people with."
 	icon_state = "stun baton"
-	item_state = "baton0"
+	item_state = "baton"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/swords_axes.dmi', "right_hand" = 'icons/mob/in-hand/right/swords_axes.dmi')
 	flags = FPRINT
 	slot_flags = SLOT_BELT
@@ -257,7 +257,6 @@
 	name = "stunprod"
 	desc = "An improvised stun baton."
 	icon_state = "stunprod_nocell"
-	item_state = "prod"
 	force = 3
 	throwforce = 5
 	stunforce = 5
@@ -278,7 +277,6 @@
 /obj/item/weapon/melee/baton/harm
 	desc = "A baton for permanently incapacitating people with."
 	icon_state = "harmbaton"
-	item_state = "baton0"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/swords_axes.dmi', "right_hand" = 'icons/mob/in-hand/right/swords_axes.dmi')
 	origin_tech = Tc_COMBAT + "=2;" + Tc_SYNDICATE + "=3"
 	attack_verb = list("robusts", "harms")

--- a/maps/randomvaults/mothership_lab.dm
+++ b/maps/randomvaults/mothership_lab.dm
@@ -1020,7 +1020,7 @@
 	name = "stun probe"
 	desc = "An unusual baton used by MDF pacifiers. Less than lethal, not quite nonlethal."
 	icon_state = "stun probe"
-	item_state = "s_probe0"
+	item_state = "s_probe"
 	origin_tech = Tc_COMBAT + "=3" + Tc_POWERSTORAGE + "=2"
 	hitcost = 50 // 20 stuns with integrated cell, but can't upgrade or remove it. Doesn't have a normal baton's vulnerability to emp blasts. Compatible with rechargers
 	can_swap_cell = FALSE


### PR DESCRIPTION


## What this does
Shows all stun batons in hands again, broken by #37357.

Fixes #39266.

## Why it's good
Fair and balanced stun baton gameplay for both assistants and security!

## How it was tested
<img width="300" height="234" alt="image" src="https://github.com/user-attachments/assets/b87325e2-84ce-4de9-ac49-035deb2a9fb0" />

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Stun Batons are no longer invisible.