### PR TITLE
Fixes the Surface Gas Extractor Supply Pack

### DIFF
--- a/code/datums/supply_packs/engineering.dm
+++ b/code/datums/supply_packs/engineering.dm
@@ -495,7 +495,7 @@
 	contains = list(
 		/obj/item/weapon/circuitboard/gas_extraction,
 		/obj/item/weapon/circuitboard/gas_extractor,
-		/obj/machinery/atmospherics/miner
+		/obj/machinery/atmospherics/miner/surface
 	)
 	name = "Surface Gas Extraction Kit"
 	cost = 200


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Adds the correct type of gas miner to the Surface Gas Extractor supply pack so that the gas extractor can actually be used.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
The supply pack was non-functional before this change.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
0% committed from the web editor

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: The Surface Gas Extractor supply pack now includes the correct type of gas miner to pair with the extractor.
