### PR TITLE
Delivery pass fixes

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -243,6 +243,7 @@ var/MAX_EXPLOSION_RANGE = 32
 #define PASSDOOR	(1<<6) //not just airlocks, but also firelocks, windoors etc
 #define PASSGIRDER	(1<<7)
 #define PASSRAILING (1<<8)
+#define PASSFLAPS   (1<<9)
 
 #define PASSALL		(~0) //bolt of pain
 

--- a/code/game/objects/structures/flaps.dm
+++ b/code/game/objects/structures/flaps.dm
@@ -6,7 +6,7 @@
 	density = 0
 	anchored = 1
 	plane = ABOVE_HUMAN_PLANE
-	pass_flags_self = PASSGLASS
+	pass_flags_self = PASSGLASS | PASSFLAPS
 	var/airtight = 0
 
 /obj/effect/plasticflaps_overlay
@@ -72,7 +72,7 @@ var/obj/effect/plasticflaps_overlay/PO
 
 	else if(isliving(mover)) // You Shall Not Pass!
 		var/mob/living/M = mover
-		if(!M.lying && !istype(M, /mob/living/carbon/monkey) && !istype(M, /mob/living/carbon/slime) && !istype(M, /mob/living/simple_animal/mouse))  //If your not laying down, or a small creature, no pass.
+		if(!M.lying && M.stat < DEAD)  //If your not laying down, or alive, no pass.
 			return 0
 	if(!istype(mover)) // Aircheck!
 		return !airtight

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -5,7 +5,7 @@
 	icon_state = "monkey1"
 	icon = 'icons/mob/monkey.dmi'
 	gender = NEUTER
-	pass_flags = PASSTABLE | PASSRAILING
+	pass_flags = PASSTABLE | PASSRAILING | PASSFLAPS
 	update_icon = 0		///no need to call regenerate_icon
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/animal/monkey
 	species_type = /mob/living/carbon/monkey

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -2,7 +2,7 @@
 	name = "baby slime"
 	desc = null
 	icon = 'icons/mob/slimes.dmi'
-	pass_flags = PASSTABLE
+	pass_flags = PASSTABLE | PASSFLAPS
 	layer = SLIME_LAYER
 	gender = NEUTER
 	update_icon = 0

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1284,7 +1284,11 @@ Thanks.
 /mob/living/to_bump(atom/movable/AM as mob|obj)
 	spawn(0)
 		INVOKE_EVENT(src, /event/to_bump, "bumper" = src, "bumped" = AM)
-		if (now_pushing || !loc || size <= SIZE_TINY)
+		if (now_pushing || !loc)
+			return
+		if (size <= SIZE_TINY)
+			if(istype(AM,/obj/machinery/disposal/deliveryChute)) //hotfix
+				AM.Bumped(src)
 			return
 		now_pushing = 1
 		if (istype(AM, /obj/structure/bed/roller)) //no pushing rollerbeds that have people on them

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -21,7 +21,7 @@
 	emote_hear = list("squeeks","squeaks","squiks")
 	emote_see = list("runs in a circle", "shakes", "scritches at something")
 	emote_sound = list('sound/effects/mousesqueek.ogg')
-	pass_flags = PASSTABLE | PASSRAILING
+	pass_flags = PASSTABLE | PASSRAILING | PASSFLAPS
 	flags = HEAR_ALWAYS | PROXMOVE
 	speak_chance = 1
 	turns_per_move = 5

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -164,14 +164,11 @@ var/list/tagger_locations = list()
 
 	//testing("[src] FUCKING BUMPED BY \a [AM]")
 
-	if(istype(AM, /obj))
+	if(isobj(AM) || ismob(AM))
 		receive_atom(AM)
-	else if(istype(AM, /mob))
-		receive_atom(AM)
-
 
 /obj/machinery/disposal/deliveryChute/conveyor_act(var/atom/movable/AM, var/obj/machinery/conveyor/CB)
-	if(istype(AM,/obj/item))
+	if(isobj(AM) || ismob(AM))
 		if(stat & BROKEN || !AM || mode <=0 || !deconstructable)
 			return FALSE
 		receive_atom(AM)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -168,7 +168,7 @@ var/list/tagger_locations = list()
 		receive_atom(AM)
 
 /obj/machinery/disposal/deliveryChute/conveyor_act(var/atom/movable/AM, var/obj/machinery/conveyor/CB)
-	if(isobj(AM) || ismob(AM))
+	if(istype(AM,/obj/item))
 		if(stat & BROKEN || !AM || mode <=0 || !deconstructable)
 			return FALSE
 		receive_atom(AM)


### PR DESCRIPTION
[consistency]

## What this does
Closes #15621.

## How it was tested
Making a conveyor, flaps, delivery chute, using all 3 with dead mobs and mice.

## Changelog
:cl:
 * tweak: Plastic flaps now let dead mobs of any kind pass.
 * bugfix: Delivery chutes now let tiny mobs inside.