### PR TITLE
Caps NTEV Odyssey at 10 players

### DIFF
--- a/code/datums/next_map.dm
+++ b/code/datums/next_map.dm
@@ -186,6 +186,7 @@
 /datum/next_map/odyssey
 	name = "NTEV Odyssey"
 	path = "odyssey"
+	max_players = 10
 
 /proc/get_votable_maps()
 	var/list/votable_maps = list()


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Makes Odyssey only voteable if there are 10 players or less online.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
The map in its current state does not support more than ~10 players.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
0%

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: NTEV Odyssey can now only be voted on when 10 players or less are online.
