### PR TITLE
Shuttle Loader

### DIFF
--- a/code/controllers/subsystem/init/finishing.dm
+++ b/code/controllers/subsystem/init/finishing.dm
@@ -14,6 +14,8 @@ var/datum/subsystem/finish/SSfinish
 /datum/subsystem/finish/Initialize(timeofday)
 	setup_shuttles()
 
+	setup_loaded_shuttle_transits()
+
 	stat_collection.artifacts_discovered = 0 // Because artifacts during generation get counted otherwise!
 
 	..()

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -183,10 +183,22 @@ var/skip_turf_init = FALSE //NEVER change this var for anything other than incre
 
 	//load all roundstart dungeons
 	for(var/T in map.load_map_elements)
+		// Skip elements already loaded synchronously in world/New() via map.early_load_map_elements.
+		var/element_type
+		if(ispath(T))
+			element_type = T
+		else if(istype(T, /datum/map_element))
+			var/datum/map_element/ME = T
+			element_type = ME.type
+		if(element_type && (element_type in map.early_loaded_map_element_types))
+			continue
 		load_dungeon(T, 0, TRUE)
 
 	for(var/T in map.load_custom_fixedvaults)
 		load_dungeon(T, 0, FALSE, FALSE)
+
+	if(map.load_shuttles && map.load_shuttles.len)
+		load_map_shuttles()
 
 	watch = start_watch()
 	for(var/datum/virtual_z/vz in map.getAllVLevels())

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -197,7 +197,7 @@ var/skip_turf_init = FALSE //NEVER change this var for anything other than incre
 	for(var/T in map.load_custom_fixedvaults)
 		load_dungeon(T, 0, FALSE, FALSE)
 
-	if(map.load_shuttles && map.load_shuttles.len)
+	if(map?.load_shuttles?.len)
 		load_map_shuttles()
 
 	watch = start_watch()

--- a/code/datums/shuttle.dm
+++ b/code/datums/shuttle.dm
@@ -104,16 +104,14 @@
 	// loaded dynamically by a gamemode/event). Holds a typepath, not an instance.
 	var/starting_area_path
 
-	// Set by /proc/load_map_shuttles when this shuttle is loaded via a
-	// /datum/map_element/shuttle. Points at the parking destination port the
-	// loader created in the shuttle's parking vlevel.
+	// Set by /proc/load_map_shuttles when this shuttle is loaded via a /datum/map_element/shuttle.
+	// Points at the parking destination port the loader created in the shuttle's parking vlevel.
 	var/obj/docking_port/destination/parking_port
 
 /datum/shuttle/New(var/area/starting_area)
 	.=..()
 
-	// Register every shuttle datum by type so the shuttle loader can resolve us
-	// even if our area doesn't exist yet (and we therefore aren't in `shuttles`).
+	// Register every shuttle datum by type so the shuttle loader can resolve us even if our area doesn't exist yet (and we therefore aren't in the global shuttles list).
 	shuttle_datums_by_path[type] = src
 
 	if(starting_area)
@@ -150,14 +148,11 @@
 		if(!linked_area && linked_areas.len)
 			linked_area = linked_areas[1]
 
-// Called by the shuttle loader after a shuttle DMM has been loaded into a parking
-// vlevel. Folds the loaded areas into linked_areas and picks a linked_area.
+// Called by the shuttle loader after a shuttle DMM has been loaded into a parking vlevel and adds the loaded areas into linked_areas.
 /datum/shuttle/proc/attach_loaded_areas(list/areas)
 	for(var/area/A in areas)
 		linked_areas |= A
 
-	// If we have a starting_area_path, also fold in any newly-instantiated subtypes
-	// that didn't exist when New() ran.
 	if(starting_area_path)
 		for(var/area/A in world)
 			if(istype(A, starting_area_path))
@@ -175,9 +170,8 @@
 	if(istype(linked_area))
 		shuttles |= src
 
