### PR TITLE
more junglestation improvments

### DIFF
--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -379,12 +379,14 @@ var/global/list/accessable_v_levels = list(
 	name = "jungle surface"
 	base_turf = /turf/unsimulated/floor/planetary/dirt/jungle
 	base_area = /area/surface/jungle/landing //hacky workaround.
+	movementChance = 0
 	planetside = TRUE
 
 /datum/zLevel/jungleunderground
 	name = "jungle underground"
 	base_turf = /turf/unsimulated/floor/planetary/cave/jungle
 	base_area = /area/surface/jungle/underground
+	movementChance = 0
 	planetside = TRUE
 
 /datum/zLevel/junglesurface/mining

--- a/maps/junglestation.dmm
+++ b/maps/junglestation.dmm
@@ -7131,8 +7131,12 @@
 	},
 /area/centcom/test)
 "cEk" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning";
+	tag = "icon-warning"
+	},
 /turf/simulated/floor{
-	icon_state = "whitepurple"
+	icon_state = "whitered"
 	},
 /area/research_outpost/dorm2{
 	icon_state = "toxlab";
@@ -10328,6 +10332,13 @@
 	},
 /turf/unsimulated/floor/planetary/concrete/jungle,
 /area/shuttle/research/station)
+"dML" = (
+/obj/structure/closet/bombcloset,
+/turf/simulated/floor,
+/area/research_outpost/dorm2{
+	icon_state = "toxlab";
+	name = "Toxins"
+	})
 "dMN" = (
 /turf/simulated/wall/r_wall,
 /area/science/rd)
@@ -12816,6 +12827,20 @@
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/unsimulated/floor/planetary/grass/jungle/no_flora,
 /area/surface/jungle)
