### PR TITLE
hard del fixes 20260519

### DIFF
--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -148,7 +148,7 @@
 	using.alpha = ui_alpha
 	src.adding += using
 
-	inv_box.pointer_to_list = &src.adding
+	using.pointer_to_list = &src.adding
 
 	using = new /obj/abstract/screen/inventory
 	using.name = "hand"
@@ -161,7 +161,7 @@
 	using.alpha = ui_alpha
 	src.adding += using
 
-	inv_box.pointer_to_list = &src.adding
+	using.pointer_to_list = &src.adding
 
 	inv_box = new /obj/abstract/screen/inventory
 	inv_box.name = "id"
@@ -189,7 +189,7 @@
 	inv_box.alpha = ui_alpha
 	src.other += inv_box
 
-	inv_box.pointer_to_list = &src.adding
+	inv_box.pointer_to_list = &src.other
 
 	inv_box = new /obj/abstract/screen/inventory
 	inv_box.name = "back"
@@ -255,7 +255,7 @@
 	using.alpha = ui_alpha
 	src.hotkeybuttons += using
 
-	inv_box.pointer_to_list = &src.hotkeybuttons
+	using.pointer_to_list = &src.hotkeybuttons
 
 	using = new /obj/abstract/screen
 	using.name = "toggle"
@@ -266,7 +266,7 @@
 	using.alpha = ui_alpha
 	src.adding += using
 
-	inv_box.pointer_to_list = &src.adding
+	using.pointer_to_list = &src.adding
 
 	using = new /obj/abstract/screen
 	using.name = "equip"
@@ -277,7 +277,7 @@
 	using.alpha = ui_alpha
 	src.adding += using
 
-	inv_box.pointer_to_list = &src.adding
+	using.pointer_to_list = &src.adding
 
 	inv_box = new /obj/abstract/screen/inventory
 	inv_box.name = "gloves"
@@ -366,7 +366,7 @@
 	mymob.throw_icon.alpha = ui_alpha
 	src.hotkeybuttons += mymob.throw_icon
 
-	mymob.throw_icon.pointer_to_list = &src.adding
+	mymob.throw_icon.pointer_to_list = &src.hotkeybuttons
 	mymob.throw_icon.pointer_to_var = &mymob.throw_icon
 
 	mymob.kick_icon = new /obj/abstract/screen
@@ -391,7 +391,7 @@
 	src.hotkeybuttons += mymob.bite_icon
 
 	mymob.bite_icon.pointer_to_list = &src.hotkeybuttons
-	mymob.bite_icon.pointer_to_var = &mymob.kick_icon
+	mymob.bite_icon.pointer_to_var = &mymob.bite_icon
 
 	mymob.internals = new /obj/abstract/screen
 	mymob.internals.icon = 'icons/mob/screen1.dmi'
@@ -420,8 +420,8 @@
 	mymob.pullin.screen_loc = ui_pull_resist
 	src.hotkeybuttons += mymob.pullin
 
-	mymob.bite_icon.pointer_to_list = &src.hotkeybuttons
-	mymob.healths.pointer_to_var = &mymob.pullin
+	mymob.pullin.pointer_to_list = &src.hotkeybuttons
+	mymob.pullin.pointer_to_var = &mymob.pullin
 
 	mymob.zone_sel = new /obj/abstract/screen/zone_sel
 	mymob.zone_sel.icon = ui_style
@@ -432,7 +432,7 @@
 
 	//Handle the gun settings buttons
 	mymob.gun_setting_icon = new /obj/abstract/screen/gun/mode
-	mymob.healths.pointer_to_var = &mymob.gun_setting_icon
+	mymob.gun_setting_icon.pointer_to_var = &mymob.gun_setting_icon
 
 	if (mymob.client)
 		if (mymob.client.gun_mode) // If in aim mode, correct the sprite

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -382,6 +382,10 @@ var/list/map_dimension_cache = list()
 	//finally instance all remainings objects/mobs
 	for(index=1,index < first_turf_index,index++)
 		var/atom/new_atom = instance_atom(members[index],members_attributes[index],xcrd,ycrd,zcrd,rotate,overwrite)
+		// dont keep refs to things that qdel themselves in New() (like /obj/effect/decal/warning_stripes or whatever paint decals or something)
+		// prevent hdel
+		if(new_atom && new_atom.gcDestroyed)
+			continue
 		spawned_atoms.Add(new_atom)
 
 	if(!spawned_atoms.len)

--- a/code/modules/lighting/light_mob.dm
+++ b/code/modules/lighting/light_mob.dm
@@ -22,6 +22,12 @@
 	lighting_planemaster = new(client)
 	self_vision = new(client)
 
+	// ensure these are properly cleaned up when client.reset_screen or something runs
+	// lest the old mob keep a ref to them for ever (until inevitable hdel)
+	dark_plane.pointer_to_var = &dark_plane
+	lighting_planemaster.pointer_to_var = &lighting_planemaster
+	self_vision.pointer_to_var = &self_vision
+
 	update_darkness()
 	register_event(/event/before_move, src, /mob/proc/check_dark_vision)
 


### PR DESCRIPTION
## What this does

Fix some hdels
these happen when something qdels but isn't properly cleaned up beforehand

- There are some screen hdels caused by bad pointers that dont clean up properly (maybe from copypasted code by the looks of it)
- some mapping thingys like an object that solely exists to drop a decal but qdels itself but then is also stored in the `spawned_atoms` list which retains a ref, which means it gets hdel'd
- some lighting planes that an old mob retains refs to when a client switches mobs

## Why it's good
hdels bad

## How it was tested

- start box, check hdels (mapping thingys)
- spawned a pulse demon for shits and giggles, ghosted and then assigned myself to it, ran around, ghosted, checked hdels (the other two)

pre-fix there were hdels
post-fix there were not (the above ones anyway)

## Changelog
no user-facing change beyond very slight performance improvement maybe sometimes