### PR TITLE
Odyssey radevent fix

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -383,7 +383,7 @@ var/area/space_area
 /area/proc/power_change()
 	for(var/obj/machinery/M in src)	// for each machine in the area
 		M.power_change()				// reverify power status (to update icons etc.)
-	if (fire || eject || party)
+	if (fire || eject || party || radalert)
 		updateicon()
 
 /area/proc/usage(const/chan)

--- a/maps/odyssey/events.dm
+++ b/maps/odyssey/events.dm
@@ -122,13 +122,14 @@
 		/area/shuttle/odyssey/hallway/aft,
 		/area/shuttle/odyssey/engineering,
 		/area/shuttle/odyssey/bridge,
+		/area/shuttle/odyssey/bridge_lobby,
 	)
 
 /datum/command_alert/radiation_storm/odyssey
 	name = "Radiation Storm - Warning"
 	alert_title = "Anomaly Alert"
 	alert = 'sound/AI/radiation.ogg'
-	message = "High levels of radiation detected near the station, ETA in 30 seconds. Please evacuate into the ship's bridge or aft."
+	message = "High levels of radiation detected near the ship, ETA in 30 seconds. Please evacuate to the bridge, aft hallway, engineering, or maintenance."
 
 /datum/event/radiation_storm/odyssey/start()
 	spawn()
@@ -147,17 +148,17 @@
 			var/irradiationThisBurst = rand(15, 25)
 			for(var/obj/machinery/power/rad_collector/R in rad_collectors)
 				var/turf/T = get_turf(R)
-				if(!T || is_safe_zone(T.loc, T))
+				if(!T || !odyssey_shuttle.has_area(T.loc) || is_safe_zone(T.loc, T))
 					continue
 				R.receive_pulse(irradiationThisBurst * 50)
 			for(var/obj/item/weapon/am_containment/decelerator/D in decelerators)
 				var/turf/T = get_turf(D)
-				if(!T || is_safe_zone(T.loc, T))
+				if(!T || !odyssey_shuttle.has_area(T.loc) || is_safe_zone(T.loc, T))
 					continue
 				D.receive_pulse(irradiationThisBurst * 50)
 			for(var/obj/machinery/portable_atmospherics/hydroponics/tray in hydro_trays)
 				var/turf/T = get_turf(tray)
-				if(!T || is_safe_zone(T.loc, T))
+				if(!T || !odyssey_shuttle.has_area(T.loc) || is_safe_zone(T.loc, T))
 					continue
 				tray.receive_pulse(irradiationThisBurst * 50)
 
@@ -165,7 +166,7 @@
 				if(istype(H.loc, /obj/spacepod))
 					continue
 				var/turf/T = get_turf(H)
-				if(!T || is_safe_zone(T.loc, T))
+				if(!T || !odyssey_shuttle.has_area(T.loc) || is_safe_zone(T.loc, T))
 					continue
 				var/randomMutation = prob(50)
 				var/applied_rads = (H.apply_radiation(irradiationThisBurst, RAD_EXTERNAL) > (irradiationThisBurst / 4))


### PR DESCRIPTION
## What this does

- Only turfs that are part of the Oddysey itself can be targeted (not the outpost or whatever else, the only safe area are on the Odyssey)
- Tweak to the wording to list all the safe areas
- Add bridge lobby as a safe area for a tiny bit more room
- Fix a bug with the rad alert overlay where it wouldnt fire properly if area power changed   

## Why it's good
I can only guess what went wrong from a few broken descriptions on discord but this might help maybe

basically tons of people died

## How it was tested
In my mind, extensively, I thought really really hard, I looked like this while doing it

<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/6e2c1af6-fed9-4b27-8d3a-d5b59c30518a" />

## Changelog
:cl:
 * bugfix: Rad alerts should update properly when area power changes
 * tweak: Odyssey is a bit clearer about where is safe and where isn't during rad alerts
 *  bugfix: Rad alert events only target the Odyssey itself  
