### PR TITLE
Runtime fixes 20260519

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -448,7 +448,7 @@ var/area/space_area
 	for(var/mob/mob_in_obj in Obj.contents)
 		if(istype(mob_in_obj))
 			INVOKE_EVENT(mob_in_obj, /event/mob_area_changed, "mob" = mob_in_obj, "newarea" = src, "oldarea" = oldArea)
-			if(oldArea.v && src.v && (oldArea.v != src.v))
+			if(oldArea?.v && src.v && (oldArea.v != src.v))
 				var/datum/virtual_z/old_v = oldArea.v
 				var/datum/virtual_z/new_v = src.v
 				if(istype(mob_in_obj, /mob/living))

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -677,7 +677,10 @@
 			return
 	if(arcanetampered)
 		to_chat(user, "<span class='sinister'>You feel different.</span>")
-		H.Humanize(pick("Unathi","Tajaran","Insectoid","Grey",/*and worst of all*/"Vox"))
+		var/mob/living/carbon/human/new_H = H.Humanize(pick("Unathi","Tajaran","Insectoid","Grey",/*and worst of all*/"Vox")) //damn right
+		if (!new_H)
+			return
+		H = new_H
 		var/list/species_facial_hair = valid_sprite_accessories(facial_hair_styles_list, H.gender, H.species.name)
 		if(species_facial_hair.len)
 			H.my_appearance.f_style = pick(species_facial_hair)

--- a/code/modules/RCD/engie.dm
+++ b/code/modules/RCD/engie.dm
@@ -16,20 +16,20 @@
 	if(!no_schematics)
 		var/datum/rcd_scematic_grouping/destroy/dest_g = new(src)
 		dest_g.schematics+= new /datum/rcd_grouped_schematic/destroy_all(src)
-	
+
 		var/datum/rcd_scematic_grouping/build_wall/engi_std/wall_g = new(src)
 		var/datum/rcd_scematic_grouping/build_floors/engi_std/floor_g = new(src)
 		var/datum/rcd_scematic_grouping/build_windows/engi_std/window_g = new(src)
 		var/datum/rcd_scematic_grouping/build_airlock/engi_std/airlock_g=new(src)
 		var/datum/rcd_scematic_grouping/misc_objects/engi_std/misc_g=new(src)
-	
+
 		schem_groups+=dest_g
 		schem_groups+=wall_g
 		schem_groups+=floor_g
 		schem_groups+=airlock_g
 		schem_groups+=window_g
 		schem_groups+=misc_g
-	
+
 		current_menu=schem_groups[1]?.name
 		schem_groups[1]?.switch_to()
 
@@ -39,7 +39,7 @@
 		for(var/datum/rcd_scematic_grouping/schemgroup in schem_groups)
 			schemgroup.send_assets(L.client)
 			for(var/datum/rcd_grouped_schematic/sch)
-				sch.send_assets(L.client)	
+				sch.send_assets(L.client)
 
 /obj/item/device/rcd/matter/engineering/Destroy()
 	. = ..()
@@ -50,13 +50,13 @@
 		return
 
 	return ..()
-	
+
 /obj/item/device/rcd/matter/engineering/attack_self(var/mob/user)
-	rebuild_ui()	
+	rebuild_ui()
 	interface.show(user)
 	if( locate(user.client) in loaded_clients )
 		return
-		
+
 	for(var/datum/rcd_scematic_grouping/schemgroup in schem_groups)
 		schemgroup.send_assets(user.client)
 		for(var/datum/rcd_grouped_schematic/sch)
@@ -66,7 +66,7 @@
 	loaded_clients+=user.client
 
 
-/obj/item/device/rcd/matter/engineering/Topic(var/href, var/list/href_list)	
+/obj/item/device/rcd/matter/engineering/Topic(var/href, var/list/href_list)
 	if(href_list["clear_images"])
 		loaded_clients=new()
 	if(href_list["set_group"])
@@ -90,7 +90,7 @@
 					do_spark()
 					rebuild_ui()
 					break
-		return			
+		return
 	if(href_list["set_arg"])
 		if(href_list["value_togglelist"])
 			var/val =  href_list["value_isnum"]=="yes" ? text2num(href_list["value"]) : href_list["value"]