-// Hook called by setup_loaded_shuttle_transits() after the loader has wired up
-// the shuttle's transit dock. Override per-shuttle for post-setup behaviour
-// (announcements, dock binding, transit area decoration, etc.).
+// Hook called by setup_loaded_shuttle_transits() after the loader has wired up the shuttle's transit dock.
+// Override per-shuttle for post-setup behaviour (announcements, dock binding, transit area decoration, etc.).
 /datum/shuttle/proc/post_setup()
 	return
 

--- a/code/datums/shuttle.dm
+++ b/code/datums/shuttle.dm
@@ -104,8 +104,17 @@
 	// loaded dynamically by a gamemode/event). Holds a typepath, not an instance.
 	var/starting_area_path
 
+	// Set by /proc/load_map_shuttles when this shuttle is loaded via a
+	// /datum/map_element/shuttle. Points at the parking destination port the
+	// loader created in the shuttle's parking vlevel.
+	var/obj/docking_port/destination/parking_port
+
 /datum/shuttle/New(var/area/starting_area)
 	.=..()
+
+	// Register every shuttle datum by type so the shuttle loader can resolve us
+	// even if our area doesn't exist yet (and we therefore aren't in `shuttles`).
+	shuttle_datums_by_path[type] = src
 
 	if(starting_area)
 		if(ispath(starting_area))
@@ -140,6 +149,37 @@
 				break
 		if(!linked_area && linked_areas.len)
 			linked_area = linked_areas[1]
+
+// Called by the shuttle loader after a shuttle DMM has been loaded into a parking
+// vlevel. Folds the loaded areas into linked_areas and picks a linked_area.
+/datum/shuttle/proc/attach_loaded_areas(list/areas)
+	for(var/area/A in areas)
+		linked_areas |= A
+
+	// If we have a starting_area_path, also fold in any newly-instantiated subtypes
+	// that didn't exist when New() ran.
+	if(starting_area_path)
+		for(var/area/A in world)
+			if(istype(A, starting_area_path))
+				linked_areas |= A
+
+	if(!linked_area?.contents.len)
+		linked_area = null
+	for(var/area/A in linked_areas)
+		if(A.contents.len)
+			linked_area = A
+			break
+	if(!linked_area && linked_areas.len)
+		linked_area = linked_areas[1]
+
+	if(istype(linked_area))
+		shuttles |= src
+
+// Hook called by setup_loaded_shuttle_transits() after the loader has wired up
+// the shuttle's transit dock. Override per-shuttle for post-setup behaviour
+// (announcements, dock binding, transit area decoration, etc.).
+/datum/shuttle/proc/post_setup()
+	return
 
 // Returns the combined contents of all linked areas
 /datum/shuttle/proc/shuttle_contents()

--- a/code/modules/randomMaps/shuttle_loader.dm
+++ b/code/modules/randomMaps/shuttle_loader.dm
@@ -1,22 +1,20 @@
-// Shuttle loading via map element. Used by maps that declare load_shuttles.
-//
-// Each entry in /datum/map/load_shuttles is a /datum/map_element/shuttle subtype.
-// At map init time (after fixedvaults), each one loads its DMM into a fresh
-// VZ_PARKING vlevel, places a parking destination port at the shuttle's docking
-// turf, and back-fills the global shuttle datum so setup_shuttles() picks it
-// up like any other shuttle.
+/* Shuttle loading via map element. Used by maps that declare load_shuttles.
+
+Each entry in /datum/map/load_shuttles is a /datum/map_element/shuttle subtype.
+At map init time (after fixedvaults), each one loads its DMM into a fresh VZ_PARKING vlevel,
+places a parking destination port at the shuttle's docking turf,
+and back-fills the global shuttle datum so setup_shuttles() picks it up like any other shuttle.
+
+*/
 
 // Registry of /datum/shuttle datums by type, populated in /datum/shuttle/New.
-// Lets the shuttle loader resolve a shuttle datum even if its area doesn't
-// exist yet (and so it isn't in the global shuttles list).
+// Lets the shuttle loader resolve a shuttle datum even if its area doesn't exist yet (and so it isn't in the global shuttles list).
 var/global/list/shuttle_datums_by_path = list()
 
 // Loaded shuttle map elements, in load order.
 var/global/list/datum/map_element/shuttle/loaded_shuttle_map_elements = list()
 
