### PR TITLE
increases maximum odyssey voting population to 15

### DIFF
--- a/code/datums/next_map.dm
+++ b/code/datums/next_map.dm
@@ -186,7 +186,7 @@
 /datum/next_map/odyssey
 	name = "NTEV Odyssey"
 	path = "odyssey"
-	max_players = 10
+	max_players = 15
 
 /proc/get_votable_maps()
 	var/list/votable_maps = list()


### PR DESCRIPTION
[tweak] [odyssey] [cannotreproduce] [honk]
## What this does
see title

## Why it's good
just because there's 10 players in the last round doesn't mean there'll be 10 players in the next one. 10 player max means it only gets ran during deadpop. the map isn't really getting ran much anymore because of the previous change. and while the station is small, it's capable of supporting more people, especially considering that population changes between rounds and obsgang players hog a player slot.

## How it was tested
wasn't

## Changelog
:cl:
 * tweak: odyssey is now voteable up to 15 players, up from 10
