### PR TITLE
Runtime fixes 20260615

### DIFF
--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -80,6 +80,8 @@
 			if(!signal.data[gas_ID])
 				signal.data[gas_ID] = 0
 		signal.data["sigtype"]="status"
+		if(!radio_connection)
+			return
 		radio_connection.post_signal(src, signal, filter = RADIO_ATMOSIA)
 
 /obj/machinery/air_sensor/proc/set_frequency(new_frequency)
@@ -486,6 +488,8 @@ font-weight:bold;
 	send_signal(list("tag"=device, "status"))
 
 /obj/machinery/computer/general_air_control/large_tank_control/proc/send_signal(var/list/data)
+	if(!radio_connection)
+		return 0
 	var/datum/signal/signal = new /datum/signal
 	signal.transmission_method = 1 //radio signal
 	signal.source = src

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -230,7 +230,6 @@ steam.start() -- spawns the effect
 /proc/spark(var/atom/loc, var/amount = 3, var/cardinals = TRUE, var/surfaceburn = FALSE, var/silent = FALSE)
 	loc = get_turf(loc)
 	if(isnull(loc)) //something in nullspace, holy crap! abort sparks!
-		qdel(src)
 		return
 	var/tally = -1 //Prevent the sparks from starting if there are already too many sparks on the same tile. -1 to exclude itself
 	for(var/obj/effect/sparks/S in loc.contents)

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -229,6 +229,9 @@ steam.start() -- spawns the effect
   */
 /proc/spark(var/atom/loc, var/amount = 3, var/cardinals = TRUE, var/surfaceburn = FALSE, var/silent = FALSE)
 	loc = get_turf(loc)
+	if(isnull(loc)) //something in nullspace, holy crap! abort sparks!
+		qdel(src)
+		return
 	var/tally = -1 //Prevent the sparks from starting if there are already too many sparks on the same tile. -1 to exclude itself
 	for(var/obj/effect/sparks/S in loc.contents)
 		tally++

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -235,6 +235,7 @@
 
 /obj/item/weapon/melee/defibrillator/improvised/New()
 	verbs -= /obj/item/weapon/melee/defibrillator/improvised/verb/remove_cell
+	return ..()
 
 /obj/item/weapon/melee/defibrillator/improvised/examine(var/mob/user)
 	. = ..()

--- a/code/modules/dna/dna_modifier.dm
+++ b/code/modules/dna/dna_modifier.dm
@@ -456,8 +456,7 @@
 
 /obj/machinery/computer/scan_consolenew/Destroy()
 	if(connected)
-		if(connected.connected == src)
-			connected.connected = null
+		connected.connected -= src
 		connected = null
 	for(var/datum/block_label/label in labels)
 		qdel(label)
@@ -498,7 +497,7 @@
 /obj/machinery/computer/scan_consolenew/initialize()
 	connected = findScanner()
 	if(connected)
-		connected.connected = src
+		connected.connected += src
 
 /obj/machinery/computer/scan_consolenew/ex_act(severity)
 	switch(severity)

--- a/code/modules/dna/dna_modifier.dm
+++ b/code/modules/dna/dna_modifier.dm
@@ -558,7 +558,7 @@
 		if(!connected)
 			connected = findScanner() //lets get that machine
 			if(connected)
-				connected.connected = src
+				connected.connected += src
 		ui_interact(user)
 
 /obj/machinery/computer/scan_consolenew/AltClick()

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -17,11 +17,11 @@
 	for(var/datum/organ/external/cosmetic_organ in cosmetic_organs)
 		cosmetic_organ.droplimb(TRUE, TRUE)
 	var/gib_radius = 0
-	if(reagents.has_any_reagents(LUBES))
+	if(reagents?.has_any_reagents(LUBES))
 		gib_radius = 6 //Your insides are all lubed, so gibs travel much further
 
 	anim(target = src, a_icon = 'icons/mob/mob.dmi', flick_anim = "gibbed-h", sleeptime = 15)
-	hgibs(loc, virus2, dna, species.flesh_color, species.blood_color, gib_radius)
+	hgibs(loc, virus2, dna, species?.flesh_color, species?.blood_color, gib_radius)
 	spawn()
 		qdel(src)
 

--- a/code/modules/power/monitor.dm
+++ b/code/modules/power/monitor.dm
@@ -212,7 +212,7 @@
 		var/list/demand = history["demand"]
 		if(!demand)
 			history["demand"] = list()
-			supply = history["demand"]
+			demand = history["demand"]
 
 		var/datum/powernet/connected_powernet = power_connection.get_powernet()
 		if(connected_powernet)

--- a/code/modules/power/monitor.dm
+++ b/code/modules/power/monitor.dm
@@ -206,7 +206,13 @@
 		next_record = world.time + record_interval
 
 		var/list/supply = history["supply"]
