### PR TITLE
Clowns Remain Clumsy After Cloning

### DIFF
--- a/code/datums/body_archive.dm
+++ b/code/datums/body_archive.dm
@@ -111,6 +111,7 @@ var/list/body_archives = list()
 	R.default_language = default_language
 	R.times_cloned = times_cloned
 	R.talkcount = talkcount
+	R.clown = M_CLUMSY in mutations
 
 	archive.data["dna_records"] = R
 	archive.data["underwear"] = underwear
@@ -150,6 +151,8 @@ var/list/body_archives = list()
 	var/mob/living/carbon/human/H = new /mob/living/carbon/human(loc, R.dna.species, delay_ready_dna = TRUE)
 	H.times_cloned = 0
 	H.talkcount = R.talkcount
+	if(R.clown)
+		H.mutations.Add(M_CLUMSY)
 	if(isplasmaman(H))
 		H.fire_sprite = "Plasmaman"
 	H.dna = R.dna.Clone()

--- a/code/datums/body_archive.dm
+++ b/code/datums/body_archive.dm
@@ -111,7 +111,7 @@ var/list/body_archives = list()
 	R.default_language = default_language
 	R.times_cloned = times_cloned
 	R.talkcount = talkcount
-	R.clown = M_CLUMSY in mutations
+	R.clown = (M_CLUMSY in mutations)
 
 	archive.data["dna_records"] = R
 	archive.data["underwear"] = underwear

--- a/code/game/objects/structures/dorfpod.dm
+++ b/code/game/objects/structures/dorfpod.dm
@@ -97,6 +97,7 @@ var/obj/structure/dorfpod/center/dorfpod
 	R.default_language = subject.default_language
 	R.times_cloned = subject.times_cloned
 	R.talkcount = subject.talkcount
+	R.clown = M_CLUMSY in subject.mutations
 
 	if (!isnull(subject.mind))
 		R.mind = "\ref[subject.mind]"
@@ -141,6 +142,8 @@ var/obj/structure/dorfpod/center/dorfpod
 	var/mob/living/carbon/human/H = new /mob/living/carbon/human(exit, R.dna.species, delay_ready_dna = TRUE)
 	H.times_cloned = R.times_cloned +1
 	H.talkcount = R.talkcount
+	if(R.clown)
+		H.mutations.Add(M_CLUMSY)
 
 	if(isplasmaman(H))
 		H.fire_sprite = "Plasmaman"

--- a/code/game/objects/structures/dorfpod.dm
+++ b/code/game/objects/structures/dorfpod.dm
@@ -97,7 +97,7 @@ var/obj/structure/dorfpod/center/dorfpod
 	R.default_language = subject.default_language
 	R.times_cloned = subject.times_cloned
 	R.talkcount = subject.talkcount
-	R.clown = M_CLUMSY in subject.mutations
+	R.clown = (M_CLUMSY in subject.mutations)
 
 	if (!isnull(subject.mind))
 		R.mind = "\ref[subject.mind]"

--- a/code/modules/dna/dna_modifier.dm
+++ b/code/modules/dna/dna_modifier.dm
@@ -18,6 +18,7 @@
 	var/default_language=null
 	var/times_cloned=0
 	var/talkcount
+	var/clown
 
 /datum/dna2/record/proc/GetData()
 	var/list/ser=list("data" = null, "owner" = null, "label" = null, "type" = null, "ue" = 0)

--- a/code/modules/dna/dna_modifier.dm
+++ b/code/modules/dna/dna_modifier.dm
@@ -49,6 +49,7 @@
 	new_copy.attack_log = attack_log.Copy()
 	new_copy.default_language = default_language
 	new_copy.times_cloned = times_cloned
+	new_copy.clown = clown
 
 	return new_copy
 

--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -351,7 +351,7 @@
 	R.default_language = H.default_language
 	R.times_cloned = H.times_cloned
 	R.talkcount = H.talkcount
-	R.clown = M_CLUMSY in H.mutations
+	R.clown = (M_CLUMSY in H.mutations)
 	if (!isnull(H.mind))
 		R.mind = "\ref[H.mind]"
 	cloned_records += R

--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -16,7 +16,7 @@
 	req_access = list(access_genetics) //For premature unlocking.
 	var/mob/living/occupant
 	//list of mob/living/ that are currently in the pod. Usually only one, but in exceptional circumstances there may be multiple. All are ejected at the same time (when everyone's ready)
-	var/list/occupants[0] 
+	var/list/occupants[0]
 	var/heal_level = 0 //The clone is released once its health reaches this level.
 	var/locked = FALSE
 	var/frequency = 0
@@ -238,9 +238,11 @@
 		H = new /mob/living/carbon/human(src, R.dna.species, delay_ready_dna = TRUE)
 	H.times_cloned = R.times_cloned + 1
 	H.talkcount = R.talkcount
+	if(R.clown)
+		H.mutations.Add(M_CLUMSY)
 
 	if(isplasmaman(H))
