### PR TITLE
crate weighing machine description update

### DIFF
--- a/code/datums/cargo_forwarding.dm
+++ b/code/datums/cargo_forwarding.dm
@@ -156,7 +156,7 @@
 
 /obj/machinery/crate_weigher
 	name = "crate weigher"
-	desc = "Weighs crates, and adds relevant info to a shipping manifest. There is a slot on it for inserting a shipping manifest, which will have the weight printed on it should a crate be weighed."
+	desc = "Weighs crates, and adds relevant info to a shipping manifest."
 	icon = 'icons/obj/machines/crate_weigher.dmi'
 	icon_state = "up"
 	layer = OPEN_DOOR_LAYER // Below the crates
@@ -267,6 +267,13 @@
 	if(C.locked_to || C.is_locking())
 		return
 	C.Move(loc)
+
+/obj/machinery/crate_weigher/examine(mob/user)
+	..()
+	if(current_manifest)
+		to_chat(user, "<span class='notice'>There is a manifest currently inserted.</span>")
+		return
+	to_chat(user, "<span class='notice'>There is a slot available for a manifest to be inserted.</span>")
 
 /obj/machinery/crate_weigher/proc/remove_crate()
 	current_crate = null

--- a/code/datums/cargo_forwarding.dm
+++ b/code/datums/cargo_forwarding.dm
@@ -156,7 +156,7 @@
 
 /obj/machinery/crate_weigher
 	name = "crate weigher"
-	desc = "Weighs crates, and adds relevant info to a shipping manifest."
+	desc = "Weighs crates, and adds relevant info to a shipping manifest. There is a slot on it for inserting a shipping manifest, which will have the weight printed on it should a crate be weighed."
 	icon = 'icons/obj/machines/crate_weigher.dmi'
 	icon_state = "up"
 	layer = OPEN_DOOR_LAYER // Below the crates


### PR DESCRIPTION
## What this does
Updates the crate weighing machine's description for in-game tutorialising

## Why it's good
I spent a good few rounds wondering how to use this thing without wanting to resort to the wiki. Figured in-game information is better than wiki trawling.

## How it was tested
right-click -> examine

## Changelog
Incredibly minor change, shouldn't require a changelog, but if so, I'll uncomment the changelog 
<!-- :cl:
 * tweak: Changes the description on the crate weigher to better inform new technicians how it works.
 --!>
