### PR TITLE
Gives pulse demon yellowed light spell a quicken cost

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon_powers.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon_powers.dm
@@ -622,6 +622,7 @@
 	hud_state = "blackout"
 	charge_cost = 2000
 	purchase_cost = 10000
+	quicken_cost = 10000
 	in_apc = TRUE
 
 /spell/pulse_demon/yellowlight/choose_targets(var/mob/user = usr)


### PR DESCRIPTION
[bugfix]

## What this does
Closes #39270.
[oversight] as the upgrade was an after thought.

## How it was tested
Spawned pulse demon, ckeyed into it, upgraded enough charge, purchased yellow light, upgraded, used it again.

## Changelog
:cl:
 * bugfix: Pulse demon yellowed light spells now have an actual upgrade cost of 10,000 watts.