+		if(!supply)
+			history["supply"] = list()
+			supply = history["supply"]
 		var/list/demand = history["demand"]
+		if(!demand)
+			history["demand"] = list()
+			supply = history["demand"]
 
 		var/datum/powernet/connected_powernet = power_connection.get_powernet()
 		if(connected_powernet)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -237,10 +237,10 @@ var/const/INGEST = 2
 		var/turf/T = get_turf(my_atom)
 		if(!T) //we got removed, duh
 			T = get_turf(R.my_atom)
-		minimal_investigation_log(I_CHEMS, "[whodunnit ? "[key_name(whodunnit)]" : "(N/A, last user processed: [usr.ckey])"] \
+		minimal_investigation_log(I_CHEMS, "[whodunnit ? "[key_name(whodunnit)]" : "(N/A, last user processed: [key_name(usr)])"] \
 		transferred [english_list(logged_message)] from \a [my_atom] \ref[my_atom] to \a [R.my_atom] \ref[R.my_atom].", prefix=" ([T.x],[T.y],[T.z])")
 		if(adminwarn_message.len)
-			message_admins("[whodunnit ? "[key_name_and_info(whodunnit)] " : "(unknown whodunnit, last whodunnit processed: [usr.ckey])"]\
+			message_admins("[whodunnit ? "[key_name_and_info(whodunnit)] " : "(unknown whodunnit, last whodunnit processed: [key_name(usr)])"]\
 			has transferred [english_list(adminwarn_message)] from \a [my_atom] (<A HREF='?_src_=vars;Vars=\ref[my_atom]'>VV</A>) to \a [R.my_atom] (<A HREF='?_src_=vars;Vars=\ref[R.my_atom]'>VV</A>).\
 			[whodunnit ? " [formatJumpTo(whodunnit)]" : ""]")
 

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -43,6 +43,8 @@
 		if(reagents.total_volume) //Deal with the reagents in the food
 			reagents.reaction(M, INGEST, amount_override = min(reagents.total_volume,amount_per_transfer_from_this)/(reagents.reagent_list.len))
 			spawn(5)
+				if(!reagents)
+					return 0
 				reagents.trans_to(M, amount_per_transfer_from_this)
 
 		playsound(M.loc,'sound/items/drink.ogg', rand(10, 50), 1)
@@ -69,6 +71,8 @@
 		if(reagents.total_volume) //Deal with the reagents in the food
 			reagents.reaction(M, INGEST, amount_override = min(reagents.total_volume,amount_per_transfer_from_this)/(reagents.reagent_list.len))
 			spawn(5)
+				if(!reagents)
+					return 0
 				reagents.trans_to(M, amount_per_transfer_from_this)
 
 		playsound(M.loc,'sound/items/drink.ogg', rand(10,50), 1)

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -44,7 +44,7 @@
 			reagents.reaction(M, INGEST, amount_override = min(reagents.total_volume,amount_per_transfer_from_this)/(reagents.reagent_list.len))
 			spawn(5)
 				if(!reagents)
-					return 0
+					return
 				reagents.trans_to(M, amount_per_transfer_from_this)
 
 		playsound(M.loc,'sound/items/drink.ogg', rand(10, 50), 1)
@@ -72,7 +72,7 @@
 			reagents.reaction(M, INGEST, amount_override = min(reagents.total_volume,amount_per_transfer_from_this)/(reagents.reagent_list.len))
 			spawn(5)
 				if(!reagents)
-					return 0
+					return
 				reagents.trans_to(M, amount_per_transfer_from_this)
 
 		playsound(M.loc,'sound/items/drink.ogg', rand(10,50), 1)

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -261,6 +261,8 @@ var/list/special_fruits = list()
 			spawn()
 				spark(A)
 	else //Teleports the thrower instead.
+		if(!M)
+			return 0 //Nobody to teleport... There was a runtime here!!
 		spark(M)
 		new/obj/effect/decal/cleanable/molten_item(M.loc) //Leaves a pile of goo behind for dramatic effect.
 		M.unlock_from()


### PR DESCRIPTION


## What this does
RUNTIMES FIXED
1. DNA Scannner runtimes related to incomplete changeover in #37407 to list type variable
2. Runtime related to bluespace tomatoes getting thrown by non-mob things.
3. Runtime related to trans_to when nobody has touched the container at any point, resulting in a null usr.
4. Things sparking in nullspace will no longer runtime.
5. Fixed a condiment-related runtime after a spawn() forgot to check if things still existed.
6. Fixed some atmos-related runtimes that occur when a radio connection is broken.
7. Powermonitor computers won't spam runtimes if they fail to properly initialize.
8. Fixes a divide by zero from improvised defibs burning
9. Gibbed mobs that are also subject to qdel will have less runtimes.

## Why it's good
RUNTIMES FIXED

## How it was tested
Tested the first case but the others less so (did not test them!!)

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Various runtime fixes.