### PR TITLE
Deff Medbay Window + RC

### DIFF
--- a/maps/defficiency.dmm
+++ b/maps/defficiency.dmm
@@ -21028,9 +21028,9 @@
 "aNP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/bed/roller/deff,
-/obj/structure/sign/nosmoking_1{
-	pixel_x = -26;
-	pixel_y = 4
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -101427,7 +101427,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered,
 /obj/structure/sign/nosmoking_1{
-	pixel_x = -32
+	pixel_x = 32
 	},
 /turf/simulated/floor/plating,
 /area/research_outpost/atmos)
@@ -109140,9 +109140,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/structure/sign/nosmoking_1{
+	pixel_x = 26;
+	pixel_y = 4
 	},
 /turf/simulated/floor{
 	icon_state = "dark"

--- a/maps/defficiency.dmm
+++ b/maps/defficiency.dmm
@@ -21849,6 +21849,10 @@
 	pixel_x = -22;
 	pixel_y = -10
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -32;
+	pixel_y = null
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "dark_navy";
@@ -32570,9 +32574,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -28
 	},
 /turf/simulated/floor{
 	icon_state = "dark"

--- a/maps/defficiency.dmm
+++ b/maps/defficiency.dmm
@@ -21144,9 +21144,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -28
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -22783,10 +22780,9 @@
 /area/medical/medbay)
 "aQZ" = (
 /obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 5;
-	phone_name = "Brig Medbay";
-	pixel_y = 24
+	department = "Medbay";
+	pixel_y = 30;
+	phone_name = "Medbay Lobby"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -26923,15 +26919,6 @@
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/light{
-	dir = 4;
-	pixel_y = -3
-	},
-/obj/machinery/camera{
-	dir = 8;
-	name = "Medbay - Hallway";
-	pixel_y = 1
-	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark_navy_corner";
@@ -26946,9 +26933,6 @@
 /area/medical/medbay2)
 "aYP" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/sign/examroom{
-	pixel_x = -28
-	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "dark_navy_corner";
@@ -27998,9 +27982,14 @@
 /area/medical/medbay2)
 "baA" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
+/obj/machinery/light{
 	dir = 4;
-	pixel_x = 24
+	pixel_y = -3
+	},
+/obj/machinery/camera{
+	dir = 8;
+	name = "Medbay - Hallway";
+	pixel_y = 1
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -32581,6 +32570,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -28
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -109147,6 +109139,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -110176,12 +110172,15 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/flora/pottedplant/random,
+/obj/item/device/radio/intercom/medbay{
+	pixel_y = -26
+	},
+/obj/structure/sign/examroom{
+	pixel_x = -28
+	},
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_y = 10
-	},
-/obj/item/device/radio/intercom/medbay{
-	pixel_y = -26
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -227533,7 +227532,7 @@ aSG
 aXr
 baz
 bbX
-aXr
+aPr
 aXr
 bgQ
 aCV

--- a/maps/defficiency.dmm
+++ b/maps/defficiency.dmm
@@ -101427,7 +101427,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered,
 /obj/structure/sign/nosmoking_1{
-	pixel_x = 32
+	pixel_x = -32
 	},
 /turf/simulated/floor/plating,
 /area/research_outpost/atmos)


### PR DESCRIPTION
A few medbay requests (A window and fixing the requests console to be named properly)
Honestly surprised it just straight up didnt have a front door window every station has one
<img width="728" height="680" alt="Untitled" src="https://github.com/user-attachments/assets/d6f055ed-eecc-4522-b25a-0a9ddcc3a800" />
[deff]

closes #38249 (fixed already)
closes #34697 (fixed already)
closes #38948 (fixed already)
closes #39280 (This PR)
does part of #38749 

*tweak: minor changes to deff medbay
