### PR TITLE
(Bus only) Arcane tampered door teleport chance

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -61,6 +61,7 @@ var/list/all_doors = list()
 	var/being_cut = FALSE
 	var/explosion_block = 0 //regular airlocks are 1, blast doors are 3, higher values mean increasingly effective at blocking explosions.
 	var/obj/machinery/door/arcane_linked_door = null
+	var/arcane_teleport_chance = 100
 
 /obj/machinery/door/proc/bashed_in(mob/user)
 	playsound(src, 'sound/items/Deconstruct.ogg', 50, 1)
@@ -446,7 +447,7 @@ var/list/all_doors = list()
 /obj/machinery/door/Crossed(AM as mob|obj) //Since we can't actually quite open AS the car goes through us, we'll do the next best thing: open as the car goes into our tile.
 	if(istype(AM, /obj/structure/bed/chair/vehicle/firebird)) //Which is not 100% correct for things like windoors but it's close enough.
 		open()
-	if(arcanetampered && arcane_linked_door && !density && istype(AM,/atom/movable))
+	if(arcanetampered && arcane_linked_door && !density && istype(AM,/atom/movable) && prob(arcane_teleport_chance))
 		var/atom/movable/A = AM
 		var/turf/goodturf = arcane_linked_door.arcane_linkable()
 		if(goodturf)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Adds a var to doors to modify their arcane tamper chance to activate. Default is 100% so nothing changes for normal use. This is so admins can vv it for buses.
## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
More options for admin bus.
## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Brought the prob down to 0 and it stopped working
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Added a new option for admins to modify the arcane tamper activation chance on doors.

