### PR TITLE
optimizes jungle animals

### DIFF
--- a/code/game/objects/misc_weapons.dm
+++ b/code/game/objects/misc_weapons.dm
@@ -605,11 +605,6 @@ var/list/available_redphone_names3 = list("1","2","3","4","5","6","7","8","9")
 					trappedbear.update_icon()
 					trappedbear = null
 					anchored = FALSE
-					
-					if(istype(trappedbear,/mob/living/simple_animal/complex))
-						var/mob/living/simple_animal/complex/CA=trappedbear
-						CA.family+=user
-						to_chat(user,"<span class='notice'>\The [trappedbear] seems appreciative.</span>")
 					return
 				else
 					user.visible_message("<span class='warning'>\The [H] fails to pry \the [src] off of \the [trappedbear], and crushes their leg even more!</span>", \
@@ -701,10 +696,6 @@ var/list/available_redphone_names3 = list("1","2","3","4","5","6","7","8","9")
 				unlock_atom(trappedbear)
 				trappedbear.update_icon()
 				trappedbear = null
-				if(istype(trappedbear,/mob/living/simple_animal/complex))
-					var/mob/living/simple_animal/complex/CA=trappedbear
-					CA.family+=user
-					to_chat(user,"<span class='notice'>\The [trappedbear] seems appreciative.</span>")
 	else
 		to_chat(user, "<span class='notice'>You carefully set the bear trap off with \the [I.name].</span>")
 		playsound(src, 'sound/effects/snap.ogg', 60, 1)

--- a/code/modules/maps/spawners/jungle_spawns.dm
+++ b/code/modules/maps/spawners/jungle_spawns.dm
@@ -25,17 +25,15 @@ var/list/junglemobs_passive_rare=list(
 /obj/abstract/map/spawner/jungle_any/New()
 	var/rng=rand()
 	if(rng < 0.65) //65% chance of friendly mobs
-		amount=rand(3,6)
+		amount=rand(3,5)
 		if(prob(20)) //20% chance for rare (13% overall)
 			amount = rand(1,2)
 			to_spawn = pick(junglemobs_passive_rare)
 		else
 			to_spawn = pick(junglemobs_passive)
 	else
-		amount=rand(2,5)
+		amount=rand(3,5)
 		to_spawn = pick(junglemobs_hostile)
-		if(to_spawn==/mob/living/simple_animal/complex/panther) //being carnivores only, they need a bit of help to get the population ball rolling. also they spread out a lot.
-			amount+=2
 	..()
 
 
@@ -44,7 +42,7 @@ var/list/junglemobs_passive_rare=list(
 	icon_state="jungle_mob_fren"
 	
 /obj/abstract/map/spawner/jungle_fren/New()
-	amount=rand(3,6)
+	amount=rand(3,5)
 	if(prob(20))
 		to_spawn = pick(junglemobs_passive_rare)
 		amount = rand(1,2)
@@ -58,6 +56,6 @@ var/list/junglemobs_passive_rare=list(
 	icon_state="jungle_mob_hostile"
 	
 /obj/abstract/map/spawner/jungle_hostile/New()
-	amount=rand(3,6)
+	amount=rand(3,5)
 	to_spawn = pick(junglemobs_hostile)
 	..()

--- a/code/modules/maps/spawners/jungle_spawns.dm
+++ b/code/modules/maps/spawners/jungle_spawns.dm
@@ -20,9 +20,9 @@ var/list/junglemobs_passive_rare=list(
 
 //how many mobs we want to exist on junga
 var/alist/spawn_targets=alist(
-	/mob/living/simple_animal/complex/dinosaur=30,
-	/mob/living/simple_animal/complex/panther=30,
-	/mob/living/simple_animal/complex/bear=30,
+	/mob/living/simple_animal/complex/dinosaur=35,
+	/mob/living/simple_animal/complex/panther=35,
+	/mob/living/simple_animal/complex/bear=40,
 	/mob/living/simple_animal/complex/crocodile=15,
 	/mob/living/simple_animal/complex/frog=10,
 	/mob/living/simple_animal/complex/frog/poison=10,

--- a/code/modules/maps/spawners/jungle_spawns.dm
+++ b/code/modules/maps/spawners/jungle_spawns.dm
@@ -64,8 +64,10 @@ var/alist/spawn_targets=alist(
 		current_mob_counts[M.type]=(current_mob_counts[M.type] || 0) +1
 	for(var/path,target in spawn_targets) //check if they're under our target
 		if (current_mob_counts[path]<target)
-			//world.log <<"[path] ([current_mob_counts[path]]) was under [target], spawning 1 more."
-			new path(src.loc)
+			var/tospawn=target - current_mob_counts[path] //how many behind the target we are
+			tospawn = max(3,min(5,floor(tospawn/2) )) //do some scaling to try to spawn them with a group with an acceptable size. this will result in some over and undershoots, but that's ok.
+			while(tospawn--)
+				new path(src.loc)
 			return
 		
 //random peaceful wildlife. :)

--- a/code/modules/maps/spawners/jungle_spawns.dm
+++ b/code/modules/maps/spawners/jungle_spawns.dm
@@ -18,25 +18,56 @@ var/list/junglemobs_passive_rare=list(
 /mob/living/simple_animal/complex/capybara_wild,
 )
 
+//how many mobs we want to exist on junga
+var/alist/spawn_targets=alist(
+	/mob/living/simple_animal/complex/dinosaur=30,
+	/mob/living/simple_animal/complex/panther=30,
+	/mob/living/simple_animal/complex/bear=30,
+	/mob/living/simple_animal/complex/crocodile=15,
+	/mob/living/simple_animal/complex/frog=10,
+	/mob/living/simple_animal/complex/frog/poison=10,
+	/mob/living/simple_animal/complex/parrot=15,
+	/mob/living/simple_animal/complex/capybara_wild=6,
+)
+
 //any wildlife, be it fren-shaped or not.
 /obj/abstract/map/spawner/jungle_any
 	icon_state="jungle_mob_random"
+	var/spawn_periodically=TRUE
+	var/ticker=0
 
 /obj/abstract/map/spawner/jungle_any/New()
+	if(spawn_periodically)
+		processing_objects+=src
 	var/rng=rand()
 	if(rng < 0.65) //65% chance of friendly mobs
-		amount=rand(3,5)
+		amount=rand(3,4)
 		if(prob(20)) //20% chance for rare (13% overall)
 			amount = rand(1,2)
 			to_spawn = pick(junglemobs_passive_rare)
 		else
 			to_spawn = pick(junglemobs_passive)
 	else
-		amount=rand(3,5)
+		amount=rand(3,4)
 		to_spawn = pick(junglemobs_hostile)
 	..()
 
-
+/obj/abstract/map/spawner/jungle_any/process()
+	ticker++
+	if(ticker%10!=0 || prob(75) ) //25% chance to fire every 10 ticks. ensures it won't happen a whole lot, and will randomize locations a bit
+		return
+	for(var/mob/M in range(7)) //do not spawn if we're being observed
+		if(M.client)
+			return
+	var/alist/current_mob_counts=alist()
+	for(var/mob/M in mob_list) //count all mobs
+		current_mob_counts[M.type]=(current_mob_counts[M.type] || 0) +1
+	for(var/path,target in spawn_targets) //check if they're under our target
+		if (current_mob_counts[path]<target)
+			//world.log <<"[path] ([current_mob_counts[path]]) was under [target], spawning 1 more."
+			new path(src.loc)
+			return
+		
 //random peaceful wildlife. :)
 /obj/abstract/map/spawner/jungle_fren
 	icon_state="jungle_mob_fren"

--- a/code/modules/mob/living/complex_animal/base.dm
+++ b/code/modules/mob/living/complex_animal/base.dm
@@ -230,7 +230,7 @@
 		for(var/mob/living/simple_animal/complex/A in cache_objects_in_extended_area)
 			if(A.type==src.type && A.stat!=DEAD)
 				localcount++
-		if(localcount<max_local_population && nutrition >= (max_food- get_offspring_cost()*2) && prob(50))
+		if(localcount<max_local_population && localcount>1 && nutrition >= (max_food- (size*7.5)*2) && prob(50))
 			behavior_state=ANIMAL_STATE_MATING
 			return FALSE
 		else
@@ -358,10 +358,10 @@
 		else
 			if(gender=="female")
 				if(generate_offspring(M))
-					M.nutrition-=M.get_offspring_cost()
+					M.nutrition-=(M.size*7.5)
 					M.abort_target()
 
-					nutrition-=get_offspring_cost()
+					nutrition-=(size*7.5)
 					abort_target()
 
 					M.lastmate=M.matingcooldown
@@ -607,9 +607,7 @@
 
 //only fired when the mob is seen by us, and we have the AVOID_PRED flag
 /mob/living/simple_animal/complex/proc/determine_isthreat(var/mob/individual)
-	if(!verify_target(individual))
-		return FALSE
-	if(is_pacified())
+	if(!individual || individual.stat==DEAD)
 		return FALSE
 	if(is_kin(individual))
 		return FALSE
@@ -648,9 +646,6 @@
 	if(prob(10))
 		emote("me",MESSAGE_HEAR, "vocalizes.")
 
-
-/mob/living/simple_animal/complex/proc/get_offspring_cost()
-	return size*7.5
 
 // if you don't want offspring, then return FALSE here.
 /mob/living/simple_animal/complex/proc/can_offspring(var/mob/living/simple_animal/complex/mate)

--- a/code/modules/mob/living/complex_animal/base.dm
+++ b/code/modules/mob/living/complex_animal/base.dm
@@ -21,7 +21,6 @@
 #define ANIMAL_FOODPRIORITY_CORPSES 3	//no need to beat a dead horse. we should be eating it instead.
 #define ANIMAL_FOODPRIORITY_SIZEDIFF_LARGER -4	//bigger=more dangerous, right?
 #define ANIMAL_FOODPRIORITY_SIZEDIFF_SMALLER -2	//prefer bigger meals
-#define ANIMAL_FOODPRIORITY_FAMILY -5	//hi ma :)
 #define ANIMAL_FOODPRIORITY_UNDESIRABLE -5	//poison... poison... tasty fish!
 
 #define ANIMAL_STATE_IDLE 0	//hanging around.
@@ -49,7 +48,6 @@
 	var/ticks_this_state=0
 	var/atom/target = null
 	var/turf/territory=null //turf location
-	var/list/family = list() //list of mobs. avoid attacking them and whatnot. also can be used for taming.
 	environment_smash_flags = 0xFFFFFF
 	var/movespeed=5 //lower=faster.
 	var/kin_check_type_path=null //for mobs with many subtypes. set to the parent mob type. leave null if not needed
@@ -79,9 +77,6 @@
 	cache_objects_in_view=null
 	cache_objects_in_extended_area=null
 	target=null
-	for(var/mob/living/simple_animal/complex/C in family) //we will be referenced by our family, so clear us from that.
-		C.family -=src
-	family=null
 	..()
 
 
@@ -230,10 +225,16 @@
 /mob/living/simple_animal/complex/proc/tick_state_idle()
 	abort_target()
 
-	//attempt reproduction only while full
-	if(lastmate<=0 && nutrition >= (max_food- get_offspring_cost()*2) && prob(50))
-		behavior_state=ANIMAL_STATE_MATING
-		return FALSE
+	if(lastmate<=0)
+		var/localcount=0
+		for(var/mob/living/simple_animal/complex/A in cache_objects_in_extended_area)
+			if(A.type==src.type && A.stat!=DEAD)
+				localcount++
+		if(localcount<max_local_population && nutrition >= (max_food- get_offspring_cost()*2) && prob(50))
+			behavior_state=ANIMAL_STATE_MATING
+			return FALSE
+		else
+			lastmate=2 //stop processing this for a few ticks to save some CPU
 
 	get_idle_sounds()
 
@@ -392,8 +393,6 @@
 		behavior_state=ANIMAL_STATE_IDLE
 
 /mob/living/simple_animal/complex/proc/is_kin(var/mob/target)
-	if(target in family)
-		return TRUE
 	if(target.faction == src.faction && src.faction!="neutral")
 		return TRUE
 	if(kin_check_type_path)
@@ -457,8 +456,6 @@
 				p+=ANIMAL_FOODPRIORITY_SIZEDIFF_LARGER
 			if(M.size < src.size-2) //smaller things ain't worth our time
 				p+=ANIMAL_FOODPRIORITY_SIZEDIFF_SMALLER
-			if(M in family)
-				p+=ANIMAL_FOODPRIORITY_FAMILY
 			if(istype(A,/mob/living/simple_animal))
 				var/mob/living/simple_animal/SA=A
 				if(SA.is_poisonous)
@@ -488,13 +485,13 @@
 		get_aggro_msg(victim)
 	target=victim
 	behavior_state=state
-	if( !(behavior_flags & ANIMAL_BEHAVIOR_PACK_DYNAMICS) && !family.len)
+	if( !(behavior_flags & ANIMAL_BEHAVIOR_PACK_DYNAMICS))
 		return
 	if(istype(target,/mob/living))
 		var/mob/living/T=target
 		if(T.stat!=DEAD)
 			for(var/mob/living/simple_animal/complex/M in cache_objects_in_view)
-				if( (behavior_flags & ANIMAL_BEHAVIOR_PACK_DYNAMICS) || (M in family))
+				if( (behavior_flags & ANIMAL_BEHAVIOR_PACK_DYNAMICS))
 					if(is_kin(M) && !M.is_kin(target)) //rally the pack to us, if the target is not kin
 						if(M.behavior_state!=state) //if the pack member is not engaged in similar activity
 							M.aggro_drawn(victim,state) //do this recursively for each. don't kick the bee hive.
@@ -670,12 +667,6 @@
 		return FALSE
 	if(mate.type!=src.type)
 		return FALSE
-	var/localcount=0
-	for(var/mob/living/simple_animal/complex/A in cache_objects_in_extended_area)
-		if(A.type==src.type && A.stat!=DEAD)
-			localcount++
-	if(localcount>max_local_population)
-		return FALSE
 	if(lastmate>0)
 		return FALSE
 	if((src.gender=="male" && mate.gender=="female") || (mate.gender=="male" && src.gender=="female"))
@@ -689,10 +680,6 @@
 		return FALSE
 	child.faction=faction
 	child.nutrition=child.max_food*0.5
-	family+=child
-	father.family+=child
-	child.family+=src
-	child.family+=father
 	return child
 	
 

--- a/code/modules/mob/living/complex_animal/base.dm
+++ b/code/modules/mob/living/complex_animal/base.dm
@@ -135,20 +135,18 @@
 		return 0
 	ticks_dead=0
 
+	cache_objects_in_extended_area = range(src,16)
+	cache_objects_in_view = view(src,7) //refresh it every life tick.
+
 	if(last_state!=behavior_state)
 		ticks_this_state=0
 		last_state=behavior_state
 	else
-		ticks_this_state++
-
-	cache_objects_in_view = view(src,7) //refresh it every life tick.
-	cache_objects_in_extended_area = range(src,16)
+		ticks_this_state++		
 
 	reagents?.metabolize(src)
 
 	nutrition-=max_food*food_per_tick
-
-	lastmate--
 
 	if(lasthealth<=health && health<maxHealth)
 		health=min(maxHealth,health+maxHealth*healthregen)
@@ -168,6 +166,11 @@
 	interrupt_territory() //next, prioritize defending our home
 	interrupt_fear() //then, prioritize saving our own ass.
 
+
+	if (behavior_state==ANIMAL_STATE_IDLE==last_state && (ticks_this_state % 3!=1) ) //throttle idle ticking
+		walk(src,0)
+		return 1
+
 	switch(behavior_state)
 		if(ANIMAL_STATE_IDLE)
 			tick_state_idle()
@@ -179,8 +182,6 @@
 			tick_state_attacking()
 		if(ANIMAL_STATE_FLEEING)
 			tick_state_fleeing()
-		if(ANIMAL_STATE_MATING)
-			tick_state_mating()
 		if(ANIMAL_STATE_SPECIAL)
 			tick_state_special()
 	return 1
@@ -223,28 +224,18 @@
 
 //state functions return TRUE if the behavior_state is unchanged, and FALSE if not. basically just do if(..())
 /mob/living/simple_animal/complex/proc/tick_state_idle()
-	abort_target()
-
-	if(lastmate<=0)
-		var/localcount=0
-		for(var/mob/living/simple_animal/complex/A in cache_objects_in_extended_area)
-			if(A.type==src.type && A.stat!=DEAD)
-				localcount++
-		if(localcount<max_local_population && localcount>1 && nutrition >= (max_food- (size*7.5)*2) && prob(50))
-			behavior_state=ANIMAL_STATE_MATING
-			return FALSE
-		else
-			lastmate=2 //stop processing this for a few ticks to save some CPU
+	if(target)
+		abort_target()
 
 	get_idle_sounds()
 
-	if(prob(25))//move around randomly sometimes
-		if(behavior_flags & ANIMAL_BEHAVIOR_TERRITORIAL && territory)
-			walk_to(src,locate(territory.x+rand(-3,3),territory.y+rand(-3,3),territory.z),0,movespeed)
-		else
-			walk_to(src,locate(x+rand(-3,3),y+rand(-3,3),z),0,movespeed)
+	//move around randomly sometimes
+	if(behavior_flags & ANIMAL_BEHAVIOR_TERRITORIAL && territory)
+		walk_to(src,locate(territory.x+rand(-3,3),territory.y+rand(-3,3),territory.z),0,movespeed)
+	else
+		walk_to(src,locate(x+rand(-3,3),y+rand(-3,3),z),0,movespeed)
 
-	if(territory && prob(25)) //randomly move the territory
+	if(territory) //randomly move the territory
 		if(behavior_flags & ANIMAL_BEHAVIOR_PACK_DYNAMICS) //move our territory closer to pack members
 			var/list/mob/living/simple_animal/complex/members=list()
 			for(var/mob/living/simple_animal/complex/M in cache_objects_in_view)

--- a/code/modules/mob/living/complex_animal/base.dm
+++ b/code/modules/mob/living/complex_animal/base.dm
@@ -262,14 +262,20 @@
 	return TRUE
 
 /mob/living/simple_animal/complex/proc/tick_state_hunting()
-	if(nutrition>max_food*0.75)
+	if(nutrition>max_food*0.60)
 		abort_target()
 		return FALSE
-	if(!verify_target(target,20,TRUE) || (ticks_this_state>9 && prob(25)) )
+	if(!verify_target(target,16,TRUE) || (ticks_this_state>9 && prob(25)) )
 		abort_target(FALSE)
 		var/list/possible=rank_foodsources(get_food())
 		var/list/pickfrom=list()
 		var/highestprio=-999999
+		
+		if(nutrition>max_food*0.2) //avoid disliked targets, unless we are really desperate for food.
+			highestprio = 0
+		else if(nutrition>max_food*0.05) //I NEEEEEEEED IIIIIIIIT
+			highestprio= -4
+		
 		for(var/atom/A in possible) //get the highest ranked objects
 			var/rank=possible[A]
 			if(rank>highestprio)
@@ -279,10 +285,6 @@
 				pickfrom+=A
 		if(pickfrom.len)
 			target=pick(pickfrom)
-		if(highestprio<0 && nutrition>max_food*0.2) //avoid disliked targets, unless we are really desperate for food.
-			target=null
-		if(highestprio<-4 && nutrition>max_food*0.05) //I NEEEEEEEED IIIIIIIIT
-			target=null
 		if(!target) //if we can't find a suitable target, move around randomly
 			walk_to(src,locate(x+rand(-15,15),y+rand(-15,15),z),0,movespeed)
 		else
@@ -405,40 +407,28 @@
 //return a list of valid salad
 /mob/living/simple_animal/complex/proc/get_food()
 	var/list/foodsources=list()
-	for(var/atom/A in cache_objects_in_view)
-		if(A==src) //do not eat ourselves
-			continue
-		if(food_flags & ANIMAL_HERBIVORE)
-			if(istype(A,/obj/structure/flora) && !istype(A,/obj/structure/flora/tree) && !istype(A,/obj/structure/flora/rock))
+	if(food_flags & ANIMAL_HERBIVORE)
+		for(var/obj/structure/flora/A in cache_objects_in_view)
+			if(!istype(A,/obj/structure/flora/tree) && !istype(A,/obj/structure/flora/rock))
 				foodsources+=A
-				continue
-		if(food_flags & ANIMAL_FRUGIVORE)
-			if(istype(A,/obj/structure/flora/jungle_berries))
-				var/obj/structure/flora/jungle_berries/bush=A
-				if(bush.hasberries)
-					foodsources+=A
-					continue
-		if(food_flags & ANIMAL_CARNIVORE)
-			if(istype(A,/mob/living))
-				var/mob/living/M=A
-				if(M.stat!=DEAD)
-					if(!is_pacified() && behavior_flags & ANIMAL_BEHAVIOR_PREDATORY)
-						foodsources+=M
-						continue
-				else
-					foodsources+=M
-					continue
-			else if(istype(A,/obj/item/organ) && !istype(A,/obj/item/organ/external/head) && !istype(A,/obj/item/organ/internal/brain)) //we don't want to round remove people
+	
+	else if(food_flags & ANIMAL_FRUGIVORE)
+		for(var/obj/structure/flora/jungle_berries/A in cache_objects_in_view)
+			if(A.hasberries)
 				foodsources+=A
-				continue
-
-		//no easy way to check if it's meat. oh well.
-		if(istype(A,/obj/item/weapon/reagent_containers/food/snacks))
-			foodsources+=A
-			continue
-	for(var/atom/A in foodsources)
-		if(!verify_target(A,-1,TRUE))
-			foodsources-=A
+	
+	if(food_flags & ANIMAL_CARNIVORE)
+		for(var/obj/item/organ/A in cache_objects_in_view)
+			if(!istype(A,/obj/item/organ/external/head) && !istype(A,/obj/item/organ/internal/brain)) //we don't want to round remove people
+				foodsources+=A 
+		if((behavior_flags & ANIMAL_BEHAVIOR_PREDATORY) && !is_pacified())
+			for(var/mob/living/A in cache_objects_in_view)
+				if(A.stat!=DEAD && A!=src)
+					foodsources+=A 
+	
+	for(var/obj/item/weapon/reagent_containers/food/snacks/A in cache_objects_in_view) //no easy way to check if it's meat. oh well.
+		foodsources+=A
+	
 	return foodsources
 
 //take the list from get_food, and create an associated list ranking our affinity for them
@@ -469,6 +459,7 @@
 		if(istype(A,/obj/structure/flora))
 			p+=ANIMAL_FOODPRIORITY_PLANTS
 		out[A]=p
+	
 	return out
 
 

--- a/code/modules/mob/living/complex_animal/base.dm
+++ b/code/modules/mob/living/complex_animal/base.dm
@@ -12,9 +12,8 @@
 #define ANIMAL_FRUGIVORE	(1<<2 ) //fruits (jungle berry bushes). implied with HERBIVORE, but can be used on its own.
 
 #define ANIMAL_FLAG_NEVER_STARVE	(1<<0)
-#define ANIMAL_FLAG_NEVER_AGE	(1<<1)
-#define ANIMAL_FLAG_NEVER_ROT	(1<<2)
-#define ANIMAL_FLAG_IMMORTAL	ANIMAL_FLAG_NEVER_STARVE | ANIMAL_FLAG_NEVER_AGE
+#define ANIMAL_FLAG_NEVER_ROT	(1<<1)
+#define ANIMAL_FLAG_IMMORTAL	ANIMAL_FLAG_NEVER_STARVE
 
 #define ANIMAL_FOODPRIORITY_CANNIBAL -5	//she rips out my bones just like i'm an animal
 #define ANIMAL_FOODPRIORITY_PRECOOKED 5	//why would you eat a plant when you could eat a tasty donut or burger?
@@ -48,8 +47,6 @@
 	var/animal_flags = 0
 	var/last_state = -1
 	var/ticks_this_state=0
-	var/mob_age = 0
-	var/mob_max_age = 450 //15 minutes. above this, the mob will start rolling to die of old age.
 	var/atom/target = null
 	var/turf/territory=null //turf location
 	var/list/family = list() //list of mobs. avoid attacking them and whatnot. also can be used for taming.
@@ -59,7 +56,7 @@
 	var/petable=FALSE
 	var/lastmate=0
 	var/matingcooldown=60 //2 minutes
-	var/max_local_population=8 //to prevent total overpopulation
+	var/max_local_population=5 //to prevent total overpopulation
 	var/healthregen=0.01
 	var/lasthealth=0.0
 	var/ticks_dead=0
@@ -89,7 +86,7 @@
 
 
 /mob/living/simple_animal/complex/proc/allow_msg()
-	for(var/mob/m in range(src,11)) //only do emotes/say things if a player is nearby. this is to reduce log spam and make obsgang not want to die, even though they should just play the game.
+	for(var/mob/m in cache_objects_in_extended_area) //only do emotes/say things if a player is nearby. this is to reduce log spam and make obsgang not want to die, even though they should just play the game.
 		if(m.client)
 			return TRUE
 	return FALSE
@@ -163,27 +160,13 @@
 		nutrition-=max_food*food_per_tick*0.25 //use extra food when regaining health
 	lasthealth=health
 
-	if(nutrition<0 && prob(20) && !(animal_flags&ANIMAL_FLAG_NEVER_STARVE) )
+	if(nutrition<0 && !(animal_flags&ANIMAL_FLAG_NEVER_STARVE) && prob(20) )
 		emote("deathgasp")
 		health=0
 	if(health<=0 && stat != DEAD)
 		death()
 		return 0
-	if(mob_max_age && mob_age > mob_max_age && !(animal_flags&ANIMAL_FLAG_NEVER_AGE) )
-		var/chancetokeelover = 0.5*((mob_age-mob_max_age)/mob_max_age)
-		chancetokeelover = 1-(1/(chancetokeelover+1))
-		// math formula: 1-\frac{1}{.5\left(\frac{\left(x-m\right)}{m}\right)+1} 
-		//basically, the older you are, the more likley you are to die.
-		//if you are 3x as old as the max age, you have a 50% chance to die.
-		//this is ran every tick, by the way, so the probabilities add up.
-		chancetokeelover*=0.25 //ok nevermind reduce the chance a bit it happens a bit too fast.
-		if(rand() < chancetokeelover)
-			emote("deathgasp")
-			health=0
-			stat=DEAD
-			return 0
-	mob_age++
-
+	
 	escape()
 
 	interrupt_hunger() //prioritize eating over all other things
@@ -248,14 +231,14 @@
 	abort_target()
 
 	//attempt reproduction only while full
-	if(nutrition >= (max_food- get_offspring_cost()*2) && get_offspring_cost() && prob(50) && lastmate<=0)
+	if(lastmate<=0 && nutrition >= (max_food- get_offspring_cost()*2) && prob(50))
 		behavior_state=ANIMAL_STATE_MATING
 		return FALSE
 
 	get_idle_sounds()
 
 	if(prob(25))//move around randomly sometimes
-		if(territory && prob(50))
+		if(behavior_flags & ANIMAL_BEHAVIOR_TERRITORIAL && territory)
 			walk_to(src,locate(territory.x+rand(-3,3),territory.y+rand(-3,3),territory.z),0,movespeed)
 		else
 			walk_to(src,locate(x+rand(-3,3),y+rand(-3,3),z),0,movespeed)
@@ -275,9 +258,6 @@
 						territory =T
 		else //just random movment
 			territory=locate(territory.x+rand(-4,4),territory.y+rand(-4,4),territory.z)
-
-	if(behavior_flags & ANIMAL_BEHAVIOR_TERRITORIAL && !territory) //if we can't find the territory, regenerate it
-		territory=locate(x,y,z)
 	return TRUE
 
 /mob/living/simple_animal/complex/proc/tick_state_hunting()
@@ -354,16 +334,14 @@
 
 /mob/living/simple_animal/complex/proc/tick_state_mating()
 	if(!verify_target(target,16)) //ignores line of sight and has increased range to help sparse populations not die out.
-		for(var/atom/A in cache_objects_in_extended_area )
-			if(istype(A,/mob/living/simple_animal/complex))
-				var/mob/living/simple_animal/complex/CA=A
-				if(can_offspring(CA) && CA.can_offspring(src) && CA.behavior_state==ANIMAL_STATE_MATING && !CA.target) //you better believe we're going to enforce the communicative property.
-					visible_message("<b>\the [src]</b> looks lovingly at \the [CA].")
-					target=CA
-					CA.visible_message("<b>\the [CA]</b> looks lovingly at \the [src].")
-					CA.target=src
-					walk_to(src,CA,0,src.movespeed)
-					walk_to(CA,src,0,CA.movespeed)
+		for(var/mob/living/simple_animal/complex/CA in cache_objects_in_extended_area )
+			if(CA.behavior_state==ANIMAL_STATE_MATING && !CA.target && can_offspring(CA) && CA.can_offspring(src)) //you better believe we're going to enforce the communicative property.
+				visible_message("<b>\the [src]</b> looks lovingly at \the [CA].")
+				target=CA
+				CA.visible_message("<b>\the [CA]</b> looks lovingly at \the [src].")
+				CA.target=src
+				walk_to(src,CA,0,src.movespeed)
+				walk_to(CA,src,0,CA.movespeed)
 		if(!target) //if we can't find one, exit back to idle
 			abort_target()
 			return FALSE
@@ -414,8 +392,6 @@
 		behavior_state=ANIMAL_STATE_IDLE
 
 /mob/living/simple_animal/complex/proc/is_kin(var/mob/target)
-	if(!istype(target,/mob))
-		return FALSE
 	if(target in family)
 		return TRUE
 	if(target.faction == src.faction && src.faction!="neutral")
@@ -424,8 +400,7 @@
 		if(istype(target,kin_check_type_path))
 			return TRUE
 	else
-		if(istype(target,src.type) || istype(src,target.type))
-			return TRUE
+		return target.type==src.type
 	return FALSE
 
 //return a list of valid salad
@@ -438,9 +413,6 @@
 			if(istype(A,/obj/structure/flora) && !istype(A,/obj/structure/flora/tree) && !istype(A,/obj/structure/flora/rock))
 				foodsources+=A
 				continue
-			if(istype(A,/turf/unsimulated/floor/planetary/grass/jungle))
-				foodsources+=A
-				continue
 		if(food_flags & ANIMAL_FRUGIVORE)
 			if(istype(A,/obj/structure/flora/jungle_berries))
 				var/obj/structure/flora/jungle_berries/bush=A
@@ -448,7 +420,7 @@
 					foodsources+=A
 					continue
 		if(food_flags & ANIMAL_CARNIVORE)
-			if(istype(A,/mob/living/carbon) || istype(A,/mob/living/simple_animal) || istype(A,/mob/living/simple_animal/complex))
+			if(istype(A,/mob/living))
 				var/mob/living/M=A
 				if(M.stat!=DEAD)
 					if(!is_pacified() && behavior_flags & ANIMAL_BEHAVIOR_PREDATORY)
@@ -533,8 +505,6 @@
 		return FALSE
 	if(is_pacified())
 		return FALSE
-	if(!victim)
-		return FALSE
 	if(istype(victim,/mob))
 		.= unarmed_attack_mob(victim)
 	else
@@ -543,8 +513,6 @@
 		get_attack_msg(victim)
 
 /mob/living/simple_animal/complex/proc/tryeat(var/victim)
-	if(!victim)
-		return FALSE
 	if(!verify_target(victim,1,TRUE))
 		return FALSE
 	if(istype(target,/mob/living))
@@ -584,10 +552,6 @@
 		else
 			visible_message("<b>\The [src]</b> nibbles at \the [target].")
 		nutrition+=5
-
-	else if (istype(target,/turf))
-		nutrition+=1
-		visible_message("<b>\The [src]</b> nibbles at \the [target].")
 	else if(istype(target,/obj/item/weapon/reagent_containers/food/snacks))
 		var/obj/item/weapon/reagent_containers/food/snacks/F=target
 		visible_message("<b>\The [src]</b> takes a bite out of <b>\the [F]</b>.")
@@ -647,10 +611,6 @@
 		return FALSE
 	if(is_pacified())
 		return FALSE
-	if(isliving(trespasser))
-		var/mob/living/L = trespasser
-		if(L.pacify_aura)
-			return FALSE
 	if(istype(trespasser,/mob/living/simple_animal/complex))
 		var/mob/living/simple_animal/complex/A=trespasser
 		if(A.behavior_flags & ANIMAL_BEHAVIOR_UNDESIRABLE)
@@ -715,8 +675,6 @@
 		if(A.type==src.type && A.stat!=DEAD)
 			localcount++
 	if(localcount>max_local_population)
-		return FALSE
-	if(mob_age>mob_max_age*1.5 || mob_age<mob_max_age*0.1) //too young or too old? no can do.
 		return FALSE
 	if(lastmate>0)
 		return FALSE

--- a/code/modules/mob/living/complex_animal/jungle_mobs/bears.dm
+++ b/code/modules/mob/living/complex_animal/jungle_mobs/bears.dm
@@ -16,7 +16,6 @@
 	behavior_flags = ANIMAL_BEHAVIOR_PREDATORY | ANIMAL_BEHAVIOR_RETALIATE | ANIMAL_BEHAVIOR_PACK_DYNAMICS | ANIMAL_BEHAVIOR_DESTRUCTIVE | ANIMAL_BEHAVIOR_AVOID_CAPTURE
 	movespeed=5
 	kin_check_type_path=/mob/living/simple_animal/complex/bear
-	max_local_population=5
 	var/sea_bear=TRUE
 
 /mob/living/simple_animal/complex/bear/get_idle_sounds()
@@ -60,7 +59,6 @@
 	maxHealth=250
 	armor=list(melee=10,bullet=30,laser=40,energy=0,bomb=0,bio=0,rad=0)
 	max_food=200
-	mob_max_age=9999999
 	healthregen=0.02
 	food_per_tick = 0.0005
 	melee_damage_upper=40
@@ -140,7 +138,6 @@
 	animal_flags = ANIMAL_FLAG_IMMORTAL
 	movespeed=4
 	health=100
-	mob_max_age=9999999
 	melee_damage_upper=50
 	melee_damage_lower=20
 	maxHealth=100

--- a/code/modules/mob/living/complex_animal/jungle_mobs/bears.dm
+++ b/code/modules/mob/living/complex_animal/jungle_mobs/bears.dm
@@ -67,6 +67,7 @@
 	animal_flags = ANIMAL_FLAG_IMMORTAL | ANIMAL_FLAG_NEVER_ROT
 	movespeed=4
 	sea_bear=FALSE
+	max_local_population=0
 
 /mob/living/simple_animal/complex/bear/spare/can_offspring(var/mob/living/simple_animal/complex/mate)
 	return FALSE
@@ -107,9 +108,9 @@
 	
 
 /mob/living/simple_animal/complex/bear/panda/can_offspring(var/mob/living/simple_animal/complex/mate)
-	.=..()
 	if(prob(75))
 		return FALSE
+	.=..()
 
 /mob/living/simple_animal/complex/bear/panda/get_butchering_products()
 	return list(/datum/butchering_product/skin/bear/panda, /datum/butchering_product/teeth/lots)
@@ -144,6 +145,7 @@
 	food_per_tick=0.0
 	healthregen=0.015
 	sea_bear=FALSE
+	max_local_population=0
 
 /mob/living/simple_animal/complex/bear/polar/chef/can_offspring(var/mob/living/simple_animal/complex/mate)
 	return FALSE	

--- a/code/modules/mob/living/complex_animal/jungle_mobs/bears.dm
+++ b/code/modules/mob/living/complex_animal/jungle_mobs/bears.dm
@@ -83,14 +83,14 @@
 	target=victim
 	behavior_state=state
 	get_aggro_msg(victim)
-	if( !(behavior_flags & ANIMAL_BEHAVIOR_PACK_DYNAMICS) && !family.len)
+	if( !(behavior_flags & ANIMAL_BEHAVIOR_PACK_DYNAMICS) )
 		return
 	if(istype(target,/mob/living))
 		var/mob/living/T=target
 		if(T.stat!=DEAD)
 			var/list/nearby_objects=range(15,src) //increased range, and ignores visibility. have fun!
 			for(var/mob/living/simple_animal/complex/M in nearby_objects)
-				if( (behavior_flags & ANIMAL_BEHAVIOR_PACK_DYNAMICS) || (M in family))
+				if( (behavior_flags & ANIMAL_BEHAVIOR_PACK_DYNAMICS) )
 					if(is_kin(M) && !M.is_kin(target))
 						if(M.behavior_state!=state)
 							M.aggro_drawn(victim,state)

--- a/code/modules/mob/living/complex_animal/jungle_mobs/capybara_wild.dm
+++ b/code/modules/mob/living/complex_animal/jungle_mobs/capybara_wild.dm
@@ -8,7 +8,6 @@
 	health=25
 	maxHealth=25
 	max_food=30
-	mob_max_age=9999999 //a long time.
 	food_flags = ANIMAL_HERBIVORE
 	animal_flags = ANIMAL_FLAG_IMMORTAL
 	behavior_flags = ANIMAL_BEHAVIOR_PACK_DYNAMICS | ANIMAL_BEHAVIOR_AVOID_CAPTURE

--- a/code/modules/mob/living/complex_animal/jungle_mobs/crocodile.dm
+++ b/code/modules/mob/living/complex_animal/jungle_mobs/crocodile.dm
@@ -14,8 +14,6 @@
 	melee_damage_lower=15
 	behavior_flags = ANIMAL_BEHAVIOR_PREDATORY | ANIMAL_BEHAVIOR_RETALIATE | ANIMAL_BEHAVIOR_DESTRUCTIVE | ANIMAL_BEHAVIOR_TERRITORIAL
 	movespeed=5
-	max_local_population = 5
-	mob_max_age = 900 // 30 minutes
 	food_per_tick = 0.0001
 	var/stuntracker=FALSE //prevents being stunlocked
 	

--- a/code/modules/mob/living/complex_animal/jungle_mobs/crocodile.dm
+++ b/code/modules/mob/living/complex_animal/jungle_mobs/crocodile.dm
@@ -70,9 +70,9 @@
 	armor=list(melee=35,bullet=15,laser=20,energy=0,bomb=10,bio=0,rad=0)
 	petable=TRUE
 	is_pet=TRUE
+	max_local_population=0
 
-/mob/living/simple_animal/complex/crocodile/schnapps/get_offspring_cost()
-	return 0 //no infinite schnapps.	
+
 /mob/living/simple_animal/complex/crocodile/schnapps/can_offspring()
 	return FALSE
 

--- a/code/modules/mob/living/complex_animal/jungle_mobs/panther.dm
+++ b/code/modules/mob/living/complex_animal/jungle_mobs/panther.dm
@@ -18,6 +18,9 @@
 	matingcooldown=30
 	var/list/mob/affinity_list=list() // stores people we like.
 
+/mob/living/simple_animal/complex/panther/Destroy()
+	affinity_list=null
+	..()
 
 /mob/living/simple_animal/complex/panther/get_idle_sounds()
 	if(prob(20))

--- a/code/modules/mob/living/complex_animal/jungle_mobs/panther.dm
+++ b/code/modules/mob/living/complex_animal/jungle_mobs/panther.dm
@@ -46,6 +46,8 @@
 /mob/living/simple_animal/complex/panther/is_kin(var/mob/target)
 	if(istype(target,/mob/living/simple_animal/cat) && !istype(target,/mob/living/simple_animal/cat/snek))
 		return TRUE
+	if ((affinity_list[target] || 0) > 10)
+		return TRUE
 	return ..()
 
 
@@ -78,12 +80,8 @@
 		affinity_list[M]=0
 	affinity_list[M]+=affinity_change
 	var/aff=affinity_list[M]
-	if(aff>10 && !(M in family) )
+	if(aff>10 )
 		to_chat(M,"<span class='notice'>\the [src] looks like it warmed up to you!</span>")
-		family+=M
-	if(aff<0 && (M in family))
-		to_chat(M,"<span class='notice'>\the [src] looks at you with contempt!</span>")
-		family-=M
 
 /mob/living/simple_animal/complex/panther/get_butchering_products()
 	return list(/datum/butchering_product/skin/cat/lots,/datum/butchering_product/teeth/lots)

--- a/code/modules/mob/living/complex_animal/jungle_mobs/parrot.dm
+++ b/code/modules/mob/living/complex_animal/jungle_mobs/parrot.dm
@@ -29,6 +29,10 @@
 									/obj/machinery/suit_storage_unit,	/obj/structure/flora/tree)
 
 
+/mob/living/simple_animal/complex/parrot/Destroy()
+	heard_phrases=null
+	..()
+
 /mob/living/simple_animal/complex/parrot/Hear(var/datum/speech/speech, var/rendered_speech="")
 	if(speech.speaker && speech.speaker != src && !(speech.message in heard_phrases) && !(speech.message in builtin_phrases)  ) //Don't imitate ourselves
 		if(heard_phrases.len >= 20)


### PR DESCRIPTION
[jungle] [performance]

## What this does
makes junglestation run a whole lot better by reducing mobs, the time they take to run, and how much the mobs increase over time.

* removes animals dying of old age
* removes the animal family list
* animals no longer mate, instead spawning from spawners with hard limits
* rewrote a lot of logic to be more performant
* reordered logic for more speed
* reduced ticking of some logic
* reduces the number of jungle mobs spawned

**before**
<img width="552" height="224" alt="before" src="https://github.com/user-attachments/assets/5a0001a8-1986-4555-a02d-1eb17be41c31" />


**after**
<img width="579" height="205" alt="after_3" src="https://github.com/user-attachments/assets/6df3d918-f7e6-40e3-872d-46af05e6b598" />

<img width="1024" height="414" alt="Capture" src="https://github.com/user-attachments/assets/e990b868-1d18-4844-8060-3c1d824eaa9a" />


## Why it's good
performance is good. simplifies things that didn't need to be so complicated. keeps jungle mobs' quirks while doing so.

## How it was tested
went in game and let it run for 15 minutes. observed the mob count not increasing meaningfully after 5 minutes into the round. see images. observed mobs and saw that they were still doing their unique behaviors. additionally let it run for 1 hour to verify that mob count didn't explode over time

## Changelog
:cl:
 * tweak: reduced the count of jungle mobs
 * bugfix: jungle mobs have been heavily optimized and should result in junglestation running much better, especially as a round goes on