+"eFq" = (
+/obj/effect/decal/warning_stripes{
+	dir = 1;
+	icon_state = "warning";
+	tag = "icon-warning (NORTH)"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "whitered"
+	},
+/area/research_outpost/dorm2{
+	icon_state = "toxlab";
+	name = "Toxins"
+	})
 "eFF" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -13019,9 +13044,14 @@
 /turf/unsimulated/floor/planetary/path/jungle_plated,
 /area/surface/jungle/fenced)
 "eKp" = (
-/turf/simulated/floor{
+/obj/effect/decal/warning_stripes{
 	dir = 9;
-	icon_state = "whitepurple"
+	icon_state = "warning";
+	tag = "icon-warning (NORTHEAST)"
+	},
+/turf/simulated/floor{
+	icon_state = "whitered";
+	dir = 9
 	},
 /area/research_outpost/dorm2{
 	icon_state = "toxlab";
@@ -18471,6 +18501,19 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
 /area/library)
+"gPc" = (
+/obj/structure/table,
+/obj/item/weapon/reagent_containers/food/drinks/coffee{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/research_outpost/dorm2{
+	icon_state = "toxlab";
+	name = "Toxins"
+	})
 "gPg" = (
 /obj/structure/sign/securearea{
 	name = "DANGER: SPIDERS";
@@ -19806,9 +19849,14 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/decal/warning_stripes{
+	dir = 1;
+	icon_state = "warning";
+	tag = "icon-warning (NORTH)"
+	},
 /turf/simulated/floor{
 	dir = 1;
-	icon_state = "whitepurple"
+	icon_state = "whitered"
 	},
 /area/research_outpost/dorm2{
 	icon_state = "toxlab";
@@ -28853,9 +28901,14 @@
 	},
 /area/shuttle/administration/centcom)
 "kJP" = (
-/turf/simulated/floor{
+/obj/effect/decal/warning_stripes{
 	dir = 5;
-	icon_state = "whitepurple"
+	icon_state = "warning";
+	tag = "icon-warning (NORTHEAST)"
+	},
+/turf/simulated/floor{
+	icon_state = "whitered";
+	dir = 5
 	},
 /area/research_outpost/dorm2{
 	icon_state = "toxlab";
@@ -29416,6 +29469,17 @@
 /obj/machinery/cooking/deepfryer,
 /turf/unsimulated/floor/planetary/path/jungle_plated,
 /area/crew_quarters/kitchen)
+"kXc" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/research_outpost/dorm2{
+	icon_state = "toxlab";
+	name = "Toxins"
+	})
 "kXk" = (
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid/internalbleed{
@@ -33877,9 +33941,14 @@
 /turf/simulated/floor/shuttle,
 /area/centcom/evac)
 "mCa" = (
-/turf/simulated/floor{
+/obj/effect/decal/warning_stripes{
 	dir = 10;
-	icon_state = "whitepurple"
+	icon_state = "warning";
+	tag = "icon-warning (SOUTHWEST)"
+	},
+/turf/simulated/floor{
+	icon_state = "whitered";
+	dir = 10
 	},
 /area/research_outpost/dorm2{
 	icon_state = "toxlab";
@@ -38413,6 +38482,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor,
 /area/research_outpost/maintstore1{
 	icon_state = "toxstorage";
@@ -40692,9 +40762,15 @@
 	},
 /area/security/armory)
 "pgA" = (
-/turf/simulated/floor{
+/obj/structure/closet/firecloset,
+/obj/effect/decal/warning_stripes{
 	dir = 6;
-	icon_state = "whitepurple"
+	icon_state = "warning";
+	tag = "icon-warning (SOUTHEAST)"
+	},
+/turf/simulated/floor{
+	icon_state = "whitered";
+	dir = 6
 	},
 /area/research_outpost/dorm2{
 	icon_state = "toxlab";
@@ -49435,9 +49511,14 @@
 	},
 /area/medical/virology)
 "snb" = (
+/obj/effect/decal/warning_stripes{
+	dir = 8;
+	icon_state = "warning";
+	tag = "icon-warning (EAST)"
+	},
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "whitepurple"
+	icon_state = "whitered"
 	},
 /area/research_outpost/dorm2{
 	icon_state = "toxlab";
@@ -52183,6 +52264,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 27
+	},
 /turf/simulated/floor,
 /area/research_outpost/dorm2{
 	icon_state = "toxlab";
@@ -53206,6 +53291,17 @@
 "tFd" = (
 /turf/unsimulated/floor/planetary/path/jungle,
 /area/surface/jungle/mining)
+"tFh" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/research_outpost/dorm2{
+	icon_state = "toxlab";
+	name = "Toxins"
+	})
 "tFZ" = (
 /obj/structure/closet/emcloset/vox,
 /turf/unsimulated/floor/planetary/grass/jungle/no_flora,
@@ -55220,6 +55316,20 @@
 	icon_state = "floor4"
 	},
 /area/syndicate_mothership/elite_squad)
+"uuK" = (
+/obj/effect/decal/warning_stripes{
+	dir = 4;
+	icon_state = "warning";
+	tag = "icon-warning (EAST)"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "whitered"
+	},
+/area/research_outpost/dorm2{
+	icon_state = "toxlab";
+	name = "Toxins"
+	})
 "uuL" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -59544,6 +59654,7 @@
 /obj/machinery/light_switch{
 	pixel_x = 28
 	},
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor,
 /area/research_outpost/maintstore1{
 	icon_state = "toxstorage";
@@ -63152,6 +63263,9 @@
 "xpr" = (
 /obj/structure/table,
 /obj/item/device/pipe_painter,
+/obj/item/tool/screwdriver{
+	pixel_y = 18
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -460473,7 +460587,7 @@ cTx
 akL
 gNo
 cTx
-cTx
+dML
 epp
 ugv
 ugv
@@ -461520,8 +461634,8 @@ rIh
 rIh
 tFd
 epp
-pQF
-mqQ
+eFq
+kXc
 cEk
 rEb
 gTF
@@ -461873,7 +461987,7 @@ tFd
 tFd
 epp
 hpp
-mqQ
+gPc
 cEk
 mqQ
 pEH
@@ -462224,8 +462338,8 @@ rIh
 tFd
 tFd
 epp
-pQF
-mqQ
+eFq
+tFh
 cEk
 xpr
 gTF
@@ -462577,7 +462691,7 @@ tFd
 tFd
 epp
 kJP
-oom
+uuK
 pgA
 epp
 epp

--- a/maps/junglestation.dmm
+++ b/maps/junglestation.dmm
@@ -490,6 +490,18 @@
 	icon_state = "floorgrime"
 	},
 /area/security/processing)
+"akt" = (
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "whitepurple"
+	},
+/area/research_outpost/dorm2{
+	icon_state = "toxlab";
+	name = "Toxins"
+	})
 "akL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -9791,6 +9803,10 @@
 	default_scrubbed_gases = list("plasma");
 	dir = 1
 	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -11967,6 +11983,10 @@
 	},
 /area/security/warden)
 "enM" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whitepurple"
@@ -16175,6 +16195,9 @@
 /obj/item/weapon/pickaxe,
 /obj/item/weapon/storage/belt/utility,
 /obj/structure/table,
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
 /turf/simulated/floor,
 /area/mine/eva)
 "fUf" = (
@@ -18969,6 +18992,10 @@
 /area/medical/surgery)
 "gWW" = (
 /obj/machinery/smartfridge,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whitegreen"
@@ -33173,6 +33200,10 @@
 	network = list("RD","SS13");
 	dir = 8
 	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/simulated/floor,
 /area/research_outpost/hallway)
 "mnj" = (
@@ -35120,6 +35151,14 @@
 	icon_state = "red"
 	},
 /area/security/lobby)
+"mYR" = (
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
+/turf/simulated/floor{
+	icon_state = "dark vault full"
+	},
+/area/research_outpost/harvesting)
 "mYY" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -35765,6 +35804,9 @@
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/alarm{
+	pixel_y = 23
 	},
 /turf/simulated/floor/plating,
 /area/research_outpost/atmos)
@@ -43456,6 +43498,12 @@
 /area/server{
 	name = "AI Integrity Restoration Room"
 	})
+"qgQ" = (
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
+/turf/simulated/floor,
+/area/research_outpost/gearstore)
 "qgR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44037,6 +44085,9 @@
 	name = "Research Outpost Hallway Starboard";
 	network = list("RD","SS13");
 	pixel_x = 24
+	},
+/obj/machinery/alarm{
+	pixel_y = 23
 	},
 /turf/simulated/floor,
 /area/research_outpost/entry)