-//
 // Map element that loads a shuttle DMM into its own VZ_PARKING vlevel.
-//
 /datum/map_element/shuttle
 	name = "shuttle"
 	vz_type = VZ_PARKING
@@ -28,8 +26,7 @@ var/global/list/datum/map_element/shuttle/loaded_shuttle_map_elements = list()
 	// Buffer of empty space turfs around the shuttle inside its parking vlevel.
 	var/parking_buffer = 7
 
-	// If non-zero, the parking vlevel will be exactly this wide/tall instead of
-	// being sized dynamically from the shuttle dimensions + parking_buffer.
+	// If non-zero, the parking vlevel will be exactly this wide/tall instead of being sized dynamically from the shuttle dimensions + parking_buffer.
 	var/parking_width = 0
 	var/parking_height = 0
 
@@ -59,8 +56,7 @@ var/global/list/datum/map_element/shuttle/loaded_shuttle_map_elements = list()
 
 	S.attach_loaded_areas(loaded_areas)
 
-	// Place the parking destination port at the shuttle's docking turf so the
-	// shuttle auto-docks here when initialize() runs in setup_shuttles().
+	// Place the parking destination port at the shuttle's docking turf so the shuttle auto-docks here when initialize() runs in setup_shuttles().
 	var/obj/docking_port/shuttle/shuttle_port = null
 	for(var/area/A in S.linked_areas)
 		for(var/obj/docking_port/shuttle/P in A.contents)
@@ -83,8 +79,7 @@ var/global/list/datum/map_element/shuttle/loaded_shuttle_map_elements = list()
 	parking.areaname = "[S.name] parking"
 	S.parking_port = parking
 
-// Loads each /datum/map_element/shuttle entry in map.load_shuttles into its
-// own parking vlevel. Called by SSmapping after fixedvaults.
+// Loads each /datum/map_element/shuttle entry in map.load_shuttles into its own parking vlevel.
 /proc/load_map_shuttles()
 	for(var/T in map.load_shuttles)
 		var/datum/map_element/shuttle/ME
@@ -97,30 +92,22 @@ var/global/list/datum/map_element/shuttle/loaded_shuttle_map_elements = list()
 			continue
 
 		ME.assign_dimensions()
-		// Pad each side of the loaded shuttle with parking_buffer turfs. Use
-		// addVLevel rather than addMapElementVLevel so the vlevel defaults
-		// (movement allowed, teleport allowed, etc.) match a regular parking
-		// area instead of a protected dungeon.
+		// Add an empty space buffer
 		var/vlevel_w = ME.parking_width ? ME.parking_width : ME.width + ME.parking_buffer * 2
 		var/vlevel_h = ME.parking_height ? ME.parking_height : ME.height + ME.parking_buffer * 2
 		var/datum/virtual_z/parking_vz = map.addVLevel(vlevel_w, vlevel_h)
 		parking_vz.level_type = ME.vz_type
 		parking_vz.name = "[ME.name] parking"
-		// Centre the shuttle within its parking vlevel so visiting shuttles
-		// have room to dock on every side. With no explicit parking_width/_height
-		// this still produces parking_buffer turfs of margin on each side.
+		// Center the shuttle
 		var/x_offset = round((vlevel_w - ME.width) / 2)
 		var/y_offset = round((vlevel_h - ME.height) / 2)
 		ME.load(parking_vz.x_min - 1 + x_offset, parking_vz.y_min - 1 + y_offset, parking_vz.parent_z.z, ME.rotation)
 
-		// Tie the parking vlevel to the shuttle datum once we know which one
-		// ended up linked to the loaded areas.
 		var/datum/shuttle/S = shuttle_datums_by_path[ME.shuttle_datum_path]
 		if(S)
 			parking_vz.linked_shuttle = S
 
-// After setup_shuttles() has run, give each loaded shuttle a transit vlevel
-// (if it doesn't have one yet) and fire its post_setup() hook.
+// After setup_shuttles() has run, give each loaded shuttle a transit vlevel (if it doesn't have one yet) and fire its post_setup() hook.
 /proc/setup_loaded_shuttle_transits()
 	if(!loaded_shuttle_map_elements.len)
 		return

