### PR TITLE
Lets mouse-piloted spiderbots ventcrawl.

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -52,6 +52,7 @@
 		/obj/item/device/radio/borg,
 		/obj/machinery/camera,
 		/obj/item/device/mmi,
+		/mob/living/simple_animal/mouse,
 	)
 	return allowed_items
 


### PR DESCRIPTION
## What this does
Mouse-spiderbots can now ventcrawl. 
## Why it's good
They should've from the start, but they forgot to add mice to the ventcrawl allowed items list (which does include the MMI) when making #27780, plus it makes no sense that a whole human brain in a can (way bigger than a mouse) on top of the spiderbot can, while a mouse doing the same cannot. 
:cl:
 * bugfix: Mouse-piloted Spiderbots can now ventcrawl.