### PR TITLE
Disables Jungle Station

### DIFF
--- a/code/datums/next_map.dm
+++ b/code/datums/next_map.dm
@@ -182,6 +182,7 @@
 /datum/next_map/junglestation
 	name = "Jungle Station" //NT Colony Gamma-8 - the trve name.
 	path = "junglestation"
+	is_enabled = FALSE
 
 /datum/next_map/odyssey
 	name = "NTEV Odyssey"


### PR DESCRIPTION
Can we stop with the abandoned maps that people vote on to grief?
I can make a poll if this is required but damn

 * rscdel: Jungle has been removed from the map vote, pending actual work.
