### PR TITLE
Honk Serum OD (50u) can now permanently clumsify - 'Nothing' OD (50u) can now permanently unclumsify

### DIFF
--- a/code/modules/reagents/reagents/reagents_drink.dm
+++ b/code/modules/reagents/reagents/reagents_drink.dm
@@ -263,6 +263,7 @@
 	color = "#FFFFFF" //rgb: 255, 255, 255
 	nutriment_factor = 0
 	glass_name = "nothing"
+	overdose_am = 50
 
 /datum/reagent/drink/nothing/on_mob_life(var/mob/living/M)
     if(ishuman(M))
@@ -276,6 +277,13 @@
                 M.heal_organ_damage(0, REM)
             if(M.getToxLoss() && prob(80))
                 M.adjustToxLoss(-REM)
+
+/datum/reagent/drink/nothing/on_overdose(var/mob/living/H)
+	if(ishuman(H))
+		var/mob/living/carbon/human/M = H
+		if(M_CLUMSY in M.mutations)
+			M.mutations.Remove(M_CLUMSY)
+			M.visible_message("<span class='notice'>\The [M] seems to get a grasp over themselves...</span>", "<span class='notice'>You have outgrown that wave of clumsiness.</span>'")
 
 /datum/reagent/drink/potato_juice
 	name = "Potato Juice"

--- a/code/modules/reagents/reagents/reagents_toxin.dm
+++ b/code/modules/reagents/reagents/reagents_toxin.dm
@@ -308,6 +308,7 @@
 	if(ishuman(H))
 		var/mob/living/carbon/human/M = H
 		M.mutations.Add(M_CLUMSY)
+		H.visible_message("<span class='notice'>\The [H] seems to be stumbling over himself...</span>", "<span class='notice'>You feel clumsier than before.</span>'")
 
 /datum/reagent/honkserum/on_mob_life(var/mob/living/M)
 	if(..())

--- a/code/modules/reagents/reagents/reagents_toxin.dm
+++ b/code/modules/reagents/reagents/reagents_toxin.dm
@@ -290,7 +290,7 @@
 	reagent_state = REAGENT_STATE_LIQUID
 	color = "#F2C900" //rgb: 242, 201, 0
 	custom_metabolism = 0.05
-	overdose_am = REAGENTS_OVERDOSE
+	overdose_am = 50
 	arcane_id = SILENCER
 
 /datum/reagent/honkserum/on_overdose(var/mob/living/H)
@@ -304,6 +304,10 @@
 			qdel(H.wear_mask)
 			H.visible_message("<span class='warning'>\The [H]'s mask melts!</span>")
 		H.visible_message("<span class='notice'>\The [H]'s face goes pale for a split second, and then regains some colour.</span>", "<span class='notice'><i>Where did Marcel go...?</i></span>'")
+
+	if(ishuman(H))
+		var/mob/living/carbon/human/M = H
+		M.mutations.Add(M_CLUMSY)
 
 /datum/reagent/honkserum/on_mob_life(var/mob/living/M)
 	if(..())

--- a/code/modules/reagents/reagents/reagents_toxin.dm
+++ b/code/modules/reagents/reagents/reagents_toxin.dm
@@ -309,7 +309,7 @@
 		var/mob/living/carbon/human/M = H
 		if(!(M_CLUMSY in M.mutations))
 			M.mutations.Add(M_CLUMSY)
-			M.visible_message("<span class='notice'>\The [M] seems to be stumbling over himself...</span>", "<span class='notice'>You feel clumsier than before.</span>'")
+			M.visible_message("<span class='notice'>\The [M] seems to be stumbling over...</span>", "<span class='notice'>You feel clumsier than before.</span>'")
 
 /datum/reagent/honkserum/on_mob_life(var/mob/living/M)
 	if(..())

--- a/code/modules/reagents/reagents/reagents_toxin.dm
+++ b/code/modules/reagents/reagents/reagents_toxin.dm
@@ -307,8 +307,9 @@
 
 	if(ishuman(H))
 		var/mob/living/carbon/human/M = H
-		M.mutations.Add(M_CLUMSY)
-		H.visible_message("<span class='notice'>\The [H] seems to be stumbling over himself...</span>", "<span class='notice'>You feel clumsier than before.</span>'")
+		if(!(M_CLUMSY in M.mutations))
+			M.mutations.Add(M_CLUMSY)
+			M.visible_message("<span class='notice'>\The [M] seems to be stumbling over himself...</span>", "<span class='notice'>You feel clumsier than before.</span>'")
 
 /datum/reagent/honkserum/on_mob_life(var/mob/living/M)
 	if(..())


### PR DESCRIPTION
## What this does
Overdosing on Honk Serum will now also permanently clumsify the imbiber. Since this is a fairly strong effect, the overdose amount is now 50, instead of 30. 
On the flipside, a clumsy person can be permanently unclumsified should they chug enough 'Nothing'.
## Why it's good
Allows cloned clowns to recover their clumsiness, provides extra possible interactions between clown, mime, botany and chemistry, general funnygunk.
## How it was tested
Shot gun a bunch of times, didn't explode.
Spawned beaker with 100u honk serum, chugged.
Purged chems with waterpot mix.
Shot the same gun, exploded on me as I was now clusmified.
:cl:
 * rscadd: Overdosing on Honk Serum will now also permanently give the clumsy mutation, allowing cloned clowns to recover their lost clumsiness, and evildoers to purposefully clumsify individuals, should they acquire enough serum.
 * tweak: Honk Serum overdose amount raised from 30u to 50u.
 * rscadd: Overdosing on 'Nothing' will now permanently remove the clumsy mutation, letting forced clownification victims to regain their dexterity, and evil mimes to prank/punish their clownish counterpart.