@@ -118,16 +118,16 @@
 			settings[href_list["set_arg"]] = href_list["value_isnum"]=="yes" ? text2num(href_list["value"]) : href_list["value"]
 		rebuild_ui()
 		return
-		
+
 	return
 
 /obj/item/device/rcd/matter/engineering/rebuild_ui()
 	var/dat=""
-	
+
 	dat+="Compressed Matter: [matter]/[max_matter] <span class='schem'><a href='?src=\ref[interface];clear_images=yes;'>Reload Images</a></span><hr>"
-	
+
 	//that's right, you can embed a stylesheet in the html body, and you better believe i'm going to do this instead of setting up a whole new file for like 2 rules.
-	dat+={"<style> 
+	dat+={"<style>
 	.grouplisting{
 	text-align:center;
 	font-size:100%;
@@ -136,46 +136,46 @@
 	width:64px;
 	height:64px;
 	}
-	
+
 	.grouplisting a{
 	width:100%;
 	height:100%;
 	display:block;
 	background:revert;
 	}
-	
+
 	.clickabletable td{
 		text-align:center;
 		height:100%; /*to make it so that links inhabit the whole size of the td. kinda annoying to have to do all this.*/
 	}
-	
+
 	.clickabletable a{
 		width:100%;
 		height:100%;
 		display:block;
 	}
-	
+
 	img, .clickabletable img, .grouplisting img {
 		border:none;
 		background:none;
 		image-rendering:pixelated;
 	}
-	
+
 	</style>"}
-	
+
 	dat+="<table class='grouplisting'><tr>"
 	for(var/datum/rcd_scematic_grouping/schem_group in schem_groups)
 		dat+="<td class='[schem_group.name==current_menu ? "schem_selected" : "schem" ]'><a href='?src=\ref[interface];set_group=[schem_group.name]'><img src='[schem_group.headerimage]'><br>[schem_group.name]</a></td>"
 	dat+="</tr></table><hr>"
-	
-	
+
+
 	for(var/datum/rcd_scematic_grouping/schem_group in schem_groups)
 		if(schem_group.name==current_menu)
 			var/t=schem_group.generate_html()
 			dat+=t
 			break
-			
-	
+
+
 	interface.updateLayout(dat)
 
 /obj/item/device/rcd/matter/engineering/afterattack(var/atom/A, var/mob/user)
@@ -186,14 +186,17 @@
 	if(get_dist(A, user) > 1)
 		return 1
 
-	var/c=selected_schem.build(A,user)
-	if(!c)
-		to_chat(user, "<span class='warning'>\The [src]'s error light flickers.</span>")
+	var/c = selected_schem.build(A,user)
+	if(!c || istext(c))
+		if (istext(c))
+			to_chat(user, "<span class='warning'>\The [src]'s error light flickers: [c]</span>")
+		else
+			to_chat(user, "<span class='warning'>\The [src]'s error light flickers.</span>")
 	else
 		use_energy(c, user)
 		rebuild_ui()
 	return 1
-	
+
 
 /obj/item/device/rcd/matter/engineering/suicide_act(var/mob/living/user)
 	visible_message("<span class='danger'>[user] is using the deconstruct function on \the [src] on \himself! It looks like \he's trying to commit suicide!</span>")
@@ -218,7 +221,7 @@
 	/datum/rcd_schematic/con_window/borg,
 	)
 	var/matter=0
-	
+
 	current_menu="deconstruct"
 
 /obj/item/device/rcd/borg/engineering/New()
@@ -233,7 +236,7 @@
 	schem_groups+=new /datum/rcd_scematic_grouping/build_floors/engi_std(src)
 	schem_groups+=new /datum/rcd_scematic_grouping/build_airlock/engi_std(src)
 	schem_groups+=new /datum/rcd_scematic_grouping/build_windows/engi_std(src)
-	
+
 	current_menu=schem_groups[1]?.name
 	schem_groups[1]?.switch_to()
 
@@ -244,17 +247,17 @@
 			schemgroup.send_assets(L.client)
 			for(var/datum/rcd_grouped_schematic/sch)
 				sch.send_assets(L.client)
-	
+
 /obj/item/device/rcd/borg/engineering/attack_self(var/mob/user)
 	if(!isrobot(user))
 		return
 	matter = get_energy(user)
 
-	rebuild_ui()	
+	rebuild_ui()
 	interface.show(user)
 	if( locate(user.client) in loaded_clients )
 		return
-		
+
 	for(var/datum/rcd_scematic_grouping/schemgroup in schem_groups)
 		schemgroup.send_assets(user.client)
 		for(var/datum/rcd_grouped_schematic/sch)
@@ -288,7 +291,7 @@
 					do_spark()
 					rebuild_ui()
 					break
-		return			
+		return
 	if(href_list["set_arg"])
 		if(href_list["value_togglelist"])
 			var/val =  href_list["value_isnum"]=="yes" ? text2num(href_list["value"]) : href_list["value"]
@@ -316,16 +319,16 @@
 			settings[href_list["set_arg"]] = href_list["value_isnum"]=="yes" ? text2num(href_list["value"]) : href_list["value"]
 		rebuild_ui()
 		return
-		
+
 	return
 
 /obj/item/device/rcd/borg/engineering/rebuild_ui()
 	var/dat=""
-	
+
 	dat+="Charge: [floor(matter)] <span class='schem'><a href='?src=\ref[interface];clear_images=yes;'>Reload Images</a></span><hr>"
-	
+
 	//that's right, you can embed a stylesheet in the html body, and you better believe i'm going to do this instead of setting up a whole new file for like 2 rules.
-	dat+={"<style> 
+	dat+={"<style>
 	.grouplisting{
 	text-align:center;
 	font-size:100%;
@@ -334,46 +337,46 @@
 	width:64px;
 	height:64px;
 	}
-	
+
 	.grouplisting a{
 	width:100%;
 	height:100%;
 	display:block;
 	background:revert;
 	}
-	
+
 	.clickabletable td{
 		text-align:center;
 		height:100%; /*to make it so that links inhabit the whole size of the td. kinda annoying to have to do all this.*/
 	}
-	
+
 	.clickabletable a{
 		width:100%;
 		height:100%;
 		display:block;
 	}
-	
+
 	img, .clickabletable img, .grouplisting img {
 		border:none;
 		background:none;
 		image-rendering:pixelated;
 	}
-	
+
 	</style>"}
-	
+
 	dat+="<table class='grouplisting'><tr>"
 	for(var/datum/rcd_scematic_grouping/schem_group in schem_groups)
 		dat+="<td class='[schem_group.name==current_menu ? "schem_selected" : "schem" ]'><a href='?src=\ref[interface];set_group=[schem_group.name]'><img src='[schem_group.headerimage]'><br>[schem_group.name]</a></td>"
 	dat+="</tr></table><hr>"
-	
-	
+
+
 	for(var/datum/rcd_scematic_grouping/schem_group in schem_groups)
 		if(schem_group.name==current_menu)
 			var/t=schem_group.generate_html()
 			dat+=t
 			break
-			
-	
+
+
 	interface.updateLayout(dat)
 
 /obj/item/device/rcd/borg/engineering/afterattack(var/atom/A, var/mob/user)
@@ -393,11 +396,11 @@
 		to_chat(user, "<span class='warning'>\The [src]'s error light flickers.</span>")
 	else
 		use_energy(c, user)
-		
+
 		matter = get_energy(user)
-		
+
 		rebuild_ui()
-	return 1	
+	return 1
 
 /obj/item/device/rcd/matter/engineering/pre_loaded/adv
 	name = "advanced Rapid-Construction-Device (RCD)"
@@ -421,7 +424,7 @@
 
 /obj/item/device/rcd/matter/engineering/pre_loaded/adv/New(var/loc=null,var/no_schematics=FALSE)
 	..(loc,TRUE)
-	
+
 	if(!no_schematics)
 		var/datum/rcd_scematic_grouping/destroy/dest_g = new(src)
 		dest_g.schematics+= new /datum/rcd_grouped_schematic/destroy_all(src)
@@ -432,11 +435,11 @@
 		schem_groups+=new /datum/rcd_scematic_grouping/build_airlock/engi_std/CE(src)
 		schem_groups+=new /datum/rcd_scematic_grouping/build_windows/engi_std(src)
 		schem_groups+=new /datum/rcd_scematic_grouping/misc_objects/engi_std/CE(src)
-	
+
 		current_menu=schem_groups[1].name
 		schem_groups[1].switch_to()
 
-	
+
 /obj/item/device/rcd/matter/engineering/pre_loaded/adv/slime_act(primarytype, mob/user)
 	. = ..()
 	if(. && (slimes_accepted & primarytype))
@@ -444,20 +447,20 @@
 		if(!schematics[P.category])
 			schematics[P.category] = list()
 		schematics[P.category] += P
-		
+
 		for(var/datum/rcd_scematic_grouping/schem_group in schem_groups)
 			if(istype(schem_group,/datum/rcd_scematic_grouping/build_windows) )
 				schem_group.schematics+=new /datum/rcd_grouped_schematic/glass/plasma(src)
-				schem_group.schematics+=new /datum/rcd_grouped_schematic/glass/rplas(src)	
+				schem_group.schematics+=new /datum/rcd_grouped_schematic/glass/rplas(src)
 			if(istype(schem_group,/datum/rcd_scematic_grouping/build_airlock) )
 				schem_group.schematics+= new /datum/rcd_grouped_schematic/airlock/tabledoor/reinforced(src)
 			if(istype(schem_group,/datum/rcd_scematic_grouping/build_floors) )
 				schem_group.schematics+= new/datum/rcd_grouped_schematic/plasmaglassfloor(src)
 			if(istype(schem_group,/datum/rcd_scematic_grouping/misc_objects) )
-				schem_group.schematics+= new/datum/rcd_grouped_schematic/table/pglass(src)	
+				schem_group.schematics+= new/datum/rcd_grouped_schematic/table/pglass(src)
 		loaded_clients=list() //refresh images since we are adding more to show.
 		rebuild_ui()
-			
+
 
 /obj/item/device/rcd/matter/engineering/pre_loaded/adv/delay(var/mob/user, var/atom/target, var/amount)
 	return do_after(user, target, amount/2)
@@ -494,7 +497,7 @@
 
 /obj/item/device/rcd/matter/engineering/mech/use_energy(var/amount, var/mob/user)
 	return	//mech charge is used up elsewhere
-	
+
 /obj/item/device/rcd/matter/engineering/mech/get_energy(var/mob/user)
 	return INFINITY
-	
+

--- a/code/modules/lighting/lighting_overlay.dm
+++ b/code/modules/lighting/lighting_overlay.dm
@@ -52,7 +52,7 @@
 		qdel(src)
 		return
 
-	if (!T.lighting_corners_initialised)//may happen due to nano paint
+	if (!T.lighting_corners_initialised || !T.corners)//may happen due to nano paint
 		T.generate_missing_corners()
 
 	// To the future coder who sees this and thinks

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -29,7 +29,7 @@
 	var/area/A = loc
 	if (!A.dynamic_lighting)
 		return
-	if (!lighting_corners_initialised)
+	if (!lighting_corners_initialised || !corners)
 		generate_missing_corners()
 
 	new /atom/movable/lighting_overlay(src)

--- a/code/modules/mob/living/Astar_test.dm
+++ b/code/modules/mob/living/Astar_test.dm
@@ -7,10 +7,13 @@
 
 /mob/living/clickbot/ClickOn(var/atom/A, var/params)
 	path = get_path_to(src, A)
+	if (!length(path))
+		playsound(loc, 'sound/machines/buzz-sigh.ogg', 50, 0)
+		return
 	pathers += src
 
 /mob/living/clickbot/process_astar_path()
-	if(gcDestroyed || stat == DEAD)
+	if(gcDestroyed || stat == DEAD || !length(path))
 		return FALSE
 	step_to(src, path[1])
 	if(get_turf(src) != path[1])

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -73,8 +73,12 @@
 			if(92 to INFINITY)
 				filling.icon_state = "[icon_state]30"
 
-		filling.icon += mix_color_from_reagents(reagents.reagent_list)
-		filling.alpha = mix_alpha_from_reagents(reagents.reagent_list)
+		var/mixed = mix_color_from_reagents(reagents.reagent_list)
+		if (mixed)
+			filling.icon += mixed
+		var/mixed_alpha = mix_alpha_from_reagents(reagents.reagent_list)
+		if (mixed_alpha)
+			filling.alpha = mixed_alpha
 		overlays += filling
 
 	if(!is_open_container())


### PR DESCRIPTION
## What this does

Fixes runtimes that look like these:


- just missing a null check, neighbouring code has it
```
[17:22:46] Runtime in code/game/area/areas.dm,451: Cannot read null.v
  proc name: Entered (/area/Entered)
  usr: That One Annyoing Wizard (as Captain) (astraorigins) (/mob/living/carbon/human)
  usr.loc: The floor (285, 242, 1) (/turf/simulated/floor)
  src: the Starboard Primary Hallway (/area/hallway/primary/starboard)
  call stack:
  the Starboard Primary Hallway (/area/hallway/primary/starboard): Entered(That One Annyoing Wizard (as C... (/mob/living/carbon/human), null)
  That One Annyoing Wizard (as C... (/mob/living/carbon/human): forceEnter(the floor (285,242,1) (/turf/simulated/floor))
  Astraorigins (/client): Process Incorpmove(1)
  Astraorigins (/client): Move(the floor (285,241,1) (/turf/simulated/floor), 1, 0, 0, 0)
  Astraorigins (/client): move loop()
  Astraorigins (/client): MoveKey(1, 1)
```

- colour mixing thingy can return null, which is what happened, and byond didnt like it so it just needed a null check
```
[18:04:24] Runtime in code/modules/reagents/reagent_containers/glass/bottle.dm,76: bad icon operation
  proc name: update icon (/obj/item/weapon/reagent_containers/glass/bottle/update_icon)
  src: the unknown culture bottle (/obj/item/weapon/reagent_containers/glass/bottle/random)
  src.loc: Ian Spatz (/mob/living/carbon/human)
  call stack:
  the unknown culture bottle (/obj/item/weapon/reagent_containers/glass/bottle/random): update icon()
  the unknown culture bottle (/obj/item/weapon/reagent_containers/glass/bottle/random): thermal entropy()
  Thermal Entropy (/datum/subsystem/thermal_entropy): fire(0)
  Thermal Entropy (/datum/subsystem/thermal_entropy): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
```

- oversight in engineering RCD code where the error string was interpreted as a cost, just needs `istext` checking
```
[18:29:52] Runtime in code/modules/RCD/RCD.dm,349: type mismatch: 74 -= "it cannot deconstruct reinforc..."
  proc name: use energy (/obj/item/device/rcd/matter/use_energy)
  usr: Derrick Zoberman (realestestate) (/mob/living/carbon/human)
  usr.loc: The plating (285, 342, 5) (/turf/simulated/floor/plating/airless)
  src: the advanced Rapid-Constructio... (/obj/item/device/rcd/matter/engineering/pre_loaded/adv)
  src.loc: Derrick Zoberman (/mob/living/carbon/human)
  call stack:
  the advanced Rapid-Constructio... (/obj/item/device/rcd/matter/engineering/pre_loaded/adv): use energy("it cannot deconstruct reinforc...", Derrick Zoberman (/mob/living/carbon/human))
  the advanced Rapid-Constructio... (/obj/item/device/rcd/matter/engineering/pre_loaded/adv): afterattack(the reinforced wall (285,341,5) (/turf/simulated/wall/r_wall), Derrick Zoberman (/mob/living/carbon/human), 1, "icon-x=24;icon-y=21;left=1;but...")
  Derrick Zoberman (/mob/living/carbon/human): ClickOn(the reinforced wall (285,341,5) (/turf/simulated/wall/r_wall), "icon-x=24;icon-y=21;left=1;but...")
  the reinforced wall (285,341,5) (/turf/simulated/wall/r_wall): Click(the reinforced wall (285,341,5) (/turf/simulated/wall/r_wall), "mapwindow.map", "icon-x=24;icon-y=21;left=1;but...")
```

- old `H` kept being used after being killed by `Humanize` (also the actual returned value was ignored lol)
```
[19:15:27] Runtime in code/game/objects/items/weapons/cosmetics.dm,681: Cannot read null.name
  proc name: handle hair (/obj/item/weapon/pocket_mirror/proc/handle_hair)
  usr: Luxalg () (/mob/living/carbon/human)
  usr.loc: (nullspace)
  src:  strange pocket mirror (/obj/item/weapon/pocket_mirror/arcane)
  src.loc: the floor (317,254,1) (/turf/simulated/floor/shuttle)
  call stack:
   strange pocket mirror (/obj/item/weapon/pocket_mirror/arcane): handle hair(Luxalg (/mob/living/carbon/human), Luxalg (/mob/living/carbon/human))
   strange pocket mirror (/obj/item/weapon/pocket_mirror/arcane): attack self(Luxalg (/mob/living/carbon/human))
  Luxalg (/mob/living/carbon/human): Activate Held Object()
  Kernikov (/client): attack self()
  Kernikov (/client): treat hotkeys(6)
  Kernikov (/client): Southeast()
```

- zero path length made it upset
```
[21:48:16] Runtime in code/modules/mob/living/Astar_test.dm,15: list index out of bounds
  proc name: process astar path (/mob/living/clickbot/process_astar_path)
  src: the pathfinder (/mob/living/clickbot)
  src.loc: the floor (239,271,1) (/turf/simulated/floor)
  call stack:
  the pathfinder (/mob/living/clickbot): process astar path()
  Pathing (/datum/subsystem/pathing): fire(0)
  Pathing (/datum/subsystem/pathing): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
```

- pretty sure this happens from `ChangeTurf` fucking up the cached corners and not regenerating them properly
```
[00:03:21] Runtime in code/modules/lighting/lighting_overlay.dm,68: cannot read from list
  proc name: update overlay (/atom/movable/lighting_overlay/proc/update_overlay)
  src:  (/atom/movable/lighting_overlay)
  src.loc: the plating (165,260,3) (/turf/simulated/floor/plating/airless)
  call stack:
   (/atom/movable/lighting_overlay): update overlay()
   (/atom/movable/lighting_overlay): New(the plating (165,260,3) (/turf/simulated/floor/plating/airless), 0)
  the plating (165,260,3) (/turf/simulated/floor/plating/airless): lighting build overlay()
  the plating (165,260,3) (/turf/simulated/floor/plating/airless): ChangeTurf(/turf/space/asteroids/plating (/turf/space/asteroids/plating), 1, 1, 1, 0)
  the plating (165,260,3) (/turf/simulated/floor/plating/airless): ChangeTurf(/turf/space/asteroids/plating (/turf/space/asteroids/plating), 1, 0, 1, 0)
  /dmm_suite (/dmm_suite): instance atom(/turf/space/asteroids/plating (/turf/space/asteroids/plating), /list (/list), 165, 260, 3, 90, 1)
  /dmm_suite (/dmm_suite): parse grid("/turf/space/asteroids/plating,...", 165, 260, 3, 90, 1)
  /dmm_suite (/dmm_suite): load map(maps/randomvaults/asteroids_ra..., 3, 157, 241, Asteroids Random (/datum/map_element/vault/asteroids_random), 90, 1, 1, 25, 1, 25, 1, inf)
  Asteroids Random (/datum/map_element/vault/asteroids_random): load(157, 241, 3, 90, 1, 0, 0, inf, 0, inf, 0, inf)
  Mapping (/datum/subsystem/mapping): generate scanner encounter(NTEV Odyssey (/datum/shuttle/odyssey))
  the shuttle deep space scanner (/obj/machinery/planet_scanner/shuttle): spawn new encounter()
  the shuttle deep space scanner (/obj/machinery/planet_scanner/shuttle): complete scan()
  the shuttle deep space scanner (/obj/machinery/planet_scanner/shuttle): process scanning()
  the shuttle deep space scanner (/obj/machinery/planet_scanner/shuttle): process()
  the shuttle deep space scanner (/obj/machinery/planet_scanner/shuttle): process()
  Machinery (/datum/subsystem/machinery): fire(0)
  Machinery (/datum/subsystem/machinery): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
```


## Why it's good
runtimes bad

## How it was tested
just building, no functional test done

## Changelog
:cl:
 * bugfix: Engineering RCD should fail properly now when it does
 * bugfix: Fixed lighting breaking in rare circumstances
 * bugfix: Arcane tampered pocket mirror shouldn't misbehave as much
and also removes a metric fuckton of whitespace lol