### PR TITLE
Fix mob harddels

### DIFF
--- a/code/modules/sound/sound_emitter.dm
+++ b/code/modules/sound/sound_emitter.dm
@@ -25,10 +25,11 @@
 	var/last_sound_zone_hash = null
 	// proxy for when the sound needs to be sent to some other mob, e.g. aiEye mob movement needs sounds sent to AI Core mob
 	//  this is because the AI Eye client is null so we can't get to the SLC via the aiEye mob
-	var/mob/sound_endpoint = null
-/mob/New()
-	..()
-	sound_endpoint = src
+	var/datum/weakref/sound_endpoint = null
+
+/mob/proc/get_sound_endpoint()
+	var/mob/endpoint = sound_endpoint?.get()
+	return endpoint || src
 
 /proc/turf_volume_coeff(atom/a)
 	if (!a || !istype(a))
@@ -232,9 +233,10 @@
 	var/list/in_range = list()
 	var/turf/t_source = get_turf(source)
 	for (var/mob/player in player_list)
-		if (!player || !player.sound_endpoint)
+		if (!player)
 			continue // nowhere to send the sound
-		var/client/client = player.sound_endpoint.client
+		var/mob/endpoint = player.get_sound_endpoint()
+		var/client/client = endpoint?.client
 		if (!client || !client.listener_context)
 			continue // nowhere to send the sound
 		var/turf/receiver = get_turf(client.listener_context.proxy)

--- a/code/modules/sound/sound_zone_manager.dm
+++ b/code/modules/sound/sound_zone_manager.dm
@@ -109,7 +109,8 @@ var/global/datum/sound_zone_manager/sound_zone_manager = new
 		for (var/mob/listener in B)
 			var/client/client = listener.client
 			if (!client) // e.g. AI eye has no client, endpoint must be overridden
-				client = listener.sound_endpoint.client
+				var/mob/endpoint = listener.get_sound_endpoint()
+				client = endpoint?.client
 			if (!client || !client.listener_context)
 				CRASH("Found a listener with no client or endpoint client")
 			var/datum/sound_listener_context/context = client.listener_context
@@ -138,7 +139,7 @@ var/global/datum/sound_zone_manager/sound_zone_manager = new
 		listener_buckets[h] = list()
 	listener_buckets[h] |= SLC.proxy
 
-	SLC.proxy.sound_endpoint = SLC.client.mob
+	SLC.proxy.sound_endpoint = makeweakref(SLC.client.mob)
 	SLC.proxy.register_event(/event/moved, src, nameof(src::on_player_move()))
 	on_player_move(SLC.proxy)
 
@@ -179,7 +180,8 @@ var/global/datum/sound_zone_manager/sound_zone_manager = new
 /datum/sound_zone_manager/proc/on_player_move(mob/mover)
 	if (!mover)
 		return
-	if (!mover.sound_endpoint)
+	var/mob/endpoint = mover.get_sound_endpoint()
+	if (!endpoint)
 		return // nowhere to send the sound
 
 	var/turf/location = mover.loc
@@ -190,7 +192,7 @@ var/global/datum/sound_zone_manager/sound_zone_manager = new
 
 	update_listener(mover)
 
-	var/client/receive_client = mover.sound_endpoint.client
+	var/client/receive_client = endpoint.client
 	if (!receive_client || !receive_client.listener_context)
 		return
 


### PR DESCRIPTION
## What this does

8 months ago with the advent of the v2 sound system I added a `sound_endpoint` that keeps a ref to the mob to which sounds should be routed, mainly so the AI eye could hear only things happening near the core.
This was nulled for *mobs with a client* such that when the mob was qdel'd there'd be no more refs to that mob and it'd delete fine.
I totally overlooked the non-client mob case so every single mob when qdel'd would end up hard del'd instead, and somehow it took 8 months to surface (probably because we had a LOT of bees in the last few days)

The solution is to use a non-owning weakref so mobs that remember themselves don't prevent their own deaths and incur the wrath of hard del.

## Why it's good
hard del bad
weakref gooder then ref for non-owning case

## How it was tested
reproduced hard dels locally pre-fix
observed big reduction in hard-dels post-fix

## Changelog
:cl:
 * bugfix: Fixed a large number of hard dels impacting mobs without client