@@ -49677,6 +49728,10 @@
 	dir = 8;
 	icon_state = "warning_corner"
 	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/simulated/floor,
 /area/research_outpost/maintstore1{
 	icon_state = "toxstorage";
@@ -49922,6 +49977,9 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = -27
+	},
+/obj/machinery/alarm{
+	pixel_y = 23
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -56486,6 +56544,10 @@
 	network = list("RD","SS13")
 	},
 /obj/structure/closet,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/simulated/floor,
 /area/research_outpost/dorm1)
 "uUD" = (
@@ -61785,6 +61847,10 @@
 	},
 /obj/machinery/light/small{
 	dir = 8
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
 	},
 /turf/simulated/floor,
 /area/mine/production)
@@ -462679,7 +462745,7 @@ uuK
 pgA
 epp
 epp
-pQF
+akt
 gci
 cMw
 ueY
@@ -466545,7 +466611,7 @@ rIh
 rIh
 rIh
 dqd
-wfW
+mYR
 wfW
 tOj
 kSn
@@ -472887,7 +472953,7 @@ nsl
 nsl
 vEE
 wIo
-toi
+qgQ
 xIP
 ycD
 aBR

--- a/maps/junglestation.dmm
+++ b/maps/junglestation.dmm
@@ -30529,6 +30529,15 @@
 /obj/structure/grille/window_spawner/reinforced/full,
 /turf/simulated/floor/plating,
 /area/bridge)
+"ltC" = (
+/obj/structure/dispenser,
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/research_outpost/dorm2{
+	icon_state = "toxlab";
+	name = "Toxins"
+	})
 "ltH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
@@ -461171,7 +461180,7 @@ mqQ
 mqQ
 mqQ
 mqQ
-mqQ
+ltC
 epp
 ugv
 ugv

--- a/maps/junglestation.dmm
+++ b/maps/junglestation.dmm
@@ -36280,13 +36280,6 @@
 	icon_state = "hydrofloor"
 	},
 /area/crew_quarters/courtroom)
