### PR TITLE
supermatter can lo longer output more power than it has stored

### DIFF
--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -375,7 +375,7 @@
 		var/rads = (power / 50) * sqrt(1/(max(get_dist(l, src), 1)))
 		l.apply_radiation(rads, RAD_EXTERNAL)
 
-	power -= (power/power_loss_modifier)**3
+	power -= max(power,(power/power_loss_modifier)**3)
 
 	var/light_value = clamp(round(clamp(power / max_power, 0, 1) * max_luminosity), 0, max_luminosity)
 


### PR DESCRIPTION
[bugfix] [oldcoders]

## What this does
what the title says. this is kind of a band-aid fix on how janky shard mechanics are, though.

## Why it's good
negative power makes no sense, and further contributes to the shard acting weird when it has a lot of power

## How it was tested
went in game and verified the shard worked fine otherwise

## Changelog
:cl:
 * bugfix: The shard should no longer be able to have negative energy
