### PR TITLE
Fix a CMC TGUI crash

### DIFF
--- a/code/modules/cmc/crew.dm
+++ b/code/modules/cmc/crew.dm
@@ -508,7 +508,7 @@ TGUI PROCS
 			var/list/crew_entry = list()
 
 			crew_entry["name"] = entry[ENTRY_NAME]
-			crew_entry["job"] = entry[ENTRY_ASSIGNMENT]
+			crew_entry["job"] = entry[ENTRY_ASSIGNMENT] || ""
 			crew_entry["vitals"] = entry[ENTRY_STAT]
 			crew_entry["area"] = entry[ENTRY_AREA]
 

--- a/tgui/packages/tgui/interfaces/CrewMonitor.tsx
+++ b/tgui/packages/tgui/interfaces/CrewMonitor.tsx
@@ -144,12 +144,12 @@ export const CrewMonitor = () => {
       let comparison = 0;
       switch (sortBy) {
         case 'name':
-          comparison = a.name.localeCompare(b.name);
+          comparison = (a.name ?? '').localeCompare(b.name ?? '');
           break;
         case 'job':
           comparison = getRolePriority(a.role) - getRolePriority(b.role);
           if (comparison === 0) {
-            comparison = a.job.localeCompare(b.job);
+            comparison = (a.job ?? '').localeCompare(b.job ?? '');
           }
           break;
         case 'health':


### PR DESCRIPTION
## What this does

when two or more crew have the same role priority and at least one has a null job then the JS tries to compare a null and it crashes
this just replaces the null with an empty string at both ends

## Why it's good
interface crashing bad


## How it was tested

- make two crew, put their sensors on max, give salvage captain ID to both of them
- open CMC

before fix:
<img width="1143" height="812" alt="image" src="https://github.com/user-attachments/assets/285c225d-33f0-4dc9-9cd9-4a6984db75e7" />


after fix:
<img width="1255" height="603" alt="image" src="https://github.com/user-attachments/assets/82414c01-7b54-42e9-ad3f-817ca46832a4" />


## Changelog
:cl:
 * bugfix: Fixed a CMC TGUI bluescreen crash