--- a/code/modules/randomMaps/shuttle_loader.dm
+++ b/code/modules/randomMaps/shuttle_loader.dm
@@ -1,0 +1,137 @@
+// Shuttle loading via map element. Used by maps that declare load_shuttles.
+//
+// Each entry in /datum/map/load_shuttles is a /datum/map_element/shuttle subtype.
+// At map init time (after fixedvaults), each one loads its DMM into a fresh
+// VZ_PARKING vlevel, places a parking destination port at the shuttle's docking
+// turf, and back-fills the global shuttle datum so setup_shuttles() picks it
+// up like any other shuttle.
+
+// Registry of /datum/shuttle datums by type, populated in /datum/shuttle/New.
+// Lets the shuttle loader resolve a shuttle datum even if its area doesn't
+// exist yet (and so it isn't in the global shuttles list).
+var/global/list/shuttle_datums_by_path = list()
+
+// Loaded shuttle map elements, in load order.
+var/global/list/datum/map_element/shuttle/loaded_shuttle_map_elements = list()
+
+//
+// Map element that loads a shuttle DMM into its own VZ_PARKING vlevel.
+//
+/datum/map_element/shuttle
+	name = "shuttle"
+	vz_type = VZ_PARKING
+
+	// Type path of the global /datum/shuttle this DMM provides the body for.
+	// Required.
+	var/shuttle_datum_path = null
+
+	// Buffer of empty space turfs around the shuttle inside its parking vlevel.
+	var/parking_buffer = 7
+
+	// If non-zero, the parking vlevel will be exactly this wide/tall instead of
+	// being sized dynamically from the shuttle dimensions + parking_buffer.
+	var/parking_width = 0
+	var/parking_height = 0
+
+/datum/map_element/shuttle/initialize(list/objects)
+	..()
+	loaded_shuttle_map_elements |= src
+
+	if(!shuttle_datum_path)
+		warning("/datum/map_element/shuttle [type] has no shuttle_datum_path set")
+		return
+
+	var/datum/shuttle/S = shuttle_datums_by_path[shuttle_datum_path]
+	if(!S)
+		warning("/datum/map_element/shuttle [type]: cannot find global shuttle datum [shuttle_datum_path]. Was the shuttle datum's New() called before maps loaded?")
+		return
+
+	// Find shuttle areas in the loaded objects and back-fill the shuttle datum.
+	var/list/loaded_areas = list()
+	for(var/atom/A in objects)
+		var/area/found_area
+		if(isturf(A))
+			found_area = A.loc
+		else if(isarea(A))
+			found_area = A
+		if(found_area && !(found_area in loaded_areas))
+			loaded_areas |= found_area
+
+	S.attach_loaded_areas(loaded_areas)
+
+	// Place the parking destination port at the shuttle's docking turf so the
+	// shuttle auto-docks here when initialize() runs in setup_shuttles().
+	var/obj/docking_port/shuttle/shuttle_port = null
+	for(var/area/A in S.linked_areas)
+		for(var/obj/docking_port/shuttle/P in A.contents)
+			shuttle_port = P
+			break
+		if(shuttle_port)
+			break
+
+	if(!shuttle_port)
+		warning("/datum/map_element/shuttle [type]: loaded shuttle has no /obj/docking_port/shuttle")
+		return
+
+	var/turf/dest_turf = get_step(get_turf(shuttle_port), shuttle_port.dir)
+	if(!dest_turf)
+		warning("/datum/map_element/shuttle [type]: shuttle docking turf is off-map")
+		return
+
+	var/obj/docking_port/destination/parking = new(dest_turf)
+	parking.dir = turn(shuttle_port.dir, 180)
+	parking.areaname = "[S.name] parking"
+	S.parking_port = parking
+
+// Loads each /datum/map_element/shuttle entry in map.load_shuttles into its
+// own parking vlevel. Called by SSmapping after fixedvaults.
+/proc/load_map_shuttles()
+	for(var/T in map.load_shuttles)
+		var/datum/map_element/shuttle/ME
+		if(ispath(T, /datum/map_element/shuttle))
+			ME = new T
+		else if(istype(T, /datum/map_element/shuttle))
+			ME = T
+		else
+			warning("load_map_shuttles: ignoring [T] - not a /datum/map_element/shuttle path or instance")
+			continue
+
+		ME.assign_dimensions()
+		// Pad each side of the loaded shuttle with parking_buffer turfs. Use
+		// addVLevel rather than addMapElementVLevel so the vlevel defaults
+		// (movement allowed, teleport allowed, etc.) match a regular parking
+		// area instead of a protected dungeon.
+		var/vlevel_w = ME.parking_width ? ME.parking_width : ME.width + ME.parking_buffer * 2
+		var/vlevel_h = ME.parking_height ? ME.parking_height : ME.height + ME.parking_buffer * 2
+		var/datum/virtual_z/parking_vz = map.addVLevel(vlevel_w, vlevel_h)
+		parking_vz.level_type = ME.vz_type
+		parking_vz.name = "[ME.name] parking"
+		// Centre the shuttle within its parking vlevel so visiting shuttles
+		// have room to dock on every side. With no explicit parking_width/_height
+		// this still produces parking_buffer turfs of margin on each side.
+		var/x_offset = round((vlevel_w - ME.width) / 2)
+		var/y_offset = round((vlevel_h - ME.height) / 2)
+		ME.load(parking_vz.x_min - 1 + x_offset, parking_vz.y_min - 1 + y_offset, parking_vz.parent_z.z, ME.rotation)
+
+		// Tie the parking vlevel to the shuttle datum once we know which one
+		// ended up linked to the loaded areas.
+		var/datum/shuttle/S = shuttle_datums_by_path[ME.shuttle_datum_path]
+		if(S)
+			parking_vz.linked_shuttle = S
+
+// After setup_shuttles() has run, give each loaded shuttle a transit vlevel
+// (if it doesn't have one yet) and fire its post_setup() hook.
+/proc/setup_loaded_shuttle_transits()
+	if(!loaded_shuttle_map_elements.len)
+		return
+
+	for(var/datum/map_element/shuttle/ME in loaded_shuttle_map_elements)
+		var/datum/shuttle/S = shuttle_datums_by_path[ME.shuttle_datum_path]
+		if(!S || !S.linked_port)
+			continue
+		if(!S.transit_port)
+			var/obj/docking_port/destination/transit/transit = generate_transit_area(S)
+			if(transit)
+				S.set_transit_dock(transit)
+				S.add_dock(transit)
+		S.post_setup()

