### PR TITLE
Syringes Deflected by Armor Break Instead of Delete

### DIFF
--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -307,9 +307,8 @@
 
 		if (deflected)
 			user.visible_message("<span class='danger'>[user] tries to stab [user == target ? get_reflexive_pronoun(user.gender) : target] in \the [hit_area] with \the [src], but the attack is deflected by armor!</span>", "<span class='danger'>You try to stab [user == target ? "yourself" : "\the [target]"] in \the [hit_area] with \the [src], but the attack is deflected by armor!</span>")
-			user.u_equip(src, 1)
-			qdel(src)
-			return // Avoid the transfer since we're using qdel
+			break_needle(target, user)
+			return // Avoid the transfer
 		else
 			user.visible_message("<span class='danger'>[user] stabs [user == target ? get_reflexive_pronoun(user.gender) : target] in \the [hit_area] with \the [src]!</span>", "<span class='danger'>You stab [user == target ? "yourself" : "\the [target]"] in \the [hit_area] with \the [src]!</span>")
 			affecting.take_damage(3)
@@ -322,11 +321,16 @@
 		var/syringestab_amount_transferred = max(rand(min(reagents.total_volume, 2), (reagents.total_volume - 5)), 0) //nerfed by popular demand.
 		src.reagents.reaction(target, INGEST, amount_override = min(reagents.total_volume,syringestab_amount_transferred)/(reagents.reagent_list.len))
 		src.reagents.trans_to(target, syringestab_amount_transferred)
-	src.desc += " It is broken."
-	src.mode = SYRINGE_BROKEN
-	src.add_blood(target)
-	src.add_fingerprint(usr)
-	src.update_icon()
+	break_needle(target, user)
+
+/obj/item/weapon/reagent_containers/syringe/proc/break_needle(mob/living/carbon/target as mob, mob/living/carbon/user as mob)
+	desc += " It is broken."
+	mode = SYRINGE_BROKEN
+	if(target)
+		add_blood(target)
+	if(user)
+		add_fingerprint(user)
+	update_icon()
 
 /obj/item/weapon/reagent_containers/syringe/restock(nanobots = FALSE)
 	if(mode == 2) //SYRINGE_BROKEN

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -307,7 +307,8 @@
 
 		if (deflected)
 			user.visible_message("<span class='danger'>[user] tries to stab [user == target ? get_reflexive_pronoun(user.gender) : target] in \the [hit_area] with \the [src], but the attack is deflected by armor!</span>", "<span class='danger'>You try to stab [user == target ? "yourself" : "\the [target]"] in \the [hit_area] with \the [src], but the attack is deflected by armor!</span>")
-			break_needle(target, user)
+			break_needle()
+			add_fingerprint(user)
 			return // Avoid the transfer
 		else
 			user.visible_message("<span class='danger'>[user] stabs [user == target ? get_reflexive_pronoun(user.gender) : target] in \the [hit_area] with \the [src]!</span>", "<span class='danger'>You stab [user == target ? "yourself" : "\the [target]"] in \the [hit_area] with \the [src]!</span>")
@@ -321,15 +322,13 @@
 		var/syringestab_amount_transferred = max(rand(min(reagents.total_volume, 2), (reagents.total_volume - 5)), 0) //nerfed by popular demand.
 		src.reagents.reaction(target, INGEST, amount_override = min(reagents.total_volume,syringestab_amount_transferred)/(reagents.reagent_list.len))
 		src.reagents.trans_to(target, syringestab_amount_transferred)
-	break_needle(target, user)
+	break_needle()
+	add_blood(target)
+	add_fingerprint(user)
 
-/obj/item/weapon/reagent_containers/syringe/proc/break_needle(mob/living/carbon/target as mob, mob/living/carbon/user as mob)
+/obj/item/weapon/reagent_containers/syringe/proc/break_needle()
 	desc += " It is broken."
 	mode = SYRINGE_BROKEN
-	if(target)
-		add_blood(target)
-	if(user)
-		add_fingerprint(user)
 	update_icon()
 
 /obj/item/weapon/reagent_containers/syringe/restock(nanobots = FALSE)


### PR DESCRIPTION
## What this does
This PR changes syringe behavior such that if it's deflected by armor, it simply breaks instead of permanently deleting itself. It also changes how syringes breaking is handled on the backend, such that it can be called with a proc.

## Why it's good
Because it stops borg syringes from *hard deleting* and staying in the contents list of a borg for at least a minute when they are used in a bad way, it's good! And also more evidence for the detective to find in case of violent syringe-related crimes.

## How it was tested
<img width="419" height="352" alt="image" src="https://github.com/user-attachments/assets/0fbe495c-6903-4406-8003-cb8b7cee9d4c" />

Spawned as CMO, made a bunch of testmans, stabbed with syringes, saw deflection and non-deflection. Borged myself, tested with syringe, used recharge station to fix syringe.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Syringes deflected by armor now break instead of delete themselves.