-"nxJ" = (
-/obj/structure/bed/chair/wood/normal{
-	dir = 4
-	},
-/mob/living/simple_animal/complex/gorilla,
-/turf/unsimulated/floor/planetary/dirt/jungle,
-/area/surface/jungle/vault)
 "nxM" = (
 /obj/structure/table/plastic,
 /obj/item/clothing/under/shorts/red,
@@ -46996,15 +46989,6 @@
 	icon_state = "dark-markings"
 	},
 /area/security/armory)
-"rsT" = (
-/obj/effect/decal/warning_stripes{
-	dir = 8;
-	icon_state = "warning";
-	tag = "icon-warning (WEST)"
-	},
-/mob/living/simple_animal/complex/bear,
-/turf/unsimulated/floor/planetary/concrete/jungle,
-/area/surface/jungle/vault)
 "rsW" = (
 /obj/machinery/door/airlock/glass_command{
 	name = "Bridge";
@@ -68948,7 +68932,7 @@ lIK
 lIK
 lIK
 lIK
-xtL
+lIK
 lIK
 lIK
 lIK
@@ -69888,7 +69872,7 @@ lIK
 lIK
 lIK
 lIK
-xtL
+lIK
 lIK
 lIK
 lIK
@@ -79174,7 +79158,7 @@ lIK
 lIK
 lIK
 lIK
-xtL
+lIK
 lIK
 lIK
 lIK
@@ -80752,7 +80736,7 @@ lIK
 lIK
 lIK
 lIK
-xtL
+lIK
 lIK
 lIK
 lIK
@@ -88195,7 +88179,7 @@ lIK
 lIK
 lIK
 lIK
-xtL
+lIK
 lIK
 lIK
 lIK
@@ -89763,7 +89747,7 @@ lIK
 lIK
 lIK
 lIK
-xtL
+lIK
 lIK
 lIK
 lIK
@@ -90335,7 +90319,7 @@ lIK
 lIK
 lIK
 lIK
-xtL
+lIK
 lIK
 lIK
 lIK
@@ -92736,7 +92720,7 @@ lIK
 lIK
 lIK
 lIK
-xtL
+lIK
 lIK
 lIK
 lIK
@@ -93900,7 +93884,7 @@ lIK
 lIK
 lIK
 lIK
-xtL
+lIK
 lIK
 lIK
 lIK
@@ -100018,7 +100002,7 @@ lIK
 lIK
 lIK
 lIK
-xtL
+lIK
 lIK
 lIK
 lIK
@@ -112683,7 +112667,7 @@ lIK
 lIK
 lIK
 lIK
-cnU
+lIK
 lIK
 lIK
 lIK
@@ -114342,7 +114326,7 @@ gJc
 gJc
 gJc
 gJc
-oli
+gJc
 gJc
 gJc
 gJc
@@ -115478,7 +115462,7 @@ lIK
 lIK
 lIK
 lIK
-mCs
+lIK
 lIK
 lIK
 lIK
@@ -115818,7 +115802,7 @@ lIK
 lIK
 lIK
 lIK
-cnU
+lIK
 lIK
 lIK
 lIK
@@ -117564,7 +117548,7 @@ lIK
 lIK
 lIK
 lIK
-mCs
+lIK
 lIK
 lIK
 lIK
@@ -117982,7 +117966,7 @@ lIK
 lIK
 lIK
 lIK
-cnU
+lIK
 lIK
 lIK
 lIK
@@ -121778,7 +121762,7 @@ lIK
 lIK
 lIK
 lIK
-mCs
+lIK
 lIK
 lIK
 lIK
@@ -125018,7 +125002,7 @@ lIK
 lIK
 lIK
 lIK
-cnU
+lIK
 lIK
 lIK
 lIK
@@ -126047,7 +126031,7 @@ rnF
 rnF
 rnF
 rnF
-scy
+rnF
 rnF
 rnF
 rnF
@@ -126332,7 +126316,7 @@ gJc
 gJc
 gJc
 gJc
-oli
+gJc
 gJc
 gJc
 gJc
@@ -129874,7 +129858,7 @@ lIK
 lIK
 lIK
 lIK
-mCs
+lIK
 lIK
 lIK
 lIK
@@ -131677,7 +131661,7 @@ bRe
 bRe
 bRe
 bRe
-vfF
+bRe
 xiS
 dFK
 rnF
@@ -133428,7 +133412,7 @@ rnF
 dFK
 bRe
 bRe
-rsT
+rCj
 bRe
 bRe
 rCj
@@ -135863,7 +135847,7 @@ lIK
 lIK
 lIK
 lIK
-cnU
+lIK
 lIK
 lIK
 lIK
@@ -143546,7 +143530,7 @@ gJc
 gJc
 gJc
 gJc
-oli
+gJc
 gJc
 gJc
 gJc
@@ -143636,7 +143620,7 @@ lIK
 lIK
 lIK
 lIK
-cnU
+lIK
 lIK
 lIK
 lIK
@@ -153884,7 +153868,7 @@ gJc
 gJc
 gJc
 gJc
-oli
+gJc
 gJc
 gJc
 gJc
@@ -162519,7 +162503,7 @@ lIK
 lIK
 lIK
 lIK
-xtL
+lIK
 lIK
 lIK
 lIK
@@ -165288,7 +165272,7 @@ lIK
 lIK
 lIK
 lIK
-xtL
+lIK
 lIK
 lIK
 lIK
@@ -169632,7 +169616,7 @@ unv
 unv
 unv
 unv
-luW
+unv
 unv
 rnF
 rnF
@@ -172004,7 +171988,7 @@ gJc
 gJc
 gJc
 gJc
-oli
+gJc
 gJc
 gJc
 gJc
@@ -177476,7 +177460,7 @@ gJc
 gJc
 gJc
 gJc
-oli
+gJc
 gJc
 gJc
 gJc
@@ -177592,7 +177576,7 @@ oQA
 oQA
 oQA
 oQA
-nxJ
+mNM
 mNM
 mNM
 oQA
@@ -178294,7 +178278,7 @@ oQA
 oQA
 oQA
 oQA
-fRP
+oQA
 oQA
 icG
 icG
@@ -179001,7 +178985,7 @@ oQA
 oQA
 oQA
 oQA
-fRP
+oQA
 oQA
 oQA
 oQA
@@ -179351,7 +179335,7 @@ oQA
 oQA
 oQA
 oQA
-fRP
+oQA
 cvW
 oQA
 oQA
@@ -179709,7 +179693,7 @@ mNM
 mNM
 oQA
 oQA
-fRP
+oQA
 oQA
 oQA
 oQA
@@ -180060,7 +180044,7 @@ icG
 icG
 icG
 oQA
-fRP
+oQA
 oQA
 oQA
 oQA
@@ -180764,7 +180748,7 @@ lWc
 lWc
 nBI
 oQA
-fRP
+oQA
 oQA
 oQA
 oQA
@@ -183359,7 +183343,7 @@ unv
 unv
 unv
 unv
-luW
+unv
 unv
 unv
 rnF
@@ -184311,7 +184295,7 @@ lIK
 lIK
 lIK
 lIK
-xtL
+lIK
 lIK
 lIK
 lIK
@@ -188039,7 +188023,7 @@ lIK
 lIK
 lIK
 lIK
-xtL
+lIK
 lIK
 lIK
 lIK


### PR DESCRIPTION
[bugfix] [jungle] [performance] [tweak]

## What this does
adds a tank dispenser, fire closet, bomb suit, small scrubber, an air pump, a screwdriver, and a wall radio by the bangmeter to jungle's toxins
additionally adds missing air alarms into the roid outpost

<img width="3648" height="1888" alt="2026-05-21 22 55 37" src="https://github.com/user-attachments/assets/d1d93bb0-db32-4b5c-9b9d-ab176ea27bfb" />

also reduces the number of mobs spawn to cut down on performance overhead

before
<img width="426" height="29" alt="before" src="https://github.com/user-attachments/assets/8fae7b18-172c-4dc9-b9d8-6a0607a5c636" />

after
<img width="414" height="28" alt="after" src="https://github.com/user-attachments/assets/b68bf56f-ecb2-419b-8261-b4c69819dca0" />

and probably closes #39345 by reducing zlevel movement chance to 0

## Why it's good
adds things toxins needs to be played, and also adds a bit more flavor to the station
less CPU use is good


## How it was tested
went in game and checked MC values

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Added some missing equipment junglestation's toxins lab
 * tweak: reduced the number of mob spawns on junglestation
 * bugfix: fixed procgen content potentially teleporting the player onto the surface when in space.