--- a/code/world.dm
+++ b/code/world.dm
@@ -86,10 +86,7 @@ var/auxtools_path
 	send2mainirc("Server starting up on [config.server? "byond://[config.server]" : "byond://[world.address]:[world.port]"]")
 	send2maindiscord("**Server starting up** on `[config.server? "byond://[config.server]" : "byond://[world.address]:[world.port]"]`. Map is **[map.nameLong]**")
 
-	// Load anything the map flagged as early — runs synchronously before any
-	// client connection is possible, so spawn landmarks they contain (e.g.
-	// the Observer-Start landmark inside centcomm) are populated before the
-	// first /mob/new_player/Login() reads newplayer_start.
+	// Load anything the map flagged as early (ran before any client connection is possible)
 	if(map)
 		map.load_early_elements()
 

--- a/code/world.dm
+++ b/code/world.dm
@@ -86,6 +86,13 @@ var/auxtools_path
 	send2mainirc("Server starting up on [config.server? "byond://[config.server]" : "byond://[world.address]:[world.port]"]")
 	send2maindiscord("**Server starting up** on `[config.server? "byond://[config.server]" : "byond://[world.address]:[world.port]"]`. Map is **[map.nameLong]**")
 
+	// Load anything the map flagged as early — runs synchronously before any
+	// client connection is possible, so spawn landmarks they contain (e.g.
+	// the Observer-Start landmark inside centcomm) are populated before the
+	// first /mob/new_player/Login() reads newplayer_start.
+	if(map)
+		map.load_early_elements()
+
 	Master.Setup()
 
 	TgsInitializationComplete()

--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -74,12 +74,9 @@
 	var/list/load_map_elements = list()
 	var/list/load_custom_fixedvaults = list() //don't use this
 	//List of /datum/map_element/shuttle (path or instance) loaded after fixedvaults.
-	//Each entry creates a VZ_PARKING vlevel containing the shuttle DMM.
 	var/list/load_shuttles = list()
-	//Map elements loaded synchronously during world/New(), before Master.Setup
-	//starts subsystem init. Use for elements that must be present before the
-	//first client connection (e.g. centcomm-housed Observer-Start landmark on
-	//maps where the main DMM has no spawn landmarks of its own).
+
+	//Things that must be loaded before the first client connects (ie the title screen)
 	var/list/early_load_map_elements = list()
 	var/list/early_loaded_map_element_types = list()
 	var/center_x = 226
@@ -249,9 +246,8 @@ var/global/list/accessable_v_levels = list(
 	"Default" = list()
 )
 
-// Loads each entry in early_load_map_elements synchronously. Called from
-// world/New() before Master.Setup() so the loaded landmarks are populated
-// before any client connection / Login() can fire.
+// Loads each entry in early_load_map_elements synchronously.
+// Called from world/New() before Master.Setup() so the loaded landmarks are populated before any client connection / Login() can fire.
 /datum/map/proc/load_early_elements()
 	for(var/T in early_load_map_elements)
 		load_dungeon(T, 0, FALSE, FALSE)

--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -73,6 +73,15 @@
 	//Map elements that should be loaded together with this map. Stuff like the holodeck areas, etc.
 	var/list/load_map_elements = list()
 	var/list/load_custom_fixedvaults = list() //don't use this
+	//List of /datum/map_element/shuttle (path or instance) loaded after fixedvaults.
+	//Each entry creates a VZ_PARKING vlevel containing the shuttle DMM.
+	var/list/load_shuttles = list()
+	//Map elements loaded synchronously during world/New(), before Master.Setup
+	//starts subsystem init. Use for elements that must be present before the
+	//first client connection (e.g. centcomm-housed Observer-Start landmark on
+	//maps where the main DMM has no spawn landmarks of its own).
+	var/list/early_load_map_elements = list()
+	var/list/early_loaded_map_element_types = list()
 	var/center_x = 226
 	var/center_y = 254
 
@@ -239,6 +248,18 @@
 var/global/list/accessable_v_levels = list(
 	"Default" = list()
 )
+
+// Loads each entry in early_load_map_elements synchronously. Called from
+// world/New() before Master.Setup() so the loaded landmarks are populated
+// before any client connection / Login() can fire.
+/datum/map/proc/load_early_elements()
+	for(var/T in early_load_map_elements)
+		load_dungeon(T, 0, FALSE, FALSE)
+		if(ispath(T))
+			early_loaded_map_element_types |= T
+		else if(istype(T, /datum/map_element))
+			var/datum/map_element/ME = T
+			early_loaded_map_element_types |= ME.type
 
 /datum/map/proc/map_specific_init()
 

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -2570,6 +2570,7 @@
 #include "code\modules\projectiles\projectile\special.dm"
 #include "code\modules\projectiles\projectile\tesla.dm"
 #include "code\modules\randomMaps\dungeons.dm"
+#include "code\modules\randomMaps\shuttle_loader.dm"
 #include "code\modules\randomMaps\special.dm"
 #include "code\modules\randomMaps\transit.dm"
 #include "code\modules\randomMaps\vault_definitions.dm"


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Adds support for loading shuttles as map elements which allows maps to load various shuttles without requiring them to be baked into the map file itself. Additionally, adds a way to load map elements early so that they appear prior to allowing any client connections.

Blocked by #39269 & #39286.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
This will be used for the Odyssey 2.0 rework. The early map loader allows for placing the title screen within its own vLevel.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
TBD

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Adds the ability to load shuttles as map elements.