-		H.fire_sprite = "Plasmaman" 
+		H.fire_sprite = "Plasmaman"
 
 	H.dna = R.dna.Clone()
 	H.dna.flavor_text = R.dna.flavor_text
@@ -251,7 +253,7 @@
 	H.UpdateAppearance()
 	H.set_species(H.dna.species)
 	H.update_mutantrace()
-	
+
 	if(do_mind_transfer)
 		has_been_shade.Remove(clonemind)
 		clonemind.transfer_to(H)
@@ -293,7 +295,7 @@
 				if(!force_clone && !isobserver(P))
 					return FALSE
 				break
-	
+
 	var/original_in_cloner = (original in occupants)
 	var/mob/living/carbon/human/H
 	if(original.dna.species == "Vox") //Special case for vox so they get their feathers.
@@ -305,16 +307,18 @@
 	else
 		H.times_cloned = original.times_cloned + 1
 	H.talkcount = original.talkcount
+	if(M_CLUMSY in original.mutations)
+		H.mutations.Add(M_CLUMSY)
 
 	if(isplasmaman(H))
 		H.fire_sprite = "Plasmaman"
-	
+
 	H.dna = original.dna.Clone()
 	H.dna.flavor_text = original.dna.flavor_text
 	H.dna.species = original.dna.species
 	if(H.dna.species != "Human")
 		H.set_species(H.dna.species, TRUE)
-	
+
 	H.UpdateAppearance()
 	H.set_species(H.dna.species)
 	H.update_mutantrace()
@@ -347,6 +351,7 @@
 	R.default_language = H.default_language
 	R.times_cloned = H.times_cloned
 	R.talkcount = H.talkcount
+	R.clown = M_CLUMSY in H.mutations
 	if (!isnull(H.mind))
 		R.mind = "\ref[H.mind]"
 	cloned_records += R
@@ -362,7 +367,7 @@
 /obj/machinery/cloning/clonepod/proc/addclone(var/mob/living/carbon/human/H, var/mob/living/copy_progress_from = null)
 	if(heal_level == 0)
 		heal_level = upgraded ? 100 : rand(10,40) //Randomizes what health the clone is when ejected
-	
+
 	//only lock if we're not already working on a clone
 	if(!working)
 		locked = TRUE
@@ -444,6 +449,7 @@
     R.default_language = orig_record.default_language
     R.times_cloned = orig_record.times_cloned
     R.talkcount = orig_record.talkcount
+    R.clown = orig_record.clown
 
     var/mob/living/carbon/human/clone = growclone(R, copy_progress_from=null, do_mind_transfer=TRUE, allow_multiple=TRUE, force_clone=TRUE)
     var/datum/mind/new_mind = clone.mind

--- a/code/modules/medical/computer/cloning.dm
+++ b/code/modules/medical/computer/cloning.dm
@@ -380,7 +380,7 @@
 					temp += " "
 					i++
 					switch(code)
-						if(ERR_NO_CLONEPOD)	
+						if(ERR_NO_CLONEPOD)
 							temp += "Clone pod [i] unlinkable."
 						if(ERR_CLONEPOD_OCCUPIED)
 							temp += "Clone pod [i] is currently occupied."
@@ -491,6 +491,7 @@
 	R.default_language = subject.default_language
 	R.times_cloned = subject.times_cloned
 	R.talkcount = subject.talkcount
+	R.clown = M_CLUMSY in subject.mutations
 
 	if (!isnull(subject.mind)) //Save that mind so traitors can continue traitoring after cloning.
 		R.mind = "\ref[subject.mind]"

--- a/code/modules/medical/computer/cloning.dm
+++ b/code/modules/medical/computer/cloning.dm
@@ -491,7 +491,7 @@
 	R.default_language = subject.default_language
 	R.times_cloned = subject.times_cloned
 	R.talkcount = subject.talkcount
-	R.clown = M_CLUMSY in subject.mutations
+	R.clown = (M_CLUMSY in subject.mutations)
 
 	if (!isnull(subject.mind)) //Save that mind so traitors can continue traitoring after cloning.
 		R.mind = "\ref[subject.mind]"


### PR DESCRIPTION

## What this does
This PR allows Clumsy mutations to carry over when cloned. Fixes #33689.

Note that this may need further balance changes later if merged, since cloning is one of the only ways currently to remove the clown's ability to clown (usually done as a punishment).

## Why it's good
HONK HONK Clowns will now maintain their POWER even when CLONED! You cannot be rid of the clown so easily. And the clown can keep their powers even if they sacrifice themselves in the name of funny.
<img width="286" height="253" alt="image" src="https://github.com/user-attachments/assets/f4b0039e-03b3-4a33-9fb1-0f0691efd37f" />

pic related: clown sacrificing their powers to be funny

## How it was tested
Cloned myself and confirmed that mutations carry over between clones. Rye will not purge them.
<img width="217" height="263" alt="image" src="https://github.com/user-attachments/assets/917f1ef2-c5a8-4fc2-ac8b-1f1b4b837b1f" />


## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Clowns keep being clumsy even when cloned.
