### PR TITLE
Removes Planet Scanners from all maps execept Odyssey

### DIFF
--- a/maps/RoidStation.dmm
+++ b/maps/RoidStation.dmm
@@ -57472,8 +57472,6 @@
 /turf/simulated/floor,
 /area/hallway/primary/central)
 "cel" = (
-/obj/structure/table/reinforced,
-/obj/item/device/flash,
 /obj/item/device/radio/intercom{
 	dir = 8;
 	name = "Station Intercom (General)";
@@ -57484,6 +57482,10 @@
 	pixel_x = -25;
 	pixel_y = -10
 	},
+/obj/item/device/flash,
+/obj/item/device/flash,
+/obj/item/device/flash,
+/obj/structure/table/reinforced,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkred";
@@ -58623,10 +58625,8 @@
 /obj/structure/window/reinforced{
 	one_way = 1
 	},
-/obj/machinery/planet_scanner{
-	anchored = 1;
-	icon_state = "scanner_idle"
-	},
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/firstaid/regular,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkred";
@@ -61853,7 +61853,6 @@
 /obj/item/weapon/storage/secure/briefcase,
 /obj/item/weapon/storage/box/PDAs,
 /obj/item/weapon/storage/box/ids,
-/obj/item/weapon/storage/firstaid/regular,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},

--- a/maps/defficiency.dmm
+++ b/maps/defficiency.dmm
@@ -110151,18 +110151,6 @@
 	},
 /turf/simulated/floor/glass/plasma,
 /area/hallway/secondary/entry)
-"nil" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/planet_scanner{
-	anchored = 1;
-	icon_state = "scanner_idle"
-	},
-/turf/simulated/floor/carpet,
-/area/bridge)
 "niJ" = (
 /obj/machinery/claw_machine,
 /turf/simulated/floor{
@@ -226608,7 +226596,7 @@ cOq
 cOq
 cOq
 cOq
-nil
+cOq
 cTZ
 cUL
 cVv

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -59970,13 +59970,6 @@
 	pixel_x = 28;
 	pixel_y = 5
 	},
-/obj/machinery/planet_scanner{
-	anchored = 1;
-	icon_state = "scanner_idle"
-	},
-/obj/item/device/gps/planetary,
-/obj/item/device/gps/planetary,
-/obj/item/device/gps/planetary,
 /turf/simulated/floor{
 	icon_state = "dark vault full"
 	},

--- a/maps/lowfatbagel.dmm
+++ b/maps/lowfatbagel.dmm
@@ -24989,10 +24989,7 @@
 /turf/simulated/floor,
 /area/bridge)
 "bqn" = (
-/obj/machinery/planet_scanner{
-	anchored = 1;
-	icon_state = "scanner_idle"
-	},
+/obj/structure/flora/pottedplant/random,
 /turf/simulated/floor,
 /area/bridge)
 "bqo" = (

--- a/maps/metaclub.dmm
+++ b/maps/metaclub.dmm
@@ -35918,10 +35918,6 @@
 /turf/simulated/floor/carpet,
 /area/bridge)
 "brt" = (
-/obj/machinery/planet_scanner{
-	anchored = 1;
-	icon_state = "scanner_idle"
-	},
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "darkblue"

--- a/maps/packedstation.dmm
+++ b/maps/packedstation.dmm
@@ -1840,10 +1840,6 @@
 	pixel_x = 5;
 	pixel_y = -32
 	},
-/obj/machinery/planet_scanner{
-	anchored = 1;
-	icon_state = "scanner_idle"
-	},
 /turf/simulated/floor{
 	icon_state = "dark vault full"
 	},

--- a/maps/synergy.dmm
+++ b/maps/synergy.dmm
@@ -16955,9 +16955,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/planet_scanner{
-	anchored = 1;
-	icon_state = "scanner_idle"
+/obj/structure/flora/pottedplant/random{
+	icon_state = "plant-16"
 	},
 /turf/simulated/floor{
 	icon_state = "darkbluefull";

--- a/maps/tgstation.dmm
+++ b/maps/tgstation.dmm
@@ -32746,10 +32746,8 @@
 	},
 /area/bridge)
 "bkm" = (
-/obj/machinery/planet_scanner{
-	anchored = 1;
-	icon_state = "scanner_idle"
-	},
+/obj/structure/table,
+/obj/machinery/cell_charger,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault";

--- a/maps/waystation.dmm
+++ b/maps/waystation.dmm
@@ -30660,10 +30660,6 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
-/obj/machinery/planet_scanner{
-	anchored = 1;
-	icon_state = "scanner_idle"
-	},
 /turf/simulated/floor{
 	icon_state = "blue"
 	},

--- a/maps/wheelstation.dmm
+++ b/maps/wheelstation.dmm
@@ -104016,13 +104016,7 @@
 /turf/simulated/floor/plating,
 /area/engineering/supermatter_room)
 "uBy" = (
-/obj/machinery/planet_scanner{
-	anchored = 1;
-	icon_state = "scanner_idle"
-	},
-/obj/item/device/gps/planetary,
-/obj/item/device/gps/planetary,
-/obj/item/device/gps/planetary,
+/obj/structure/flora/pottedplant/random,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkblue"


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
See title. Scanners can still be built manually, admins can still generate planets manually, and the Exploration Shuttle was not removed.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Exploring planets is the central element of Odyssey gameplay; the entire crew comes along for the trip. Exploring planets was intended to be a deadpop activity on all station-based maps; this both clashes with the intent of Odyssey as a deadpop map and also has resulted in players treating planetary exploration as a single-player activity which detracts from round health. As an added bonus, this will decrease the amount of time spent on planets outside of Odyssey rounds which helps make the planets, their vaults, and their loot feel more fresh.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
0%

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscdel: Removed premapped Planet Scanners from all non-Odyssey maps.