### PR TITLE
Identifying more wood

### DIFF
--- a/code/game/gamemodes/endgame/xmas/snow.dm
+++ b/code/game/gamemodes/endgame/xmas/snow.dm
@@ -351,7 +351,7 @@ var/global/list/datum/stack_recipe/snow_recipes = list (
 	health = 50.0
 	pass_flags_self = PASSTABLE
 	var/maxhealth = 50.0
-	materialtype = /obj/item/stack/sheet/snow
+	sheet_type = /obj/item/stack/sheet/snow
 
 /obj/structure/window/barricade/snow/attackby(obj/item/W as obj, mob/user as mob)
 	if (istype(W, /obj/item/stack/sheet/snow))

--- a/code/game/machinery/ATMOSPHERICS/hvac/spaceheater.dm
+++ b/code/game/machinery/ATMOSPHERICS/hvac/spaceheater.dm
@@ -65,6 +65,7 @@
 	flags = null
 	machine_flags = null
 	is_cooktop = TRUE
+	w_type = RECYK_WOOD
 	var/lastcharge = null
 
 /obj/machinery/space_heater/campfire/stove
@@ -76,6 +77,7 @@
 	nocell = 2
 	machine_flags = WRENCHMOVE
 	is_cooktop = FALSE
+	w_type = NOT_RECYCLABLE
 
 /obj/machinery/space_heater/New()
 

--- a/code/game/machinery/doors/mineral.dm
+++ b/code/game/machinery/doors/mineral.dm
@@ -200,9 +200,10 @@
 	icon_state = "wooddoor_closed"
 	hardness = 1
 	soundeffect = 'sound/effects/doorcreaky.ogg'
+	sheet_type = /obj/item/stack/sheet/wood
 
 /obj/machinery/door/mineral/wood/Dismantle(devastated = 0)
-	var/obj/item/stack/resource = new/obj/item/stack/sheet/wood
+	var/obj/item/stack/resource = new sheet_type
 	if(!devastated)
 		resource.amount = oreAmount
 		new resource(get_turf(src))

--- a/code/game/objects/items/devices/instruments.dm
+++ b/code/game/objects/items/devices/instruments.dm
@@ -62,6 +62,7 @@
 	attack_verb = list("smashed")
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/items_lefthand.dmi', "right_hand" = 'icons/mob/in-hand/right/items_righthand.dmi')
 	instrumentId = "violin"
+	w_type = RECYK_WOOD
 
 /obj/item/device/instrument/guitar
 	name = "guitar"

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -438,13 +438,7 @@ Subject's pulse: ??? BPM"})
 		return
 	if(istype(A,/obj))
 		var/obj/O = A
-		var/its_wood = O.w_type == RECYK_WOOD || O.sheet_type == /obj/item/stack/sheet/wood
-		if(O.materials)
-			for(var/datum/material/mat in O.materials.storage)
-				if(mat.id == MAT_WOOD)
-					its_wood = TRUE
-					break
-		if(its_wood)
+		if(O.w_type == RECYK_WOOD || O.sheet_type == /obj/item/stack/sheet/wood || (O.materials?.getAmount(MAT_WOOD) > 0))
 			user.show_message("<span class='game say'><b>\The [src] beeps</b>, \"Yep, it's wood.\"</span>", MESSAGE_HEAR ,"<span class='notice'>\The [src] glows green.</span>")
 		else
 			user.show_message("<span class='game say'><b>\The [src] beeps</b>, \"No, it's not wood.\"</span>", MESSAGE_HEAR ,"<span class='notice'>\The [src] glows red.</span>")

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -438,7 +438,13 @@ Subject's pulse: ??? BPM"})
 		return
 	if(istype(A,/obj))
 		var/obj/O = A
-		if(O.w_type == RECYK_WOOD)
+		var/its_wood = O.w_type == RECYK_WOOD || O.sheet_type == /obj/item/stack/sheet/wood
+		if(O.materials)
+			for(var/datum/material/mat in O.materials.storage)
+				if(mat.id == MAT_WOOD)
+					its_wood = TRUE
+					break
+		if(its_wood)
 			user.show_message("<span class='game say'><b>\The [src] beeps</b>, \"Yep, it's wood.\"</span>", MESSAGE_HEAR ,"<span class='notice'>\The [src] glows green.</span>")
 		else
 			user.show_message("<span class='game say'><b>\The [src] beeps</b>, \"No, it's not wood.\"</span>", MESSAGE_HEAR ,"<span class='notice'>\The [src] glows red.</span>")

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -42,8 +42,9 @@
 	desc = "A small wooden shield. Its surface area is small, but it's still somewhat effective."
 	icon_state = "buckler"
 	w_class = W_CLASS_MEDIUM
+	w_type = RECYK_WOOD
 	slot_flags = 0
-	starting_materials = list()
+	starting_materials = list(MAT_WOOD = 8500)
 
 /obj/item/weapon/shield/riot/buckler/IsShield()
 	return prob(33) //Only attempt to block 1/3 of attacks

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -318,6 +318,7 @@
 	sharpness = 0
 	siemens_coefficient = 1
 	w_class = W_CLASS_MEDIUM
+	w_type = RECYK_WOOD
 	attack_verb = list("smacks")
 	var/list/blades = list(
 		"blade_1" = null,

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -16,8 +16,8 @@
 	health = 60 //Fairly strong
 	layer = ABOVE_DOOR_LAYER
 	pass_flags_self = PASSGLASS
+	sheet_type = /obj/item/stack/sheet/wood
 	var/busy = 0 //Oh god fucking do_after's
-	var/materialtype = /obj/item/stack/sheet/wood
 
 	fire_temp_threshold = 100 //Wooden barricades REALLY don't like fire
 	fire_volume_mod = 10 //They REALLY DON'T
@@ -116,7 +116,7 @@
 /obj/structure/window/barricade/Destroy(var/brokenup)
 
 	setDensity(FALSE) //Sanity while we do the rest
-	new materialtype(loc, sheetamount)
+	new sheet_type(loc, sheetamount)
 
 	..()
 

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -49,6 +49,7 @@
 	icon_state = "chest"
 	icon_opened = "chestopen"
 	icon_closed = "chest"
+	w_type = RECYK_WOOD
 
 /obj/structure/closet/crate/chest/potential_mimic/New()
 	..()

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -2,8 +2,9 @@
 	icon_state = "girder"
 	anchored = 1
 	density = 1
+	sheet_type = /obj/item/stack/sheet/metal
+	sheet_amt = 2
 	var/state = 0
-	var/material = /obj/item/stack/sheet/metal
 	var/construction_length = 40
 	pass_flags_self = PASSGIRDER
 
@@ -16,7 +17,7 @@
 				playsound(src, 'sound/weapons/heavysmash.ogg', 75, 1)
 				M.visible_message("<span class='danger'>[M] smashes through \the [src].</span>", \
 				"<span class='attack'>You smash through \the [src].</span>")
-				drop_stack(material, get_turf(src), 2)
+				drop_stack(sheet_type, get_turf(src), sheet_amt)
 				qdel(src)
 			else
 				M.visible_message("<span class='danger'>[M] smashes against \the [src].</span>", \
@@ -28,7 +29,7 @@
 /obj/structure/girder/wood
 	icon_state = "girder_wood"
 	name = "wooden girder"
-	material = /obj/item/stack/sheet/wood
+	sheet_type = /obj/item/stack/sheet/wood
 	construction_length = 20
 
 /obj/structure/girder/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
@@ -49,7 +50,7 @@
 			user.visible_message("<span class='warning'>[user] smashes through \the [src] with \the [W].</span>", \
 						"<span class='notice'>You smash through \the [src].</span>")
 			W.playtoolsound(src, 100)
-			new material(get_turf(src), 2)
+			new sheet_type(get_turf(src), sheet_amt)
 			qdel(src)
 	else
 		..()
@@ -72,7 +73,7 @@
 				if(do_after(user, src, construction_length))
 					user.visible_message("<span class='warning'>[user] dissasembles \the [src].</span>", \
 					"<span class='notice'>You dissasemble \the [src].</span>")
-					new material(get_turf(src), 2)
+					new sheet_type(get_turf(src), sheet_amt)
 					qdel(src)
 			else if(!anchored) //Unanchored, anchor it
 				if(!istype(src.loc, /turf/simulated/floor)) //Prevent from anchoring shit to shuttles / space
@@ -111,7 +112,7 @@
 		if(do_after(user, src, 30))
 			user.visible_message("<span class='warning'>[user] destroys \the [src]!</span>", \
 			"<span class='notice'>Your \the [PK] tears through the last of \the [src]!</span>")
-			new material(get_turf(src))
+			new sheet_type(get_turf(src))
 			qdel(src)
 
 	else if(W.is_screwdriver(user) && state == 2) //Unsecuring support struts, stage 2 to 1
@@ -151,7 +152,7 @@
 			state = 0
 			update_icon()
 
-	else if(istype(W, /obj/item/stack/rods) && state == 0 && material == /obj/item/stack/sheet/metal) //Inserting support struts, stage 0 to 1 (reinforced girder, replaces plasteel step)
+	else if(istype(W, /obj/item/stack/rods) && state == 0 && sheet_type == /obj/item/stack/sheet/metal) //Inserting support struts, stage 0 to 1 (reinforced girder, replaces plasteel step)
 		var/obj/item/stack/rods/R = W
 		if(R.amount < 2) //Do a first check BEFORE the user begins, in case he's using a single rod
 			to_chat(user, "<span class='warning'>You need more rods to finish the support struts.</span>")
@@ -186,7 +187,7 @@
 	else if(istype(W, /obj/item/stack/shuttle_panel))
 		if(state)
 			return
-		if(material != /obj/item/stack/sheet/metal)
+		if(sheet_type != /obj/item/stack/sheet/metal)
 			return
 		if(!anchored)
 			to_chat(user, "<span class='warning'>The girder needs to be secured first.</span>")
@@ -393,7 +394,7 @@
 			"<span class='notice'>You slice through \the [src].</span>", \
 			"<span class='warning'>You hear slicing noises.</span>")
 			playsound(src, 'sound/items/Welder2.ogg', 100, 1)
-			new material(get_turf(src), 2)
+			new sheet_type(get_turf(src), sheet_amt)
 			qdel(src)
 
 	//Wait, what, WHAT ?
@@ -581,7 +582,7 @@
 /obj/structure/girder/clockwork
 	name = "clockwork girder"
 	icon_state = "cog"
-	material = /obj/item/stack/sheet/brass
+	sheet_type = /obj/item/stack/sheet/brass
 	construction_length = 80
 
 /obj/structure/girder/clockwork/cultify()

--- a/code/game/objects/structures/noticeboard.dm
+++ b/code/game/objects/structures/noticeboard.dm
@@ -6,6 +6,8 @@
 	flags = FPRINT
 	density = 0
 	anchored = 1
+	sheet_type = /obj/item/stack/sheet/wood
+	sheet_amt = 2
 	var/notices = 0
 
 /obj/structure/noticeboard/initialize()
@@ -22,7 +24,7 @@
 	if(O.is_wrench(user))
 		to_chat(user, "<span class='notice'>You disassemble \the [src].</span>")
 		O.playtoolsound(src, 100)
-		new /obj/item/stack/sheet/wood (src.loc,2)
+		drop_stack(sheet_type,loc,sheet_amt,user)
 		qdel(src)
 	if(istype(O, /obj/item/weapon/paper))
 		if(notices < 5)

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -16,10 +16,10 @@
 	verb_rotates = TRUE
 	alt_click_rotates = TRUE
 	rotate_type = /obj/structure/railing
+	sheet_type = /obj/item/stack/sheet/metal
 	var/railingtype = "metal"
 	var/wrenchtime = 10
 	var/weldtime = 25
-	var/sheettype = /obj/item/stack/sheet/metal
 	var/hit_behind_chance = 90
 	var/wired = FALSE
 	var/wire_color = "#FFFFFF"
@@ -279,7 +279,7 @@
 		var/obj/item/stack/cable_coil/CC = new /obj/item/stack/cable_coil(get_turf(src),2)
 		CC._color = wire_color
 		CC.update_icon()
-	var/obj/item/stack/sheet/M = new sheettype(loc)
+	var/obj/item/stack/sheet/M = new sheet_type(loc)
 	M.amount = 2
 	qdel(src)
 
@@ -377,7 +377,7 @@
 	railingtype = "plasteel"
 	wrenchtime = 20
 	weldtime = 50
-	sheettype = /obj/item/stack/sheet/plasteel
+	sheet_type = /obj/item/stack/sheet/plasteel
 	health = 100
 	icon_state = "plasteelrailing0"
 	hit_behind_chance = 70
@@ -403,7 +403,7 @@
 
 /obj/structure/railing/wood
 	railingtype = "wooden"
-	sheettype = /obj/item/stack/sheet/wood
+	sheet_type = /obj/item/stack/sheet/wood
 	health = 30
 	icon_state = "woodenrailing0"
 	hit_behind_chance = 50

--- a/code/modules/clothes_making/weaving.dm
+++ b/code/modules/clothes_making/weaving.dm
@@ -18,6 +18,8 @@
 	density = 1
 	anchored = 0
 	pass_flags_self = PASSMACHINE
+	sheet_type = /obj/item/stack/sheet/wood
+	sheet_amt = 10
 
 	var/remaining_cloth_to_spin = 0
 	var/mob/spinner = null
@@ -62,7 +64,7 @@
 			user.visible_message("<span class='warning'>[user] dissasembles \the [src].</span>", \
 			"<span class='notice'>You dissasemble \the [src].</span>")
 			var/turf/T = get_turf(src)
-			new /obj/item/stack/sheet/wood(T, 10)
+			drop_stack(sheet_type,loc,sheet_amt,user)
 			for (var/i = 1 to round(remaining_cloth_to_spin/CLOTH_PER_FLAX))
 				new /obj/item/weapon/reagent_containers/food/snacks/grown/flax(T)
 			qdel(src)

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -113,6 +113,7 @@
 	name = "sandals"
 	icon_state = "wizard"
 	species_fit = list(VOX_SHAPED)
+	w_type = RECYK_WOOD
 
 	wizard_garb = 1
 

--- a/code/modules/fissionreactor/objects_external.dm
+++ b/code/modules/fissionreactor/objects_external.dm
@@ -36,7 +36,7 @@ included:
 	loc=origloc
 	for(var/obj/machinery/atmospherics/unary/fissionreactor_coolantport/part in range(src,1) )
 		loc=null
-		part.update_icon()			
+		part.update_icon()
 	..()
 
 /obj/machinery/atmospherics/unary/fissionreactor_coolantport/examine()
@@ -63,7 +63,7 @@ included:
 			newcase.state=3
 			newcase.update_icon()
 			qdel(src)
-			
+
 /obj/machinery/atmospherics/unary/fissionreactor_coolantport/update_icon()
 	var/dirs=0
 	overlays=list()
@@ -75,7 +75,7 @@ included:
 		dirs|=EAST
 	if(  locate(/obj/structure/fission_reactor_case) in get_step(src, WEST) )
 		dirs|=WEST
-		
+
 	if(  locate(/obj/machinery/atmospherics/unary/fissionreactor_coolantport) in get_step(src, NORTH) )
 		dirs|=NORTH
 	if(  locate(/obj/machinery/atmospherics/unary/fissionreactor_coolantport) in get_step(src, SOUTH) )
@@ -83,8 +83,8 @@ included:
 	if(  locate(/obj/machinery/atmospherics/unary/fissionreactor_coolantport) in get_step(src, EAST) )
 		dirs|=EAST
 	if(  locate(/obj/machinery/atmospherics/unary/fissionreactor_coolantport) in get_step(src, WEST) )
-		dirs|=WEST	
-		
+		dirs|=WEST
+
 	if(  locate(/obj/machinery/fissioncontroller) in get_step(src, NORTH) )
 		dirs|=NORTH
 	if(  locate(/obj/machinery/fissioncontroller) in get_step(src, SOUTH) )
@@ -92,9 +92,9 @@ included:
 	if(  locate(/obj/machinery/fissioncontroller) in get_step(src, EAST) )
 		dirs|=EAST
 	if(  locate(/obj/machinery/fissioncontroller) in get_step(src, WEST) )
-		dirs|=WEST	
-		
-	overlays+=image(icon, src,"coonantpipeoverlay")	
+		dirs|=WEST
+
+	overlays+=image(icon, src,"coonantpipeoverlay")
 	icon_state="case_[dirs]"
 
 /obj/machinery/atmospherics/unary/fissionreactor_coolantport/New()
@@ -107,21 +107,21 @@ included:
 	for(var/obj/structure/fission_reactor_case/part in range(src,1) )
 		part.update_icon()
 	for(var/obj/machinery/atmospherics/unary/fissionreactor_coolantport/part in range(src,1) )
-		part.update_icon()	
-		
+		part.update_icon()
+
 /obj/machinery/atmospherics/unary/fissionreactor_coolantport/proc/transfer_reactor() //transfer coolant from/to the reactor
 	if(!associated_reactor)
 		return
 	var/pressure_coolant=air_contents.pressure
 	var/pressure_reactor=associated_reactor.coolant.pressure
-	
+
 	var/pdiff=pressure_reactor-pressure_coolant
 	if (pdiff<0) //flowing external->reactor
-		pdiff*=-1 
+		pdiff*=-1
 		pdiff*=associated_reactor.coolant_input_amt
 		var/molestotransfer=  pdiff*air_contents.volume/(R_IDEAL_GAS_EQUATION*air_contents.temperature)
 		var/datum/gas_mixture/nu_mix=air_contents.remove(molestotransfer *0.5) //we multiply by 1/2 because if we transfer the whole difference, then it'll just swap between the 2 bodies forever.
-		associated_reactor.coolant.merge(nu_mix) 
+		associated_reactor.coolant.merge(nu_mix)
 		//air_contents.update=1
 		if(network)
 			network.update=1
@@ -132,8 +132,8 @@ included:
 		if(network)
 			network.update=1
 		//air_contents.update=1
-		
-		
+
+
 /obj/machinery/atmospherics/unary/fissionreactor_coolantport/ex_act(var/severity, var/child=null, var/mob/whodunnit)
 	switch(severity)
 		if(1) //dev
@@ -144,8 +144,8 @@ included:
 				qdel(src)
 		if(3) //light
 			return
-	
-	
+
+
 
 
 /obj/machinery/fissioncontroller
@@ -193,9 +193,9 @@ included:
 	temperature_history=tl
 	for(var/i=1, i<=max_temp_history,i++)
 		temperature_history[i]=20.0 //default it to 20K at all points
-	
+
 	interface=new /datum/html_interface(src,"Fission reactor controller",500,290,"<link rel='stylesheet' href='fission.css'>")
-	
+
 	for(var/datum/fission_reactor_holder/r in fissionreactorlist)
 		if(r.turf_in_reactor(src.loc))
 			if(r.adopt_part(src))
@@ -204,9 +204,9 @@ included:
 	for(var/obj/structure/fission_reactor_case/part in range(src,1) )
 		part.update_icon()
 	for(var/obj/machinery/atmospherics/unary/fissionreactor_coolantport/part in range(src,1) )
-		part.update_icon()	
-				
-				
+		part.update_icon()
+
+
 /obj/machinery/fissioncontroller/Destroy()
 	if(currentfuelrod)
 		currentfuelrod.forceMove(loc)
@@ -224,14 +224,14 @@ included:
 /obj/machinery/fissioncontroller/forceMove(atom/destination, step_x = 0, step_y = 0, no_tp = FALSE, harderforce = FALSE, glide_size_override = 0)
 	if(!associated_reactor) //no need to transfer ownership if there's no reactor in the first place
 		return ..()
-	
+
 	spawn() //delay proc to fire last.
 		var/datum/fission_reactor_holder/newholder= new /datum/fission_reactor_holder()
 		var/datum/fission_reactor_holder/oldholder=associated_reactor
-		
+
 		oldholder.copy_data(newholder)
 		oldholder.transfer_part_ownership(newholder)
-		
+
 		qdel(oldholder) //set our reactor to the new one.
 		..()
 		newholder.zlevel=src.z
@@ -276,7 +276,7 @@ included:
 				associated_reactor?.fuel=null
 
 			return
-				
+
 		user.visible_message("<span class='notice'>[user] starts prying the fuel reservoir out of \the [src].</span>", "<span class='notice'>You start prying the fuel reservoir out of \the [src].</span>")
 		playsound(src,'sound/items/crowbar.ogg',50)
 		if(do_after(user, src,20) && currentfuelrod)
@@ -287,7 +287,7 @@ included:
 				associated_reactor.fuel=null
 		return
 
-	
+
 	if(iswelder(I))
 		if(associated_reactor && associated_reactor.considered_on())
 			if(user.a_intent==I_HELP)
@@ -308,9 +308,9 @@ included:
 			newframe.components+=new /obj/item/weapon/stock_parts/matter_bin
 			newframe.components+=new /obj/item/weapon/stock_parts/scanning_module
 			qdel(src)
-		return	
+		return
 	..()
-		
+
 
 /obj/machinery/fissioncontroller/attack_hand(mob/user)
 	if(..())
@@ -347,12 +347,12 @@ included:
 	var/aychteeemel_string=""
 	if(!associated_reactor)
 		interface.updateLayout("<h1>NO REACTOR</h1>")
-		return 
-	
+		return
+
 	if(isinoptionsmenu)
 		aychteeemel_string={"
 <a href='?src=\ref[interface];set_set_men=0'>\[BACK\]</a><br><br>
-		
+
 AUTOSCRAM<br>
 
 <a [can_autoscram ?"" :"class='blocked'"] href='?src=\ref[interface];set_autoscram=0'>\[DISABLED\]</a>&nbsp;
@@ -390,7 +390,7 @@ CRITICAL<br>
 
 		"}
 	else
-	
+
 		var/fuelusepercent=associated_reactor.fuel? floor(associated_reactor.fuel.life*100+0.5) : 0
 		var/estimatedtimeleft =""
 		if(associated_reactor.fuel)
@@ -408,7 +408,7 @@ CRITICAL<br>
 				var/mins=floor(secs/60)
 				secs%=60
 				estimatedtimeleft="[mins]m [secs]s"
-		else	
+		else
 			estimatedtimeleft="None"
 
 		var/rodtargettpercent= floor(associated_reactor.control_rod_target*100+0.5)
@@ -424,14 +424,14 @@ CRITICAL<br>
 			status="<span class='status_done'>Depleted</span>"
 		else if (!associated_reactor.considered_on())
 			status="<span class='status_halt'>Standby</span>"
-	
+
 		var/coretemppercent= associated_reactor.temperature / FISSIONREACTOR_MELTDOWNTEMP
 		coretemppercent=max(min(coretemppercent,1),0)
 		coretemppercent=floor(coretemppercent*100+0.5)
 		var/coolanttemppercent=associated_reactor.coolant.temperature / FISSIONREACTOR_MELTDOWNTEMP
 		coolanttemppercent=max(min(coolanttemppercent,1),0)
 		coolanttemppercent=floor(coolanttemppercent*100+0.5)
-	
+
 		var/reactivity=associated_reactor.fuel_rods.len*((associated_reactor.fuel_reactivity) - ( (associated_reactor.fuel_reactivity-associated_reactor.fuel_reactivity_with_rods)*associated_reactor.control_rod_insertion))
 		var/thermaloutput=0
 		if(associated_reactor.fuel)
@@ -439,7 +439,7 @@ CRITICAL<br>
 		reactivity=floor(reactivity*100+0.5)
 		var/speed=associated_reactor.fuel_rods.len - (associated_reactor.fuel_rods_affected_by_rods*associated_reactor.control_rod_insertion)
 		speed=floor(speed*100+0.5)
-	
+
 		if (thermaloutput>=1000000000)
 			thermaloutput="[round(thermaloutput/1000000000,0.1)] GW" //if you accomplish this then good job
 		else if (thermaloutput>=1000000)
@@ -448,7 +448,7 @@ CRITICAL<br>
 			thermaloutput="[round(thermaloutput/1000,0.1)] kW"
 		else
 			thermaloutput="[round(thermaloutput,0.1)] W"
-		
+
 
 		var/highesttemp=0.0
 		var/graphstring=""
@@ -457,9 +457,9 @@ CRITICAL<br>
 			var y=(1.0-( (temperature_history[i] || 20.0) /FISSIONREACTOR_MELTDOWNTEMP))*100
 			var x=(1.0-((i-1)/(temperature_history.len-1)))*350
 			graphstring+=i==1 ? "M[x] [y]" : "L[x] [y]"
-	
-	
-	
+
+
+
 		var/coolant_tempdisplay="[floor(associated_reactor.coolant.temperature)][emagged ? "°" : ""]K"
 		var/reactor_tempdisplay="[floor(associated_reactor.temperature)][emagged ? "°" : ""]K"
 		var/reactor_highesttempdisplay="[floor(highesttemp)][emagged ? "°" : ""]K"
@@ -475,24 +475,24 @@ CRITICAL<br>
 			coolant_tempdisplay="[floor(1.8*associated_reactor.coolant.temperature)][emagged ? "°" : ""]R"
 			reactor_tempdisplay="[floor(1.8*associated_reactor.temperature)][emagged ? "°" : ""]R"
 			reactor_highesttempdisplay="[floor(1.8*highesttemp)][emagged ? "°" : ""]R"
-		
-	
+
+
 		aychteeemel_string={"<table style='border-collapse:initial;'>
 <tr><td style='vertical-align:top;'>
 
 <div style='width:350px;'>
 <div>
 <svg id='TempGraph' width=350 height=100>
-	
+
 
 	<path d='M0 82 L350 82' style='stroke:#077;'/>
 	<path d='M0 18 L350 18' style='stroke:#700;'/>
-	
-	
+
+
 	<path d='M0 [100*(1-highesttemp/FISSIONREACTOR_MELTDOWNTEMP)] L350 [100*(1-highesttemp/FISSIONREACTOR_MELTDOWNTEMP)]' style='stroke:#770;'> </path>
-	
+
 	<path d='[graphstring]'> </path>
-	
+
 	<path d='M0 0 L350 0 L350 100 L0 100 Z' style='stroke:#777;stroke-width:4px;'/>
 </svg>
 </div>
@@ -535,7 +535,7 @@ CRITICAL<br>
 <svg id='ControlRods' width=100 height=200>
 	<rect x='28' y='0' width='43' height='[associated_reactor.control_rod_target*200]' fill='#070'/>
 	<rect x='33' y='0' width='33' height='[associated_reactor.control_rod_insertion*200]' fill='#0f0'/>
-	
+
 	<path d='M0 0 L100 0 L100 200 L0 200 Z' style='stroke:#777;stroke-width:4px;'/>
 </svg>
 </div>
@@ -552,9 +552,9 @@ CRITICAL<br>
 
 </td></tr>
 </table>"}
-	
+
 	interface.updateLayout(aychteeemel_string)
-	
+
 
 /obj/machinery/fissioncontroller/update_icon()
 	overlays=null
@@ -567,7 +567,7 @@ CRITICAL<br>
 		dirs|=EAST
 	if(  locate(/obj/structure/fission_reactor_case) in get_step(src, WEST) )
 		dirs|=WEST
-		
+
 	if(  locate(/obj/machinery/atmospherics/unary/fissionreactor_coolantport) in get_step(src, NORTH) )
 		dirs|=NORTH
 	if(  locate(/obj/machinery/atmospherics/unary/fissionreactor_coolantport) in get_step(src, SOUTH) )
@@ -575,8 +575,8 @@ CRITICAL<br>
 	if(  locate(/obj/machinery/atmospherics/unary/fissionreactor_coolantport) in get_step(src, EAST) )
 		dirs|=EAST
 	if(  locate(/obj/machinery/atmospherics/unary/fissionreactor_coolantport) in get_step(src, WEST) )
-		dirs|=WEST	
-		
+		dirs|=WEST
+
 	if(  locate(/obj/machinery/fissioncontroller) in get_step(src, NORTH) )
 		dirs|=NORTH
 	if(  locate(/obj/machinery/fissioncontroller) in get_step(src, SOUTH) )
@@ -584,10 +584,10 @@ CRITICAL<br>
 	if(  locate(/obj/machinery/fissioncontroller) in get_step(src, EAST) )
 		dirs|=EAST
 	if(  locate(/obj/machinery/fissioncontroller) in get_step(src, WEST) )
-		dirs|=WEST	
-		
+		dirs|=WEST
+
 	icon_state="case_[dirs]"
-	
+
 
 
 
@@ -617,17 +617,17 @@ CRITICAL<br>
 	if(stat & BROKEN)
 		to_chat(usr, "The screen is broken. You should fix it soon.")
 		return
-	
+
 	if(!associated_reactor)
 		to_chat(usr, "The readouts indicate there's no linked reactor.")
 		return
 
 	if(associated_reactor.SCRAM)
 		to_chat(usr, "<span class='warning'>The readouts indicate that the SCRAM protocol has been activated.</span>")
-	
+
 	if(associated_reactor.temperature>=FISSIONREACTOR_DANGERTEMP)
 		to_chat(usr, "<span class='warning'>The readouts indicate that the reactor is overheated, and that you should cool it down.</span>")
-	
+
 	if(!associated_reactor.fuel)
 		to_chat(usr, "The readouts indicate there's no fuel reservoir inserted.")
 	else
@@ -651,14 +651,14 @@ CRITICAL<br>
 		if(C.mob && get_dist(C.mob.loc,src.loc)<=1)
 			interface.show( interface._getClient(interface.clients[C]) ) //"There's probably shenanigans" - dilt. yes there are.
 		else
-			interface.hide(interface._getClient(interface.clients[C]))	
+			interface.hide(interface._getClient(interface.clients[C]))
 	lastupdatetick=world.time
 
 /obj/machinery/fissioncontroller/proc/add_history_temp(var/temp=20.0)
 	temperature_history.Insert(1,temp)
 	temperature_history.len=max_temp_history
-	
-	
+
+
 /obj/machinery/fissioncontroller/proc/speakandsay(var/msg,var/level=1)
 	if(level==0) //i have no mouth
 		return
@@ -684,18 +684,18 @@ CRITICAL<br>
 		S.speaker=src
 		Broadcast_Message(S,0,0,0,list(src.z))
 		qdel(S)
-	
-	
+
+
 /obj/machinery/fissioncontroller/process()
 	update_icon()
 	if(!associated_reactor) //no reactor? no processing to be done.
 		add_history_temp()
-		return	
-		
-	ask_remakeUI(TRUE)
-		
+		return
 
-	
+	ask_remakeUI(TRUE)
+
+
+
 	associated_reactor.update_all_icos()
 	if(!powered()) //with my last breath, i curse zoidberg!
 		if(!poweroutagemsg)
@@ -704,11 +704,11 @@ CRITICAL<br>
 				speakandsay("Reactor lost power, engaging SCRAM.",talkmode_critical)
 				playsound(src,'sound/machines/fission/rc_scram.ogg',50)
 				associated_reactor.SCRAM=TRUE
-		add_history_temp()		
+		add_history_temp()
 		return
 	else
 		poweroutagemsg=FALSE
-	
+
 	add_history_temp(associated_reactor.temperature)
 
 
@@ -719,13 +719,13 @@ CRITICAL<br>
 		fueldepletedmsg=TRUE
 	else
 		fueldepletedmsg=FALSE
-	
-	
+
+
 	if(associated_reactor.temperature>=FISSIONREACTOR_DANGERTEMP && can_autoscram && !associated_reactor.SCRAM )
 		speakandsay("critical temperature reached, engaging SCRAM.",talkmode_critical)
 		playsound(src,'sound/machines/fission/rc_scram.ogg',50)
 		associated_reactor.SCRAM=TRUE
-	
+
 	if(associated_reactor.temperature>=FISSIONREACTOR_DANGERTEMP && associated_reactor.temperature>lasttempnag )
 		if(associated_reactor.temperature>=FISSIONREACTOR_MELTDOWNTEMP)
 			speakandsay("Reactor at critical temperature: [associated_reactor.temperature]K. Evacuate immediately.",talkmode_critical)
@@ -735,12 +735,12 @@ CRITICAL<br>
 			playsound(src,'sound/machines/fission/rc_alert.ogg',50)
 
 	lasttempnag=associated_reactor.temperature
-	
+
 	if(associated_reactor.fuel?.life<=0) //no fuel or depleated? no reactions to be done.
 		return
 
 
-/obj/machinery/fissioncontroller/Topic(var/href, var/list/href_list , var/datum/html_interface_client/hclient )	
+/obj/machinery/fissioncontroller/Topic(var/href, var/list/href_list , var/datum/html_interface_client/hclient )
 	if(!associated_reactor)
 		return
 	if(!powered())
@@ -759,7 +759,7 @@ CRITICAL<br>
 		if(!is_in_range(usr))
 			to_chat(usr, "<span class='warning'>WARNING: Connection failure. Reduce range.</span>")
 			return 1
-	
+
 	switch(href_list["action"])
 		if("SCRAM")
 			if(!associated_reactor.SCRAM)
@@ -779,12 +779,12 @@ CRITICAL<br>
 				to_chat(hclient.client, "The reactor safety locks prevent the fuel reservoir from being ejected!")
 				return
 			currentfuelrod.forceMove(src.loc)
-			currentfuelrod=null	
+			currentfuelrod=null
 			associated_reactor.fuel=null
-		if("swap_tempunit")	
+		if("swap_tempunit")
 			tempdisplaymode++
 			tempdisplaymode%=4
-		if("swap_gasunit")		
+		if("swap_gasunit")
 			displaycoolantinmoles=!displaycoolantinmoles
 		if("setdelta_5")
 			roddelta=5
@@ -826,7 +826,7 @@ CRITICAL<br>
 		if(associated_reactor?.SCRAM)
 			playsound(src,'sound/machines/fission/rc_scram.ogg',50)
 		associated_reactor?.SCRAM=FALSE
-	
+
 	ask_remakeUI() //update it so that changes appear NOW.
 
 
@@ -858,8 +858,8 @@ CRITICAL<br>
 	for(var/obj/structure/fission_reactor_case/part in range(src,1) )
 		part.update_icon()
 	for(var/obj/machinery/atmospherics/unary/fissionreactor_coolantport/part in range(src,1) )
-		part.update_icon()	
-	
+		part.update_icon()
+
 /obj/structure/fission_reactor_case/Destroy()
 	if(associated_reactor)
 		associated_reactor.handledestruction(src)
@@ -870,10 +870,10 @@ CRITICAL<br>
 	loc=origloc
 	for(var/obj/machinery/atmospherics/unary/fissionreactor_coolantport/part in range(src,1) )
 		loc=null
-		part.update_icon()	
+		part.update_icon()
 	..()
 
-	
+
 /obj/structure/fission_reactor_case/update_icon()
 	var/dirs=0
 	if(  locate(/obj/structure/fission_reactor_case) in get_step(src, NORTH) )
@@ -884,7 +884,7 @@ CRITICAL<br>
 		dirs|=EAST
 	if(  locate(/obj/structure/fission_reactor_case) in get_step(src, WEST) )
 		dirs|=WEST
-		
+
 	if(  locate(/obj/machinery/atmospherics/unary/fissionreactor_coolantport) in get_step(src, NORTH) )
 		dirs|=NORTH
 	if(  locate(/obj/machinery/atmospherics/unary/fissionreactor_coolantport) in get_step(src, SOUTH) )
@@ -892,8 +892,8 @@ CRITICAL<br>
 	if(  locate(/obj/machinery/atmospherics/unary/fissionreactor_coolantport) in get_step(src, EAST) )
 		dirs|=EAST
 	if(  locate(/obj/machinery/atmospherics/unary/fissionreactor_coolantport) in get_step(src, WEST) )
-		dirs|=WEST	
-		
+		dirs|=WEST
+
 	if(  locate(/obj/machinery/fissioncontroller) in get_step(src, NORTH) )
 		dirs|=NORTH
 	if(  locate(/obj/machinery/fissioncontroller) in get_step(src, SOUTH) )
@@ -901,10 +901,10 @@ CRITICAL<br>
 	if(  locate(/obj/machinery/fissioncontroller) in get_step(src, EAST) )
 		dirs|=EAST
 	if(  locate(/obj/machinery/fissioncontroller) in get_step(src, WEST) )
-		dirs|=WEST	
-		
+		dirs|=WEST
+
 	icon_state="case_[dirs]"
-	
+
 /obj/structure/fission_reactor_case/examine()
 	..()
 	if(associated_reactor?.considered_on())
@@ -944,17 +944,17 @@ CRITICAL<br>
 
 /obj/structure/girder/reactor
 	name="reactor casing girder"
-	material=/obj/item/stack/sheet/plasteel
+	sheet_type=/obj/item/stack/sheet/plasteel
 	construction_length=40
 	var/pipeadded=FALSE
 
 
-/obj/structure/girder/reactor/update_icon()	
+/obj/structure/girder/reactor/update_icon()
 	icon_state = state>=2 ? "reinforced" : "girder"
 	overlays=null
 	if(pipeadded)
-		overlays+=image('icons/obj/fissionreactor/reactorcase.dmi', src,"coonantpipeoverlay")	
-	
+		overlays+=image('icons/obj/fissionreactor/reactorcase.dmi', src,"coonantpipeoverlay")
+
 /obj/structure/girder/reactor/examine()
 	..()
 	switch(state)
@@ -994,7 +994,7 @@ CRITICAL<br>
 				if (dir&WEST)
 					dirstr="west"
 				to_chat(usr,"There's piping installed, it's facing [dirstr].")
-			
+
 /obj/structure/girder/reactor/attackby(obj/item/W as obj, mob/user as mob) //this proc uses a lot of weird checks that will probably break with the multiple construction steps, so lets just use our own override. (it's also just messy in general and hard to follow)
 	switch(state)
 		if(0) // fresh built frame
@@ -1023,12 +1023,12 @@ CRITICAL<br>
 					if(state!=0)
 						return
 					user.visible_message("<span class='warning'>[user] dissasembles \the [src].</span>", "<span class='notice'>You dissasemble \the [src].</span>")
-					new material(get_turf(src), 3)
+					new sheet_type(get_turf(src), 3)
 					qdel(src)
 				return
 			to_chat(user, "<span class='notice'>You can't find a use for \the [W]</span>")
 			return
-					
+
 		if(1) // added rods
 			if(W.is_screwdriver(user)) //fasten the rods
 				W.playtoolsound(src, 100)
@@ -1089,20 +1089,20 @@ CRITICAL<br>
 				return
 			if(istype(W, /obj/item/pipe ))
 				if(pipeadded)
-					to_chat(user, "<span class='notice'>There's already a piping added!</span>")	
+					to_chat(user, "<span class='notice'>There's already a piping added!</span>")
 					return
 				var/obj/item/pipe/P = W
 				if(P.pipe_type!=0)
-					to_chat(user, "<span class='notice'>This isn't the right pipe to use!</span>")	
+					to_chat(user, "<span class='notice'>This isn't the right pipe to use!</span>")
 					return
 				qdel(W)
 				pipeadded=TRUE
-				overlays+=image('icons/obj/fissionreactor/reactorcase.dmi', src,"coonantpipeoverlay")	
-				user.visible_message("<span class='notice'>[user] adds piping into \the [src].</span>", "<span class='notice'>You add piping into \the [src].</span>")	
+				overlays+=image('icons/obj/fissionreactor/reactorcase.dmi', src,"coonantpipeoverlay")
+				user.visible_message("<span class='notice'>[user] adds piping into \the [src].</span>", "<span class='notice'>You add piping into \the [src].</span>")
 				return
 			if(pipeadded && W.is_wrench(user))
-				W.playtoolsound(src, 100)	
-				to_chat(user, "<span class='notice'>You remove the piping from \the [src]</span>")	
+				W.playtoolsound(src, 100)
+				to_chat(user, "<span class='notice'>You remove the piping from \the [src]</span>")
 				var/obj/item/pipe/np= new /obj/item/pipe(loc)
 				np.pipe_type=0
 				np.forceMove(loc)
@@ -1124,9 +1124,9 @@ CRITICAL<br>
 				else if(dir&WEST)
 					dir=NORTH
 					nds="north"
-				to_chat(user, "<span class='notice'>You turn \the [src]'s piping. It is now facing [nds]</span>")	
+				to_chat(user, "<span class='notice'>You turn \the [src]'s piping. It is now facing [nds]</span>")
 				return
-			to_chat(user, "<span class='notice'>You can't find a use for \the [W]</span>")	
+			to_chat(user, "<span class='notice'>You can't find a use for \the [W]</span>")
 			return
 		if(3) // plating added
 			if(iswelder(W))
@@ -1139,7 +1139,7 @@ CRITICAL<br>
 					if(state!=3)
 						return
 					user.visible_message("<span class='notice'>[user] welds the external plating to \the [src]'s frame.</span>", "<span class='notice'>You weld the external plating to \the [src]'s frame.</span>")
-					
+
 					if(!pipeadded)
 						var/obj/structure/fission_reactor_case/newcase= new /obj/structure/fission_reactor_case(loc)
 						newcase.forceMove(loc)
@@ -1164,10 +1164,10 @@ CRITICAL<br>
 					user.visible_message("<span class='warning'>[user] pries the external plating off \the [src].</span>", "<span class='notice'>You pry the external plating off the \the [src].</span>")
 					add_hiddenprint(user)
 					add_fingerprint(user)
-					new material(get_turf(src), 2)
+					new sheet_type(get_turf(src), 2)
 					state--
-				return	
-			if(W.is_wrench(user))	
+				return
+			if(W.is_wrench(user))
 				W.playtoolsound(src, 100)
 				user.visible_message("<span class='warning'>[user] starts [anchored?"un":""]bolting \the [src] [anchored?"from":"to"] the floor.</span>", "<span class='notice'>You start [anchored?"un":""]bolting \the [src] [anchored?"from":"to"] the floor.</span>")
 				if(do_after(user, src, construction_length))

--- a/code/modules/food/cooking_machines.dm
+++ b/code/modules/food/cooking_machines.dm
@@ -772,6 +772,7 @@ var/global/ingredientLimit = 10
 	cooks_in_reagents = 0
 	machine_flags = null
 	is_cooktop = FALSE
+	w_type = RECYK_WOOD
 
 /obj/machinery/cooking/grill/spit/cook()
 	ingredient.pixel_y += 7 * PIXEL_MULTIPLIER

--- a/code/modules/food/customizables.dm
+++ b/code/modules/food/customizables.dm
@@ -311,6 +311,7 @@
 	icon_state = "soup"
 	item_state = "bowl"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/newsprites_lefthand.dmi', "right_hand" = 'icons/mob/in-hand/right/newsprites_righthand.dmi')
+	w_type = RECYK_WOOD
 
 /obj/item/trash/bowl/attackby(obj/item/I,mob/user,params)
 	if(istype(I,/obj/item/stack/sheet/metal))

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -741,6 +741,7 @@
 	desc = "Originally used to store liquids & powder. It is now used as a source of comfort. This one is made of wood."
 	health = 30
 	is_cooktop = FALSE
+	w_type = RECYK_WOOD
 
 /////////////////////Cooking stuff
 


### PR DESCRIPTION
[bugfix][consistency][hotfix]

## What this does
Closes #39331.
Also removes various redundant variables that work like sheet_type, plus converts sheet dropping to use this on relevant wooden items for varediting fun while fixing this.

## How it was tested
Scanning the requested items with the wood analyzer.
Dismantling items with variables previously nonexistant or redundant to sheet_type.

## Changelog
:cl:
 * bugfix: Wood analyzers are now much better at identifying wood.