### PR TITLE
the late AND gay defficiency update

### DIFF
--- a/maps/defficiency.dmm
+++ b/maps/defficiency.dmm
@@ -2901,8 +2901,8 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/newscaster{
-	pixel_y = 30
+/obj/structure/reagent_dispensers/virusfood{
+	pixel_y = 27
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -3500,7 +3500,6 @@
 /area/medical/virology)
 "ahm" = (
 /obj/machinery/disease2/diseaseanalyser,
-/obj/item/weapon/book/manual/virology_encyclopedia,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "dark green stripe";
@@ -3509,9 +3508,6 @@
 /area/medical/virology)
 "ahn" = (
 /obj/structure/table,
-/obj/structure/reagent_dispensers/virusfood{
-	pixel_x = 30
-	},
 /obj/item/weapon/virusdish/random{
 	pixel_x = 4;
 	pixel_y = -11
@@ -3887,7 +3883,7 @@
 	pixel_y = -4
 	},
 /obj/item/device/radio/intercom/medbay{
-	pixel_x = 30;
+	pixel_x = 29;
 	pixel_y = 5
 	},
 /obj/item/weapon/reagent_containers/syringe/antiviral{
@@ -4159,20 +4155,6 @@
 	tag = "icon-dark green stripe (WEST)"
 	},
 /area/medical/virology)
-"aiN" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	name = "Firelock East"
-	},
-/obj/effect/landmark/start{
-	name = "Medical Doctor"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark_navy";
-	tag = "icon-dark_navy (EAST)"
-	},
-/area/medical/sleeper)
 "aiO" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -4202,7 +4184,7 @@
 /obj/machinery/requests_console{
 	department = "Virology";
 	name = "Virology Requests Console";
-	pixel_x = 32
+	pixel_x = 29
 	},
 /obj/item/weapon/storage/box/beakers{
 	pixel_x = 6;
@@ -4732,11 +4714,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/structure/flora/pottedplant/random,
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -4763,6 +4741,10 @@
 	},
 /area/medical/virology)
 "ake" = (
+/obj/structure/wc/sink{
+	dir = 4;
+	pixel_x = 11
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark green stripe";
@@ -5134,6 +5116,10 @@
 /area/medical/virology)
 "akQ" = (
 /obj/structure/table,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /obj/machinery/microwave{
 	pixel_x = -1;
 	pixel_y = 6
@@ -5395,6 +5381,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
+/obj/machinery/light,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"
@@ -5464,7 +5451,7 @@
 /obj/structure/table,
 /obj/item/weapon/storage/box/donkpockets{
 	pixel_x = 3;
-	pixel_y = 3
+	pixel_y = 5
 	},
 /obj/machinery/light{
 	dir = 4
@@ -5758,7 +5745,11 @@
 	},
 /area/medical/virology)
 "ama" = (
-/obj/structure/closet/emcloset,
+/obj/structure/bookcase{
+	name = "Virology Manuals bookcase"
+	},
+/obj/item/weapon/book/manual/virology_encyclopedia,
+/obj/item/weapon/book/manual/virology_guide,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -6166,17 +6157,29 @@
 	},
 /area/medical/virology)
 "amT" = (
-/obj/structure/wc/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+/obj/structure/bed,
+/obj/item/weapon/bedsheet/green,
+/obj/effect/landmark/start{
+	name = "Virologist"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
 /area/medical/virology)
 "amU" = (
-/obj/structure/closet/l3closet/virology,
+/obj/structure/table,
+/obj/item/device/mass_spectrometer{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/weapon/storage/bag/trash/bio{
+	pixel_y = 4;
+	pixel_x = -8
+	},
+/obj/item/weapon/storage/secure/safe{
+	pixel_x = 31;
+	pixel_y = 5
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -6676,15 +6679,6 @@
 	dir = 9
 	},
 /obj/machinery/light,
-/obj/structure/table,
-/obj/item/weapon/storage/bag/trash/bio{
-	pixel_y = 4;
-	pixel_x = -8
-	},
-/obj/item/device/mass_spectrometer{
-	pixel_x = 6;
-	pixel_y = 5
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -6704,16 +6698,10 @@
 	},
 /area/medical/virology)
 "anU" = (
-/obj/item/weapon/storage/secure/safe{
-	pixel_x = 5;
-	pixel_y = -29
-	},
-/obj/structure/bed,
 /obj/machinery/camera{
 	dir = 1;
 	name = "Medbay - Virology Break Room"
 	},
-/obj/item/weapon/bedsheet/green,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -7151,11 +7139,11 @@
 /obj/structure/table,
 /obj/item/weapon/storage/fancy/vials{
 	pixel_x = 4;
-	pixel_y = 6
+	pixel_y = 5
 	},
 /obj/item/weapon/storage/lockbox/vials{
 	pixel_x = -3;
-	pixel_y = -2
+	pixel_y = -1
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -7816,8 +7804,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/item/device/radio/intercom/medbay/broadcast_nospeaker{
-	pixel_y = 24
+/obj/item/device/radio/intercom/medbay{
+	pixel_y = 23
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -7845,7 +7833,7 @@
 	},
 /obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/meatpizza,
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = 29
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -7990,7 +7978,7 @@
 "aqo" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/firstaid/regular{
-	pixel_x = 9;
+	pixel_x = 6;
 	pixel_y = 6
 	},
 /obj/item/weapon/storage/firstaid/regular{
@@ -8670,6 +8658,7 @@
 	dir = 4;
 	pixel_x = -23
 	},
+/obj/machinery/media/jukebox/bar,
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "dark vault stripe"
@@ -8771,8 +8760,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/machinery/door/airlock/glass_medical{
 	id_tag = "";
@@ -9484,7 +9473,8 @@
 	icon_state = "bsposter10";
 	pixel_y = 32
 	},
-/obj/machinery/media/jukebox/bar,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "dark vault stripe";
@@ -9557,10 +9547,10 @@
 /area/medical/break_room)
 "atl" = (
 /obj/machinery/vending/coffee,
-/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/light,
 /turf/simulated/floor{
 	icon_state = "dark vault stripe"
 	},
@@ -10924,9 +10914,6 @@
 	},
 /area/medical/genetics)
 "awj" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/computer/scan_consolenew,
 /turf/simulated/floor{
 	icon_state = "dark purple stripe";
@@ -11102,7 +11089,7 @@
 "awt" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/firstaid/toxin{
-	pixel_x = -5;
+	pixel_x = -3;
 	pixel_y = 5
 	},
 /obj/item/weapon/storage/firstaid/toxin{
@@ -11896,20 +11883,13 @@
 	},
 /area/medical/genetics)
 "aya" = (
-/obj/item/device/radio/intercom/medbay{
-	pixel_y = -28
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "dark purple stripe";
-	tag = "icon-dark purple stripe (WEST)"
-	},
-/area/medical/genetics)
+/turf/simulated/floor,
+/area/science/lab)
 "ayb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -12824,28 +12804,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "azF" = (
-/obj/structure/window/reinforced,
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "dark vault stripe"
-	},
+/turf/simulated/wall/r_wall,
 /area/medical/break_room)
 "azG" = (
-/obj/machinery/requests_console{
-	department = "Genetics";
-	name = "Genetics Requests Console";
-	pixel_y = -30
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/item/device/radio/intercom/medbay{
+	pixel_y = -28;
+	pixel_x = -2
 	},
 /turf/simulated/floor{
 	icon_state = "dark purple stripe";
@@ -12853,7 +12823,6 @@
 	},
 /area/medical/genetics)
 "azH" = (
-/obj/machinery/hologram/holopad,
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -14062,6 +14031,12 @@
 	pixel_y = -3;
 	pixel_x = -5
 	},
+/obj/machinery/requests_console{
+	department = "Genetics";
+	name = "Genetics Requests Console";
+	pixel_x = -28;
+	pixel_y = 2
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "dark purple stripe";
@@ -14097,6 +14072,11 @@
 	req_access_txt = "47"
 	},
 /obj/machinery/computer/telescience,
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 12;
+	pixel_y = 21
+	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "dark vault stripe";
@@ -14147,6 +14127,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/effect/landmark/start{
+	name = "Medical Doctor"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -14786,11 +14769,12 @@
 	pixel_y = -1
 	},
 /obj/item/tool/FixOVein{
-	pixel_x = 2;
+	pixel_x = -4;
 	pixel_y = 2
 	},
 /obj/item/tool/retractor{
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 2
 	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
@@ -15840,8 +15824,10 @@
 	pixel_x = -2;
 	pixel_y = -4
 	},
-/obj/machinery/newscaster{
-	pixel_x = -27
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -25;
+	pixel_y = -1
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -15855,9 +15841,12 @@
 	tag = "icon-warning (WEST)"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 26
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -15949,18 +15938,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera{
-	name = "Research Division East";
-	network = list("SS13","RD");
-	dir = 1
+/obj/machinery/light_switch{
+	pixel_y = -26;
+	pixel_x = -2
 	},
 /turf/simulated/floor{
-	icon_state = "whitepurplecorner"
+	icon_state = "white"
 	},
-/area/science/hallway)
+/area/science/xenobiology)
 "aEV" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -18959,7 +18944,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/hologram/holopad,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -19019,18 +19003,6 @@
 "aKq" = (
 /turf/simulated/wall,
 /area/medical/genetics_cloning)
-"aKr" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/medical/medbay)
 "aKs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -20823,6 +20795,13 @@
 	pixel_x = 5;
 	pixel_y = 4
 	},
+/obj/structure/sign/nosmoking_2{
+	pixel_y = 29
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -20843,13 +20822,13 @@
 	},
 /area/science/mixing)
 "aNB" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -20982,11 +20961,8 @@
 /turf/simulated/floor/plating,
 /area/medical/surgery)
 "aNL" = (
-/obj/structure/closet/hydrant{
-	pixel_y = -32
-	},
-/turf/simulated/floor/engine,
-/area/science/telescience)
+/turf/simulated/wall/r_wall,
+/area/science/rd)
 "aNM" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -21830,6 +21806,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "dark floor stripe";
@@ -22803,7 +22780,7 @@
 "aQZ" = (
 /obj/machinery/requests_console{
 	department = "Medbay";
-	pixel_y = 30;
+	pixel_y = 23;
 	phone_name = "Medbay Lobby"
 	},
 /turf/simulated/floor{
@@ -23514,14 +23491,17 @@
 	dir = 4
 	},
 /obj/structure/dispenser,
-/obj/structure/sign/nosmoking_2{
-	pixel_x = 32
-	},
 /obj/machinery/camera{
 	dir = 8;
 	name = "Science - Toxins Mixing";
 	network = list("SS13","RD");
 	pixel_y = -22
+	},
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	name = "EXTERNAL AIRLOCK";
+	pixel_x = 32
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -23700,10 +23680,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/item/device/radio/intercom/medbay{
-	pixel_y = -28;
-	pixel_x = -1
-	},
 /obj/machinery/door_control{
 	desc = "A remote control switch for the medbay foyer.";
 	id_tag = "MedbayFoyerL";
@@ -23712,6 +23688,10 @@
 	pixel_x = 15;
 	pixel_y = -24;
 	req_access_txt = "5"
+	},
+/obj/item/device/radio/intercom/medbay/broadcast_nospeaker{
+	pixel_x = -1;
+	pixel_y = -28
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -25477,12 +25457,6 @@
 /turf/simulated/floor/engine/airless,
 /area/science/mixing)
 "aVO" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 32
-	},
 /obj/machinery/camera{
 	dir = 8;
 	name = "Science - Toxins Mixing Chamber";
@@ -25632,7 +25606,7 @@
 	departmentType = 1;
 	name = "Medbay RC";
 	phone_name = "Medbay Tubes";
-	pixel_x = -32
+	pixel_x = -29
 	},
 /obj/structure/table,
 /obj/item/weapon/soap{
@@ -26234,6 +26208,10 @@
 /obj/item/weapon/storage/firstaid/regular{
 	pixel_y = 1
 	},
+/obj/item/device/radio/intercom/medbay{
+	pixel_x = -25;
+	pixel_y = 3
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -26788,19 +26766,27 @@
 /turf/simulated/floor/plating,
 /area/derelictparts/fore)
 "aYu" = (
-/obj/structure/sign/biohazard,
-/turf/simulated/wall/r_wall,
+/obj/machinery/light,
+/turf/simulated/floor/engine,
 /area/science/xenobiology)
 "aYv" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
-	name = "HIGH VOLTAGE"
+	name = "HIGH VOLTAGE";
+	pixel_x = -32
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/floor/engine,
 /area/science/xenobiology)
 "aYw" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'HIGH VOLTAGE'";
+	icon_state = "shock";
+	name = "HIGH VOLTAGE";
+	pixel_x = 32
+	},
 /turf/simulated/floor/engine,
 /area/science/xenobiology)
 "aYx" = (
@@ -27632,6 +27618,9 @@
 	req_access = null;
 	req_access_txt = "55"
 	},
+/obj/structure/sign/biohazard{
+	pixel_y = 32
+	},
 /turf/simulated/floor/plating,
 /area/science/xenobiology)
 "bac" = (
@@ -27801,6 +27790,9 @@
 	power = 1;
 	req_access = null;
 	req_access_txt = "55"
+	},
+/obj/structure/sign/biohazard{
+	pixel_y = 32
 	},
 /turf/simulated/floor/plating,
 /area/science/xenobiology)
@@ -28614,6 +28606,10 @@
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -28651,16 +28647,13 @@
 	icon_state = "warning";
 	tag = "icon-warning (EAST)"
 	},
-/obj/machinery/vending/discount,
+/obj/structure/closet/emcloset,
 /turf/simulated/floor{
 	icon_state = "darkpurple"
 	},
 /area/science/hallway)
 "bbH" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/vending/coffee,
+/obj/structure/closet/emcloset,
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "darkpurple"
@@ -28697,9 +28690,24 @@
 	},
 /area/science/hallway)
 "bbL" = (
-/obj/structure/closet/emcloset,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8;
+	name = "Firelock West"
+	},
+/obj/machinery/camera{
+	name = "Research Division West";
+	network = list("SS13","RD");
+	dir = 6
+	},
+/obj/machinery/firealarm{
+	pixel_y = 25
+	},
 /turf/simulated/floor{
-	icon_state = "darkpurple"
+	dir = 4;
+	icon_state = "whitepurplecorner"
 	},
 /area/science/hallway)
 "bbM" = (
@@ -28765,6 +28773,11 @@
 	},
 /area/science/hallway)
 "bbT" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "whitepurple"
@@ -29374,10 +29387,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/alarm{
-	pixel_y = 24;
-	target_temperature = 73.15
-	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "whitepurplecorner"
@@ -29443,9 +29452,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/camera{
-	name = "Research Division West";
-	network = list("SS13","RD")
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -29462,9 +29470,6 @@
 /obj/structure/bed/chair/office/light{
 	dir = 8
 	},
-/obj/effect/landmark/start{
-	name = "Virologist"
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -29475,8 +29480,17 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/status_display{
+	pixel_x = 32
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 24
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -30425,6 +30439,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8;
+	name = "Firelock West"
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -30469,11 +30487,9 @@
 	dir = 10
 	},
 /obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	pixel_x = 24
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -30488,9 +30504,13 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/machinery/disposal,
+/obj/machinery/disposal{
+	name = "Patient Disposal";
+	desc = "A disposal unit that leads straight to Medbay."
+	},
 /obj/structure/sign/bodydisposal{
-	pixel_x = -31
+	pixel_x = -31;
+	desc = "The pride and joy of both medical doctors and scientists; an injured man being thrown out of a pipe."
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -30510,6 +30530,9 @@
 /turf/simulated/floor,
 /area/science/lab)
 "beX" = (
+/obj/structure/closet/hydrant{
+	pixel_x = -32
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkpurple"
@@ -31428,6 +31451,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "whitepurplecorner"
@@ -31496,7 +31523,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/light,
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -31518,17 +31544,13 @@
 	},
 /area/science/hallway)
 "bgw" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor{
+	dir = 4;
 	icon_state = "whitepurplecorner"
 	},
 /area/science/hallway)
@@ -31552,6 +31574,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8;
+	name = "Firelock West"
 	},
 /turf/simulated/floor{
 	icon_state = "whitepurplecorner"
@@ -32432,7 +32458,8 @@
 /obj/machinery/camera{
 	dir = 1;
 	name = "Xenobiology Northwest";
-	network = list("SS13","RD")
+	network = list("SS13","RD");
+	pixel_x = -4
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -32453,15 +32480,22 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/newscaster{
+	pixel_x = 27
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
 /area/science/xenobiology)
 "bid" = (
-/obj/machinery/newscaster,
-/turf/simulated/wall/r_wall,
-/area/science/xenobiology)
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "whitepurplecorner"
+	},
+/area/science/hallway)
 "bie" = (
 /turf/simulated/wall,
 /area/science/server)
@@ -32559,10 +32593,8 @@
 	dir = 1;
 	name = "Firelock North"
 	},
-/obj/machinery/camera{
-	dir = 4;
-	name = "Research Division East";
-	network = list("SS13","RD")
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 25
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -32997,7 +33029,7 @@
 	tag = "icon-warning (NORTH)"
 	},
 /obj/machinery/camera{
-	dir = 8;
+	dir = 9;
 	name = "Xenobiology Northeast";
 	network = list("SS13","RD")
 	},
@@ -33022,19 +33054,12 @@
 	},
 /area/science/xenobiology)
 "bjl" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/obj/machinery/alarm{
-	pixel_y = 23
-	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
 /area/science/xenobiology)
 "bjm" = (
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
 /obj/machinery/monkey_recycler,
 /turf/simulated/floor{
 	icon_state = "white"
@@ -33051,6 +33076,11 @@
 /area/science/xenobiology)
 "bjo" = (
 /obj/machinery/computer/rdservercontrol,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'SERVER ROOM'.";
+	name = "SERVER ROOM";
+	pixel_y = 32
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -33061,11 +33091,6 @@
 	on = 1
 	},
 /obj/effect/decal/cleanable/cobweb2,
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'SERVER ROOM'.";
-	name = "SERVER ROOM";
-	pixel_x = 32
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -33094,6 +33119,11 @@
 /obj/structure/closet/secure_closet/RD,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/weapon/storage/belt/utility,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'SERVER ROOM'.";
+	name = "SERVER ROOM";
+	pixel_x = -32
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -33144,9 +33174,6 @@
 /area/science/rd)
 "bjw" = (
 /obj/machinery/computer/aifixer,
-/obj/machinery/media/receiver/boombox/wallmount{
-	pixel_x = 32
-	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -33162,15 +33189,14 @@
 	dir = 1
 	},
 /obj/item/weapon/reagent_containers/food/snacks/customizable/cook/donkpocket{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/item/weapon/reagent_containers/food/snacks/customizable/cook/donkpocket{
-	pixel_x = -6;
+	pixel_x = -5;
 	pixel_y = 3
 	},
 /obj/item/weapon/reagent_containers/food/snacks/customizable/cook/donkpocket{
-	pixel_x = -9;
+	pixel_x = -16
+	},
+/obj/item/weapon/reagent_containers/food/snacks/customizable/cook/donkpocket{
+	pixel_x = -10;
 	pixel_y = 9
 	},
 /turf/simulated/floor{
@@ -33189,15 +33215,19 @@
 	name = "Research Division Break Room"
 	},
 /obj/item/weapon/reagent_containers/food/drinks/flagmug/uruguaycup{
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/item/weapon/reagent_containers/food/drinks/flagmug/uruguaycup{
 	pixel_x = 1;
 	pixel_y = 5
 	},
 /obj/item/weapon/reagent_containers/food/drinks/flagmug/uruguaycup{
 	pixel_x = -3;
-	pixel_y = 1
-	},
-/obj/item/weapon/reagent_containers/food/drinks/flagmug/uruguaycup{
-	pixel_x = 5;
 	pixel_y = 1
 	},
 /turf/simulated/floor{
@@ -33298,6 +33328,11 @@
 	name = "Scientist"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/science/lab)
 "bjJ" = (
@@ -34143,11 +34178,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
@@ -34181,6 +34211,11 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -34211,11 +34246,17 @@
 /area/science/rd)
 "blj" = (
 /obj/structure/table,
-/obj/item/weapon/folder/purple,
-/obj/item/weapon/paper/monitorkey,
+/obj/item/weapon/paper/monitorkey{
+	pixel_y = 6;
+	pixel_x = 6
+	},
+/obj/item/weapon/folder/purple{
+	pixel_x = -3;
+	pixel_y = 2
+	},
 /obj/item/weapon/stamp/rd{
-	pixel_x = 3;
-	pixel_y = -2
+	pixel_x = -3;
+	pixel_y = -4
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -34230,13 +34271,6 @@
 	pixel_x = -5;
 	pixel_y = 9;
 	req_access_txt = "47"
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Research Director's Desk";
-	departmentType = 5;
-	name = "Research Director RC";
-	pixel_x = 30
 	},
 /obj/machinery/keycard_auth{
 	pixel_x = -4;
@@ -34253,6 +34287,15 @@
 /obj/item/weapon/cartridge/signal/toxins{
 	pixel_x = 8;
 	pixel_y = -1
+	},
+/obj/machinery/light_switch{
+	pixel_x = 24;
+	pixel_y = -6
+	},
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 27;
+	pixel_y = 4
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -34314,11 +34357,6 @@
 	},
 /area/science/hallway)
 "blp" = (
-/obj/machinery/door/airlock/research{
-	name = "Research and Development Lab";
-	req_access_txt = "7";
-	icon = 'icons/obj/doors/doorresearchglass.dmi'
-	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -34333,6 +34371,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8;
 	name = "Firelock West"
+	},
+/obj/machinery/door/airlock/glass_research{
+	name = "Research and Development Lab";
+	req_access_txt = "7"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -34374,16 +34416,16 @@
 	},
 /area/science/lab)
 "bls" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -34401,6 +34443,11 @@
 /area/science/lab)
 "blu" = (
 /obj/machinery/computer/rdconsole/core,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/science/lab)
 "blv" = (
@@ -34451,6 +34498,9 @@
 	pixel_x = -7;
 	pixel_y = -1
 	},
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -34461,13 +34511,13 @@
 	name = "Emergency Vacuum Pump"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/landmark/start{
-	name = "Paramedic"
-	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/effect/landmark/start{
+	name = "Paramedic"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -35071,27 +35121,6 @@
 	icon_state = "white"
 	},
 /area/science/xenobiology)
-"bmG" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'SERVER ROOM'.";
-	name = "SERVER ROOM";
-	pixel_x = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/structure/window/full/reinforced,
-/turf/simulated/floor/plating,
-/area/science/server)
 "bmH" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -35120,16 +35149,14 @@
 	},
 /area/science/server)
 "bmJ" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/structure/cable/yellow,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
 	},
 /obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/ai_status_display{
+	pixel_x = -32
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -35142,11 +35169,13 @@
 	name = "Research Director's Office";
 	network = list("SS13","RD")
 	},
-/obj/machinery/light_switch{
-	pixel_y = -24
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -35182,17 +35211,23 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
 /area/science/rd)
 "bmO" = (
-/obj/structure/table,
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the RD's goons from the safety of his office.";
 	name = "Research Monitor";
 	network = list("RD");
-	pixel_y = 2
+	pixel_y = 2;
+	pixel_x = 26;
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes{
 	dir = 5;
@@ -35205,9 +35240,6 @@
 /area/science/rd)
 "bmP" = (
 /obj/structure/bed/chair/comfy/beige,
-/obj/machinery/newscaster{
-	pixel_x = -25
-	},
 /obj/effect/landmark/start{
 	name = "Scientist"
 	},
@@ -35257,11 +35289,6 @@
 	},
 /area/science/lab)
 "bmT" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -35272,7 +35299,9 @@
 	},
 /obj/item/weapon/storage/bag/gadgets,
 /obj/item/stack/sheet/mineral/plastic{
-	amount = 10
+	amount = 10;
+	pixel_y = -7;
+	pixel_x = 3
 	},
 /obj/item/weapon/storage/bag/gadgets{
 	pixel_x = 2;
@@ -35320,7 +35349,6 @@
 	icon_state = "warning";
 	tag = "icon-warning (NORTH)"
 	},
-/obj/machinery/hologram/holopad,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -35347,7 +35375,8 @@
 /obj/machinery/door_control{
 	id_tag = "rnd";
 	name = "Shutters Control Button";
-	pixel_x = 24
+	pixel_x = 24;
+	pixel_y = -7
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -35782,40 +35811,57 @@
 "bnQ" = (
 /obj/structure/table,
 /obj/item/weapon/extinguisher{
-	pixel_x = 4;
-	pixel_y = 3
+	pixel_y = 5;
+	pixel_x = 1
 	},
-/obj/item/weapon/extinguisher,
-/obj/item/weapon/lazarus_injector,
+/obj/item/weapon/lazarus_injector{
+	pixel_y = 6
+	},
+/obj/item/weapon/extinguisher{
+	pixel_x = 4;
+	pixel_y = 4
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
 /area/science/xenobiology)
 "bnR" = (
 /obj/structure/table,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/plasma,
 /obj/machinery/light,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
-/obj/item/stack/sheet/mineral/plasma,
+/obj/machinery/reagentgrinder{
+	pixel_x = -9;
+	pixel_y = 15
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	pixel_x = 9;
+	pixel_y = 1
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
 /area/science/xenobiology)
 "bnS" = (
 /obj/structure/table,
-/obj/item/weapon/storage/box/monkeycubes,
-/obj/item/weapon/storage/box/monkeycubes,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/item/weapon/storage/box/monkeycubes,
+/obj/item/weapon/storage/box/monkeycubes{
+	pixel_y = 7;
+	pixel_x = 5
+	},
+/obj/item/weapon/storage/box/monkeycubes{
+	pixel_x = -12;
+	pixel_y = 5
+	},
+/obj/item/weapon/storage/box/monkeycubes{
+	pixel_x = -4;
+	pixel_y = 1
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -35828,11 +35874,14 @@
 /area/science/xenobiology)
 "bnU" = (
 /obj/structure/table,
-/obj/item/weapon/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
+/obj/item/weapon/storage/box/syringes{
+	pixel_x = 4;
+	pixel_y = 4
 	},
-/obj/item/weapon/storage/box/syringes,
+/obj/item/weapon/storage/box/beakers{
+	pixel_x = 4;
+	pixel_y = 15
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -35896,27 +35945,46 @@
 "boa" = (
 /obj/structure/table,
 /obj/item/weapon/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
+	pixel_x = -3;
+	pixel_y = 10
 	},
-/obj/item/weapon/pen,
-/obj/item/weapon/planning_frame,
+/obj/item/weapon/pen{
+	pixel_y = 9;
+	pixel_x = 8
+	},
+/obj/item/weapon/planning_frame{
+	pixel_x = -4;
+	pixel_y = -6
+	},
 /obj/effect/decal/warning_stripes{
 	dir = 8;
 	icon_state = "warning";
 	tag = "icon-warning (WEST)"
 	},
-/obj/item/clothing/glasses/welding/superior,
+/obj/item/clothing/glasses/welding/superior{
+	pixel_x = 3;
+	pixel_y = -4
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	pixel_x = -26;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
 /area/science/rd)
 "bob" = (
-/obj/structure/lamarr,
 /obj/effect/decal/warning_stripes{
 	dir = 4;
 	icon_state = "warning";
 	tag = "icon-warning (EAST)"
+	},
+/obj/structure/table,
+/obj/item/device/aicard{
+	pixel_y = -3;
+	pixel_x = -1
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -35948,7 +36016,11 @@
 	},
 /area/science/hallway)
 "bod" = (
-/obj/structure/flora/pottedplant/random,
+/obj/structure/wc/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkpurple"
@@ -35971,38 +36043,29 @@
 "bof" = (
 /turf/simulated/wall,
 /area/science/lab)
-"bog" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 25
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "whitepurplecorner"
-	},
-/area/science/hallway)
 "boh" = (
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
 /area/science/lab)
 "boi" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/structure/cable/yellow,
 /obj/structure/table,
 /obj/item/weapon/hand_labeler{
 	pixel_y = 6
 	},
 /obj/item/weapon/storage/box/labels,
 /obj/item/stack/package_wrap{
-	pixel_y = -7;
-	pixel_x = 1
+	pixel_y = -9;
+	pixel_x = 2
 	},
-/obj/item/stack/package_wrap{
-	pixel_y = -10
+/obj/machinery/requests_console{
+	department = "Science";
+	departmentType = 2;
+	name = "Science Requests Console";
+	phone_name = "Research And Development";
+	pixel_y = -2;
+	pixel_x = -29
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -36056,6 +36119,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/machinery/camera{
+	name = "Research Division East";
+	network = list("SS13","RD");
+	dir = 10
 	},
 /turf/simulated/floor{
 	icon_state = "whitepurplecorner"
@@ -36576,12 +36644,11 @@
 	},
 /area/science/rd)
 "bpp" = (
-/obj/structure/table,
-/obj/item/device/aicard,
 /obj/effect/decal/warning_stripes{
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
+/obj/structure/lamarr,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -36589,22 +36656,31 @@
 "bpq" = (
 /obj/structure/table,
 /obj/item/device/taperecorder{
-	pixel_x = -3
+	pixel_x = -4;
+	pixel_y = 4
 	},
 /obj/item/device/paicard{
-	pixel_x = 4
+	pixel_x = 5;
+	pixel_y = 3
 	},
 /obj/effect/decal/warning_stripes{
 	dir = 10;
 	icon_state = "warning";
 	tag = "icon-warning (SOUTHWEST)"
 	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Research Director's Desk";
+	departmentType = 5;
+	name = "Research Director RC";
+	pixel_x = -28;
+	pixel_y = 9
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
 /area/science/rd)
 "bpr" = (
-/obj/structure/table,
 /obj/item/weapon/circuitboard/aicore{
 	pixel_x = -2;
 	pixel_y = 4
@@ -36615,12 +36691,19 @@
 	icon_state = "warning";
 	tag = "icon-warning (SOUTHEAST)"
 	},
+/obj/structure/table,
+/obj/machinery/media/receiver/boombox/wallmount{
+	pixel_x = 28;
+	pixel_y = 7
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
 /area/science/rd)
 "bps" = (
-/obj/structure/bed/chair/comfy/beige,
+/obj/structure/bed/chair/comfy/beige{
+	dir = 1
+	},
 /obj/effect/landmark/start{
 	name = "Scientist"
 	},
@@ -36630,12 +36713,10 @@
 	},
 /area/science/hallway)
 "bpt" = (
-/obj/structure/mirror{
-	pixel_x = 24
-	},
-/obj/structure/wc/sink{
-	dir = 4;
-	pixel_x = 11
+/obj/structure/flora/pottedplant/random,
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = 3
 	},
 /turf/simulated/floor{
 	dir = 6;
@@ -36688,9 +36769,14 @@
 	charge = 100;
 	maxcharge = 15000
 	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -23
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -27;
+	pixel_y = 4
+	},
+/obj/item/stack/package_wrap{
+	pixel_y = 15;
+	pixel_x = 2
 	},
 /turf/simulated/floor{
 	dir = 10;
@@ -36698,15 +36784,13 @@
 	},
 /area/science/lab)
 "bpy" = (
-/obj/machinery/requests_console{
-	department = "Science";
-	departmentType = 2;
-	name = "Science Requests Console";
-	phone_name = "Research And Development";
-	pixel_y = -28
+/obj/structure/wc/sink{
+	dir = 4;
+	pixel_x = 11
 	},
 /obj/machinery/light_switch{
-	pixel_x = 24
+	pixel_x = -1;
+	pixel_y = -25
 	},
 /turf/simulated/floor{
 	dir = 6;
@@ -36728,8 +36812,8 @@
 	req_access_txt = "7"
 	},
 /obj/item/device/deskbell/signaler/rnd{
-	pixel_x = 3;
-	pixel_y = -3
+	pixel_x = 1;
+	pixel_y = -1
 	},
 /obj/machinery/door/firedoor/border_only{
 	name = "Firelock South"
@@ -37211,14 +37295,13 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/research{
-	name = "Research Division Access";
-	req_access_txt = "47";
-	icon = 'icons/obj/doors/doorresearchglass.dmi'
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1;
 	name = "Firelock North"
+	},
+/obj/machinery/door/airlock/glass_research{
+	name = "Research Division Access";
+	req_access_txt = "47"
 	},
 /turf/simulated/floor{
 	icon_state = "whitepurplefull"
@@ -37257,10 +37340,9 @@
 /obj/machinery/door/firedoor/border_only{
 	name = "Firelock South"
 	},
-/obj/machinery/door/airlock/research{
+/obj/machinery/door/airlock/glass_research{
 	name = "Research and Development Lab";
-	req_access_txt = "7";
-	icon = 'icons/obj/doors/doorresearchglass.dmi'
+	req_access_txt = "7"
 	},
 /turf/simulated/floor{
 	icon_state = "whitepurplefull"
@@ -37851,6 +37933,9 @@
 /obj/structure/table,
 /obj/item/weapon/aiModule/core/nanotrasen,
 /obj/item/weapon/aiModule/core/lazymov,
+/obj/machinery/ai_status_display{
+	pixel_y = 32
+	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_upload)
 "brH" = (
@@ -37892,9 +37977,6 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_upload)
 "brL" = (
-/obj/machinery/ai_status_display{
-	pixel_y = 32
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -37918,14 +38000,6 @@
 	},
 /area/turret_protected/ai_upload_foyer)
 "brN" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/turretid{
 	control_area = "\improper AI Upload Chamber";
@@ -37938,6 +38012,9 @@
 /area/turret_protected/ai_upload_foyer)
 "brO" = (
 /obj/machinery/recharge_station,
+/obj/machinery/ai_status_display{
+	pixel_y = 32
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -37951,6 +38028,9 @@
 	network = list("SS13","RD")
 	},
 /obj/structure/closet/firecloset/full,
+/obj/machinery/status_display{
+	pixel_x = -32
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "whiteblue"
@@ -38646,15 +38726,15 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -38671,6 +38751,7 @@
 /obj/effect/landmark/start{
 	name = "Cyborg"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -39046,13 +39127,13 @@
 "btU" = (
 /obj/structure/wc/sink{
 	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+	pixel_x = -11
 	},
 /obj/machinery/camera{
 	dir = 4;
 	name = "Xenobiology South";
-	network = list("SS13","RD")
+	network = list("SS13","RD");
+	pixel_y = 1
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -39164,11 +39245,15 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/machinery/hologram/holopad,
 /obj/effect/landmark/start{
 	name = "Cyborg"
 	},
 /obj/machinery/light,
+/obj/machinery/power/apc{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/structure/cable/yellow,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -39194,7 +39279,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai_upload_foyer)
 "bui" = (
@@ -39921,11 +40005,6 @@
 /turf/simulated/wall/r_wall,
 /area/science/robotics)
 "bvw" = (
-/obj/machinery/door/airlock/research{
-	name = "Robotics Lab";
-	req_access_txt = "29";
-	icon = 'icons/obj/doors/doorresearchglass.dmi'
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -39935,6 +40014,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1;
 	name = "Firelock North"
+	},
+/obj/machinery/door/airlock/glass_research{
+	name = "Robotics Lab";
+	req_access_txt = "29"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -40671,6 +40754,9 @@
 	pixel_x = -8;
 	pixel_y = 4
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "whitebluecorner"
@@ -40710,14 +40796,18 @@
 	name = "Robotics Lab North";
 	network = list("SS13","RD")
 	},
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
+/obj/item/weapon/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
 /area/science/robotics)
 "bwG" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	on = 1
-	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -40734,6 +40824,9 @@
 	pixel_x = 5;
 	pixel_y = -5
 	},
+/obj/machinery/newscaster{
+	pixel_y = 29
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -40743,6 +40836,9 @@
 	dir = 1
 	},
 /obj/machinery/suit_modifier,
+/obj/effect/landmark/start{
+	name = "Roboticist"
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -41370,9 +41466,19 @@
 	},
 /area/turret_protected/ai)
 "bxT" = (
-/obj/effect/decal/cleanable/cobweb,
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = 23;
+	pixel_x = -3
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "whitepurplecorner"
+	},
+/area/science/hallway)
 "bxU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -41385,6 +41491,10 @@
 "bxW" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
@@ -41452,18 +41562,16 @@
 /area/science/robotics)
 "bye" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
 /obj/item/weapon/stool,
-/obj/effect/landmark/start{
-	name = "Roboticist"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/science/robotics)
 "byf" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/simulated/floor{
-	icon_state = "white"
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
+/turf/simulated/floor,
 /area/science/robotics)
 "byg" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -41962,30 +42070,12 @@
 	},
 /area/turret_protected/ai)
 "bzp" = (
-/obj/structure/rack{
-	dir = 8
-	},
-/obj/item/weapon/storage/toolbox/electrical{
-	pixel_x = 1;
-	pixel_y = 6
-	},
-/obj/item/weapon/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/clothing/head/welding{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/item/clothing/glasses/welding,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/item/device/robotanalyzer,
-/obj/item/device/robotanalyzer,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "whitebluecorner"
@@ -42040,18 +42130,20 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 1;
+	on = 1
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
 /area/science/robotics)
 "bzv" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/door_control{
+	id_tag = "robotics";
+	name = "Shutters Control Button";
+	pixel_x = 24;
+	pixel_y = -8
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -42059,11 +42151,6 @@
 /area/science/robotics)
 "bzw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
@@ -42785,7 +42872,8 @@
 /obj/machinery/camera/flawless{
 	dir = 8;
 	name = "AI Chamber East";
-	network = list("RD")
+	network = list("RD");
+	pixel_y = 4
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/bluegrid,
@@ -42803,12 +42891,6 @@
 	},
 /area/turret_protected/ai)
 "bAK" = (
-/obj/structure/table,
-/obj/item/device/flash/synthetic,
-/obj/item/device/flash/synthetic,
-/obj/item/device/flash/synthetic,
-/obj/item/device/flash/synthetic,
-/obj/item/device/flash/synthetic,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
@@ -42818,13 +42900,52 @@
 	icon_state = "warning";
 	tag = "icon-warning (NORTH)"
 	},
-/obj/item/device/mmi/posibrain,
+/obj/structure/rack{
+	dir = 8
+	},
+/obj/item/weapon/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = 6
+	},
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/head/welding{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/device/robotanalyzer,
+/obj/item/device/robotanalyzer,
 /turf/simulated/floor,
 /area/science/robotics)
 "bAL" = (
-/obj/machinery/ai_status_display,
-/turf/simulated/wall/r_wall,
-/area/science/robotics)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "biohazard";
+	name = "Biohazard Blast Doors";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/glass_research{
+	name = "Mech Bay";
+	req_access_txt = "29"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1;
+	name = "Firelock North"
+	},
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/science/chargebay)
 "bAM" = (
 /obj/effect/decal/warning_stripes{
 	dir = 1;
@@ -42857,7 +42978,6 @@
 	},
 /area/science/robotics)
 "bAP" = (
-/obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor{
 	icon_state = "whiteredcorner"
 	},
@@ -43301,18 +43421,22 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai)
 "bBJ" = (
-/obj/machinery/alarm{
+/obj/effect/decal/warning_stripes{
 	dir = 8;
-	pixel_x = 22
+	icon_state = "warning";
+	tag = "icon-warning (WEST)"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai)
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/science/robotics)
 "bBK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -43323,32 +43447,42 @@
 /area/turret_protected/ai)
 "bBL" = (
 /obj/structure/table,
+/obj/item/stack/sheet/metal{
+	amount = 50;
+	pixel_y = 4
+	},
+/obj/item/stack/sheet/metal{
+	amount = 50;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/metal{
+	amount = 50;
+	pixel_y = 4
+	},
 /obj/item/stack/sheet/glass/glass{
 	amount = 20;
-	pixel_x = -3;
-	pixel_y = 6
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/machinery/ai_status_display{
+	pixel_x = -32
+	},
+/obj/item/stack/sheet/plasteel{
+	amount = 10;
+	pixel_x = -5
 	},
 /obj/item/stack/sheet/metal{
-	amount = 50
+	amount = 50;
+	pixel_y = 5
 	},
 /obj/item/stack/sheet/metal{
-	amount = 50
+	amount = 50;
+	pixel_x = -2;
+	pixel_y = 4
 	},
 /obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -25
+	amount = 50;
+	pixel_y = 3
 	},
 /turf/simulated/floor,
 /area/science/robotics)
@@ -43367,9 +43501,7 @@
 /obj/effect/landmark/start{
 	name = "Roboticist"
 	},
-/obj/structure/bed/chair/office/light{
-	dir = 4
-	},
+/obj/structure/bed/chair/office/light,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -43882,15 +44014,51 @@
 /area/turret_protected/ai)
 "bCS" = (
 /obj/structure/table,
-/obj/item/stack/sheet/plasteel{
-	amount = 10
+/obj/item/stack/cable_coil{
+	pixel_x = -3;
+	pixel_y = 6
 	},
-/obj/item/stack/cable_coil,
-/obj/item/device/flash,
-/obj/item/device/flash,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_x = -29
+	pixel_x = -27
+	},
+/obj/item/device/flash/synthetic{
+	pixel_x = 10;
+	pixel_y = 9
+	},
+/obj/item/device/flash/synthetic{
+	pixel_x = 10;
+	pixel_y = 9
+	},
+/obj/item/device/flash/synthetic{
+	pixel_x = 10;
+	pixel_y = 9
+	},
+/obj/item/device/flash/synthetic{
+	pixel_x = 10;
+	pixel_y = 12
+	},
+/obj/item/device/flash/synthetic{
+	pixel_x = 9;
+	pixel_y = 9
+	},
+/obj/item/device/flash{
+	pixel_y = 13;
+	pixel_x = -2
+	},
+/obj/item/weapon/reagent_containers/glass/beaker/large{
+	pixel_x = -7;
+	pixel_y = -10
+	},
+/obj/item/weapon/cell/high{
+	charge = 100;
+	maxcharge = 15000;
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/obj/item/device/flash{
+	pixel_y = 12;
+	pixel_x = -2
 	},
 /turf/simulated/floor,
 /area/science/robotics)
@@ -43898,6 +44066,7 @@
 /turf/simulated/floor,
 /area/science/robotics)
 "bCU" = (
+/obj/machinery/computer/rdconsole/robotics,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -44413,18 +44582,17 @@
 "bDV" = (
 /obj/structure/table,
 /obj/item/weapon/book/manual/robotics_cyborgs{
-	pixel_x = 2;
-	pixel_y = 5
+	pixel_x = 5;
+	pixel_y = 7
 	},
-/obj/item/weapon/storage/belt/utility,
-/obj/machinery/requests_console{
-	department = "Robotics";
-	departmentType = 2;
-	name = "Robotics RC";
-	pixel_x = -30
+/obj/item/weapon/storage/belt/utility{
+	pixel_y = -1;
+	pixel_x = -3
 	},
-/obj/item/weapon/storage/belt/utility,
-/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/weapon/storage/belt/utility{
+	pixel_y = -1;
+	pixel_x = -3
+	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -44440,11 +44608,8 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "bDY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/science/robotics)
@@ -44454,9 +44619,6 @@
 	icon_state = "warning";
 	tag = "icon-warning (WEST)"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
@@ -44465,20 +44627,14 @@
 	},
 /area/science/robotics)
 "bEa" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/science/robotics)
 "bEb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -44494,29 +44650,30 @@
 /area/hallway/primary/central)
 "bEd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
 /area/science/robotics)
 "bEe" = (
-/obj/machinery/door_control{
-	id_tag = "robotics";
-	name = "Shutters Control Button";
-	pixel_x = 24;
-	pixel_y = 8
+/obj/machinery/r_n_d/fabricator/circuit_imprinter,
+/obj/machinery/power/apc{
+	dir = 4;
+	pixel_x = 24
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/machinery/disposal,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -45009,13 +45166,16 @@
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai)
 "bFf" = (
-/obj/structure/wc/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+/obj/machinery/requests_console{
+	department = "Robotics";
+	departmentType = 2;
+	name = "Robotics RC";
+	pixel_x = -30;
+	pixel_y = 5
 	},
-/obj/machinery/newscaster{
-	pixel_x = -28
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/science/robotics)
@@ -45046,10 +45206,10 @@
 	},
 /area/hallway/primary/central)
 "bFj" = (
-/obj/machinery/r_n_d/fabricator/circuit_imprinter,
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/closet/wardrobe/robotics_black,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -45449,25 +45609,38 @@
 /area/turret_protected/ai)
 "bGe" = (
 /obj/structure/table,
-/obj/item/tool/retractor,
-/obj/item/tool/hemostat,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/window/reinforced/tinted{
-	dir = 8
+/obj/item/tool/circular_saw{
+	pixel_y = -13;
+	pixel_x = 3
 	},
-/obj/item/tool/circular_saw,
+/obj/item/tool/retractor{
+	pixel_x = 4;
+	pixel_y = 3
+	},
 /obj/item/tool/scalpel{
-	pixel_y = 12
+	pixel_y = 9;
+	pixel_x = -1
 	},
-/turf/simulated/floor,
+/obj/item/tool/hemostat{
+	pixel_x = -9;
+	pixel_y = 4
+	},
+/turf/simulated/floor{
+	icon_state = "whitehall"
+	},
 /area/science/robotics)
 "bGf" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 4
+/obj/structure/table,
+/obj/item/device/mmi/posibrain{
+	pixel_y = -2;
+	pixel_x = 3
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "whitehall"
+	},
 /area/science/robotics)
 "bGg" = (
 /turf/simulated/floor{
@@ -45480,23 +45653,8 @@
 	icon_state = "purple"
 	},
 /area/hallway/primary/central)
-"bGi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/item/weapon/stool,
-/turf/simulated/floor{
-	icon_state = "white"
-	},
-/area/science/robotics)
 "bGj" = (
-/obj/machinery/computer/rdconsole/robotics,
-/obj/structure/closet/hydrant{
-	pixel_x = 32
-	},
+/obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -46017,15 +46175,11 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "bHr" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 8
-	},
 /obj/structure/table,
 /obj/item/device/mmi,
 /obj/item/device/mmi,
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "whitehall"
+	icon_state = "white"
 	},
 /area/science/robotics)
 "bHs" = (
@@ -46034,14 +46188,13 @@
 	name = "Robotics Lab South";
 	network = list("SS13","RD")
 	},
-/obj/structure/window/reinforced/tinted{
-	dir = 4
-	},
 /obj/structure/table,
-/obj/item/weapon/storage/box/bodybags,
+/obj/item/weapon/storage/box/bodybags{
+	pixel_y = 3;
+	pixel_x = 1
+	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "whitehall"
+	icon_state = "white"
 	},
 /area/science/robotics)
 "bHt" = (
@@ -46065,14 +46218,26 @@
 /turf/simulated/wall/r_wall,
 /area/science/chargebay)
 "bHw" = (
-/obj/structure/closet/wardrobe/robotics_black,
-/obj/machinery/light_switch{
-	pixel_x = 22
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/simulated/floor{
-	icon_state = "white"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/area/science/robotics)
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "biohazard";
+	name = "Biohazard Blast Doors";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/science/chargebay)
 "bHx" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 2;
@@ -46569,26 +46734,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/research{
-	name = "Mech Bay";
-	req_access_txt = "29";
-	icon = 'icons/obj/doors/doorresearchglass.dmi'
-	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	name = "Firelock North"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "biohazard";
-	name = "Biohazard Blast Doors";
-	opacity = 0
 	},
 /turf/simulated/floor,
 /area/science/chargebay)
@@ -109355,6 +109504,19 @@
 	},
 /turf/simulated/floor,
 /area/hallway/primary/fore)
+"gJn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "dark green stripe";
+	tag = "icon-dark green stripe (NORTH)"
+	},
+/area/medical/virology)
 "gPn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -109459,6 +109621,13 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
+"hkd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/simulated/floor/engine,
+/area/science/xenobiology)
 "hmN" = (
 /obj/structure/bed/chair/shuttle/red{
 	dir = 1
@@ -109632,8 +109801,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/alarm{
-	pixel_y = 22
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -109901,8 +110070,8 @@
 	},
 /area/medical/surgery)
 "jPq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -110017,10 +110186,6 @@
 	tag = "icon-warning (WEST)"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 29
-	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -110268,9 +110433,8 @@
 /turf/simulated/floor/plating,
 /area/engineering/supermatter_room)
 "mUh" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
+/obj/machinery/newscaster{
+	pixel_x = 25
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -110824,6 +110988,11 @@
 	tag = "icon-warning (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -111003,6 +111172,10 @@
 /obj/machinery/light_switch{
 	pixel_x = -22;
 	pixel_y = -9
+	},
+/obj/item/device/radio/intercom/medbay{
+	pixel_x = -27;
+	pixel_y = 7
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -111309,17 +111482,18 @@
 /turf/space,
 /area)
 "tYv" = (
-/obj/structure/closet/secure_closet/scientist,
+/obj/machinery/suit_storage_unit/medical,
+/obj/item/device/radio/intercom/medbay{
+	pixel_x = -25;
+	pixel_y = 3
+	},
 /turf/simulated/floor{
-	dir = 6;
-	icon_state = "darkpurple"
+	dir = 8;
+	icon_state = "dark_navy";
+	tag = "icon-dark_navy (WEST)"
 	},
-/area/science/hallway)
+/area/medical/eva)
 "tZJ" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = -28
-	},
 /obj/machinery/camera{
 	dir = 4;
 	name = "Medbay - Cloning"
@@ -111334,6 +111508,10 @@
 	},
 /obj/machinery/alarm{
 	pixel_y = 22
+	},
+/obj/item/device/radio/intercom/medbay/broadcast_nospeaker{
+	pixel_y = -3;
+	pixel_x = -28
 	},
 /turf/simulated/floor{
 	dir = 9;
@@ -111721,6 +111899,19 @@
 /obj/item/weapon/pen,
 /turf/simulated/floor,
 /area/crew_quarters/courtroom)
+"wdG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/simulated/floor{
+	icon_state = "dark purple stripe";
+	tag = "icon-dark purple stripe (WEST)"
+	},
+/area/medical/genetics)
 "wgn" = (
 /obj/machinery/door/airlock/external{
 	name = "Arrival Airlock"
@@ -205665,7 +205856,7 @@ aSi
 aLB
 aLB
 aLB
-aYu
+aEt
 bab
 bbv
 bcT
@@ -206166,8 +206357,8 @@ aLB
 aLB
 aLB
 aLB
-aLB
-aYv
+aYu
+aEt
 bad
 bbx
 bcW
@@ -206669,7 +206860,7 @@ aSj
 aTT
 aTT
 aTT
-aTT
+aYv
 bac
 bbw
 bcV
@@ -209178,14 +209369,14 @@ aLB
 aLB
 aLB
 aLB
-aXe
-aYv
+hkd
+aEt
 baj
 bbD
 bdb
 beG
 bgo
-bid
+aEt
 aEt
 bkZ
 bgn
@@ -209681,12 +209872,12 @@ aSm
 aLB
 aLB
 aXd
-aYu
+aEt
 bai
 bbC
 bda
 beF
-bgn
+aET
 aEt
 bjl
 beD
@@ -210687,7 +210878,7 @@ aEt
 aEt
 aEt
 aEt
-bbE
+aEt
 bdc
 beH
 bgp
@@ -211692,7 +211883,7 @@ aLD
 aLD
 aLD
 bbF
-bde
+bid
 beJ
 bgr
 bbF
@@ -212699,10 +212890,10 @@ bbG
 bde
 beJ
 bgr
-bie
+bif
 bjo
 blb
-bmG
+bmH
 bnV
 bpk
 bqv
@@ -213201,7 +213392,7 @@ bbJ
 bdh
 beM
 bgu
-bie
+bif
 bjq
 bld
 bmI
@@ -213703,7 +213894,7 @@ bbI
 bdg
 beL
 bgt
-bie
+bif
 bjp
 blc
 bmH
@@ -214201,11 +214392,11 @@ aVJ
 aXh
 aYC
 aLD
-bbL
+bbK
 bdi
 beK
-bgw
-bie
+bgA
+bif
 bie
 blf
 bie
@@ -215205,8 +215396,8 @@ aVL
 aUc
 aYE
 aLD
-tYv
-bdi
+bbF
+bbL
 beP
 bgy
 bii
@@ -215221,7 +215412,7 @@ btc
 bua
 bvp
 bwy
-bxT
+bxV
 bxV
 bAE
 bBE
@@ -215706,9 +215897,9 @@ aUb
 aVK
 aXi
 aYD
-aLD
-bbF
-bdj
+aaf
+aYL
+bdi
 beO
 bgx
 bih
@@ -216209,7 +216400,7 @@ aVN
 aUc
 aLD
 aaf
-aYL
+bbM
 bdi
 beJ
 eHl
@@ -217716,15 +217907,15 @@ aLD
 aLD
 bbO
 bbO
-bdi
+bdj
 beK
-bgA
-bil
-bil
-bil
-bil
-bil
-bil
+bgz
+aNL
+aNL
+aNL
+aNL
+aNL
+aNL
 bqw
 brM
 bte
@@ -218710,7 +218901,7 @@ aEE
 kot
 aQH
 aIr
-aIr
+tYv
 mwS
 rfC
 aNN
@@ -218722,7 +218913,7 @@ aXy
 axT
 bbS
 beQ
-aET
+bgz
 bim
 bjx
 bll
@@ -218738,7 +218929,7 @@ bwA
 bxY
 bzn
 bAI
-bBJ
+bDR
 bxV
 bDX
 bvp
@@ -219239,7 +219430,7 @@ bvv
 bvv
 byb
 bzq
-bAL
+bvv
 bvv
 bvv
 bvv
@@ -219733,7 +219924,7 @@ blm
 bjC
 bim
 bim
-bim
+bbF
 brP
 bti
 bug
@@ -220224,9 +220415,9 @@ aUk
 aVS
 aVS
 pjd
-aNL
+aVS
 bbO
-bdi
+bxT
 beK
 bgC
 gst
@@ -220247,7 +220438,7 @@ bAN
 bye
 bBN
 bEa
-bFh
+byf
 bGg
 bHt
 bvv
@@ -221232,12 +221423,12 @@ aVS
 bbO
 bdm
 beS
-bgD
+bgw
 bip
 bgD
 blq
 bmR
-bog
+bdh
 bpw
 bqz
 brT
@@ -221245,13 +221436,13 @@ bdf
 buk
 bvz
 bwG
-byf
+byg
 bzu
 bAM
 bBM
 bCT
 bDY
-bCT
+bFh
 bGf
 bHs
 bvv
@@ -221739,9 +221930,9 @@ bio
 bjB
 blp
 bmQ
-bof
-bof
-bof
+bio
+bio
+bio
 brS
 taF
 lLf
@@ -221754,9 +221945,9 @@ bpI
 bFg
 bDZ
 bAO
-bAO
-bAO
-bvv
+bBJ
+bHv
+bHv
 bHv
 bHv
 bOB
@@ -222256,8 +222447,8 @@ bMr
 bAQ
 bEd
 bAQ
-bGi
 bAQ
+bAL
 bIs
 bJy
 bKC
@@ -222760,7 +222951,7 @@ bEe
 bFj
 bGj
 bHw
-bHv
+bIr
 bJz
 bHv
 bHv
@@ -223242,7 +223433,7 @@ bio
 beW
 bjH
 iVg
-bjH
+aya
 wLZ
 bmV
 hHJ
@@ -223262,7 +223453,7 @@ bvv
 bvv
 bvv
 bHv
-bHv
+bIr
 bJw
 bKA
 bLt
@@ -223744,7 +223935,7 @@ bio
 iVg
 bjH
 bjH
-bjH
+aya
 blt
 bmU
 bdk
@@ -224211,7 +224402,7 @@ ahj
 aib
 aNI
 ajx
-aOg
+gJn
 akG
 alv
 alV
@@ -224223,7 +224414,7 @@ atl
 aCY
 awj
 bgU
-aya
+wdG
 aKq
 aQR
 aEQ
@@ -224233,7 +224424,7 @@ ezU
 baC
 bap
 aNR
-aDc
+bap
 bap
 aSD
 bap
@@ -225743,7 +225934,7 @@ aPn
 aQQ
 aSE
 aUr
-aiN
+aUr
 aXo
 bbR
 baw
@@ -226740,7 +226931,7 @@ aDe
 lke
 aGL
 bbP
-aKr
+ato
 aVX
 aNU
 ato
@@ -228231,7 +228422,7 @@ afH
 akP
 afH
 akb
-amT
+anT
 anS
 afH
 aqm
@@ -229738,7 +229929,7 @@ akQ
 alz
 ama
 amU
-anT
+amT
 afH
 aqn
 arQ

--- a/maps/defficiency.dmm
+++ b/maps/defficiency.dmm
@@ -4739,6 +4739,7 @@
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/machinery/washing_machine,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -6601,11 +6602,12 @@
 /obj/structure/closet/secure_closet/medical2,
 /obj/machinery/power/apc{
 	dir = 1;
-	pixel_y = 24
+	pixel_y = 25
 	},
 /obj/structure/cable/yellow{
-	icon_state = "0-4";
-	tag = "icon-0-4"
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -7738,9 +7740,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/nmpi,
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -7748,13 +7747,26 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "apX" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/nmpi{
+	dir = 4;
+	tag = "icon-maintguide (EAST)"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "floorgrime"
 	},
-/area/medical/break_room)
+/area/maintenance/fpmaint)
 "apY" = (
 /turf/simulated/wall,
 /area/medical/break_room)
@@ -7862,8 +7874,8 @@
 	},
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "dark neutral corner";
-	tag = "icon-dark neutral corner (WEST)"
+	icon_state = "dark neutral stripe";
+	tag = "icon-dark neutral stripe (WEST)"
 	},
 /area/medical/medbay)
 "aqg" = (
@@ -7965,11 +7977,10 @@
 "aqn" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/firstaid/fire{
-	pixel_x = 2;
 	pixel_y = 7
 	},
 /obj/item/weapon/storage/firstaid/fire{
-	pixel_x = -2;
+	pixel_x = 4;
 	pixel_y = 4
 	},
 /obj/machinery/alarm{
@@ -7984,7 +7995,7 @@
 "aqo" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/firstaid/regular{
-	pixel_x = 2;
+	pixel_x = 9;
 	pixel_y = 6
 	},
 /obj/item/weapon/storage/firstaid/regular{
@@ -8656,6 +8667,7 @@
 	dir = 5;
 	tag = "icon-maintguide (NORTHEAST)"
 	},
+/obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "arD" = (
@@ -8690,21 +8702,21 @@
 	},
 /area/medical/break_room)
 "arG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/unary/vent_pump{
 	on = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
 /area/medical/break_room)
 "arH" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -8712,9 +8724,6 @@
 	},
 /area/medical/break_room)
 "arI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -8723,20 +8732,23 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
 /area/medical/break_room)
 "arJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -8747,10 +8759,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/bed/roller/deff,
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "dark neutral stripe";
-	tag = "icon-dark neutral stripe (WEST)"
+	dir = 1;
+	icon_state = "dark neutral corner";
+	tag = "icon-dark neutral corner (NORTH)"
 	},
 /area/medical/medbay)
 "arL" = (
@@ -8758,21 +8771,21 @@
 	dir = 4;
 	name = "Firelock East"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
 /obj/machinery/door/airlock/glass_medical{
 	id_tag = "";
 	name = "Break Room";
 	req_access_txt = "5"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -8811,7 +8824,8 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/iv_drip,
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -28
+	pixel_y = -28;
+	pixel_x = -4
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -9478,8 +9492,7 @@
 	icon_state = "bsposter10";
 	pixel_y = 32
 	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
+/obj/machinery/media/jukebox/bar,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -9540,10 +9553,10 @@
 	},
 /area/medical/break_room)
 "atk" = (
-/obj/structure/bookcase/manuals/medical,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/bookcase/manuals/medical,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -9563,9 +9576,7 @@
 	pixel_x = -2
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "dark neutral corner";
-	tag = "icon-dark neutral corner (NORTH)"
+	icon_state = "dark"
 	},
 /area/medical/medbay)
 "atn" = (
@@ -9650,25 +9661,20 @@
 	},
 /obj/item/weapon/storage/firstaid/o2{
 	pixel_x = 2;
-	pixel_y = 4
+	pixel_y = 10
 	},
 /obj/item/weapon/storage/firstaid/o2{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/clothing/glasses/hud/health{
-	pixel_x = 4
-	},
-/obj/item/clothing/glasses/hud/health{
-	pixel_x = 4
-	},
-/obj/item/clothing/glasses/hud/health{
-	pixel_x = 4
-	},
-/obj/item/clothing/glasses/hud/health{
-	pixel_x = 4
+	pixel_x = -4;
+	pixel_y = 7
 	},
 /obj/structure/table/glass,
+/obj/item/clothing/glasses/scanner/science{
+	pixel_x = 4;
+	pixel_y = 1
+	},
+/obj/item/clothing/glasses/scanner/science{
+	pixel_y = -2
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark_navy";
@@ -10228,10 +10234,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "auI" = (
-/turf/simulated/wall,
-/area/medical/surgery_ghetto{
-	name = "Overflow Surgery"
-	})
+/obj/machinery/door/firedoor/border_only{
+	dir = 1;
+	name = "Firelock North"
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay Surgery Overflow Maintenance";
+	req_access_txt = "45"
+	},
+/turf/simulated/floor/plating,
+/area/medical/surgery)
 "auL" = (
 /obj/structure/bed/chair/vehicle/wheelchair{
 	dir = 4
@@ -10242,10 +10254,6 @@
 /area/medical/medbay)
 "auM" = (
 /obj/machinery/hologram/holopad,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -10936,7 +10944,9 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "dark purple corner";
+	tag = "icon-dark purple corner (WEST)"
 	},
 /area/medical/medbay)
 "awl" = (
@@ -11048,17 +11058,9 @@
 	pixel_y = 8;
 	pixel_x = 6
 	},
-/obj/item/clothing/glasses/scanner/science{
-	pixel_x = -1;
-	pixel_y = 1
-	},
 /obj/item/clothing/accessory/stethoscope{
 	pixel_y = 10;
 	pixel_x = -3
-	},
-/obj/item/clothing/glasses/scanner/science{
-	pixel_x = -4;
-	pixel_y = -2
 	},
 /turf/simulated/floor{
 	icon_state = "dark_navy";
@@ -11102,11 +11104,11 @@
 "awt" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/firstaid/toxin{
-	pixel_x = 2;
+	pixel_x = -5;
 	pixel_y = 5
 	},
 /obj/item/weapon/storage/firstaid/toxin{
-	pixel_x = -2;
+	pixel_x = 4;
 	pixel_y = 3
 	},
 /obj/machinery/firealarm{
@@ -11115,6 +11117,22 @@
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/item/clothing/glasses/hud/health{
+	pixel_x = -2;
+	pixel_y = -6
+	},
+/obj/item/clothing/glasses/hud/health{
+	pixel_x = -2;
+	pixel_y = -6
+	},
+/obj/item/clothing/glasses/hud/health{
+	pixel_x = -2;
+	pixel_y = -6
+	},
+/obj/item/clothing/glasses/hud/health{
+	pixel_x = -2;
+	pixel_y = -6
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -11896,7 +11914,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/bed/roller/deff,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
@@ -11911,8 +11928,8 @@
 	},
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "dark purple corner";
-	tag = "icon-dark purple corner (WEST)"
+	icon_state = "dark purple stripe";
+	tag = "icon-dark purple stripe (WEST)"
 	},
 /area/medical/medbay)
 "ayc" = (
@@ -12648,6 +12665,10 @@
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	dir = 1;
+	name = "Science - Toxins Maintenance (Outside)"
+	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},
@@ -12666,10 +12687,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/camera{
-	dir = 1;
-	name = "Science - Toxins Maintenance (Outside)"
-	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},
@@ -12696,28 +12713,17 @@
 /area/maintenance/fpmaint)
 "azx" = (
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/obj/effect/nmpi{
-	dir = 5;
-	tag = "icon-maintguide (NORTHEAST)"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
-/area/maintenance/fpmaint)
+/turf/simulated/floor{
+	icon_state = "dark purple stripe";
+	tag = "icon-dark purple stripe (WEST)"
+	},
+/area/medical/genetics)
 "azy" = (
 /mob/living/carbon/monkey,
 /obj/structure/window/reinforced,
@@ -12821,10 +12827,8 @@
 /area/maintenance/fpmaint)
 "azF" = (
 /obj/structure/window/reinforced,
-/obj/machinery/media/jukebox/bar,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -14020,31 +14024,35 @@
 /turf/simulated/wall,
 /area/medical/paramedics)
 "aBx" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	name = "Firelock North"
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Medbay Surgery Overflow Maintenance";
-	req_access_txt = "45"
+/turf/simulated/floor{
+	icon_state = "floorgrime"
 	},
-/turf/simulated/floor/plating,
-/area/medical/surgery_ghetto{
-	name = "Overflow Surgery"
-	})
+/area/science/storage)
 "aBy" = (
 /obj/structure/table,
+/obj/item/device/flashlight/pen{
+	pixel_x = 7;
+	pixel_y = 3
+	},
 /obj/item/weapon/storage/box/gloves{
-	pixel_x = -4;
+	pixel_x = -3;
 	pixel_y = 8
+	},
+/obj/item/weapon/folder/white{
+	pixel_x = 4
+	},
+/obj/item/device/flashlight/pen{
+	pixel_x = 2;
+	pixel_y = -2
 	},
 /obj/item/device/radio/headset/headset_med{
 	pixel_y = -3;
 	pixel_x = -5
 	},
-/obj/item/weapon/folder/white,
-/obj/item/device/flashlight/pen,
-/obj/item/device/flashlight/pen,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "dark";
@@ -14082,9 +14090,9 @@
 	},
 /obj/machinery/computer/telescience,
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "dark_navy";
-	tag = "icon-dark_navy (NORTH)"
+	dir = 9;
+	icon_state = "dark vault stripe";
+	tag = "icon-dark vault stripe (NORTHWEST)"
 	},
 /area/science/telescience)
 "aBD" = (
@@ -14725,26 +14733,6 @@
 	},
 /area/medical/chemistry)
 "aCR" = (
-/obj/item/tool/surgicaldrill,
-/obj/item/tool/circular_saw,
-/obj/structure/table,
-/obj/item/tool/retractor,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor{
-	icon_state = "freezerfloor"
-	},
-/area/medical/surgery_ghetto{
-	name = "Overflow Surgery"
-	})
-"aCS" = (
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
 /obj/structure/table,
 /obj/item/tool/scalpel{
 	pixel_y = 2
@@ -14755,34 +14743,51 @@
 	name = "Medbay - Surgery Overflow"
 	},
 /turf/simulated/floor{
-	icon_state = "freezerfloor"
+	icon_state = "showroomfloor"
 	},
-/area/medical/surgery_ghetto{
-	name = "Overflow Surgery"
-	})
-"aCT" = (
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
+/area/medical/surgery)
+"aCS" = (
+/obj/structure/table,
+/obj/item/tool/bonegel,
+/obj/item/tool/bonesetter,
+/obj/item/tool/cautery{
+	pixel_x = 4
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 24
-	},
-/obj/structure/wc/sink{
-	dir = 4;
-	pixel_x = 11
+/obj/item/device/radio/intercom/medbay{
+	pixel_x = -30
 	},
 /turf/simulated/floor{
-	icon_state = "freezerfloor"
+	icon_state = "showroomfloor"
 	},
-/area/medical/surgery_ghetto{
-	name = "Overflow Surgery"
-	})
+/area/medical/surgery)
+"aCT" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/medical/surgery)
 "aCU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/simulated/wall,
-/area/medical/eva)
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "medpriv";
+	name = "Privacy Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/medical/surgery)
 "aCV" = (
 /obj/machinery/smartfridge/chemistry,
 /obj/machinery/door/firedoor/border_only{
@@ -14797,10 +14802,10 @@
 	},
 /area/medical/chemistry)
 "aCW" = (
-/obj/machinery/iv_drip,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
+/obj/structure/dispenser/oxygen,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark_navy";
@@ -14841,11 +14846,6 @@
 	pixel_y = 2;
 	pixel_x = 3
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/item/device/radio/intercom/medbay{
 	pixel_y = 22;
 	pixel_x = 10
@@ -14855,9 +14855,6 @@
 	},
 /area/medical/surgery)
 "aDb" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
@@ -15678,53 +15675,49 @@
 	},
 /area/science/storage)
 "aEC" = (
-/obj/item/device/radio/intercom/medbay{
-	pixel_x = -30
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "freezerfloor"
+	icon_state = "floorgrime"
 	},
-/area/medical/surgery_ghetto{
-	name = "Overflow Surgery"
-	})
+/area/science/storage)
 "aED" = (
 /obj/effect/landmark{
 	name = "blobstart"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "freezerfloor"
+	icon_state = "showroomfloor"
 	},
-/area/medical/surgery_ghetto{
-	name = "Overflow Surgery"
-	})
+/area/medical/surgery)
 "aEE" = (
+/obj/machinery/optable,
+/obj/machinery/light/small,
 /turf/simulated/floor{
-	icon_state = "freezerfloor"
+	icon_state = "showroomfloor"
 	},
-/area/medical/surgery_ghetto{
-	name = "Overflow Surgery"
-	})
+/area/medical/surgery)
 "aEF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	pixel_x = 27;
+	pixel_y = 3
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = 24;
-	pixel_y = -8
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
 	},
 /turf/simulated/floor{
-	icon_state = "freezerfloor"
+	icon_state = "showroomfloor"
 	},
-/area/medical/surgery_ghetto{
-	name = "Overflow Surgery"
-	})
+/area/medical/surgery)
 "aEG" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -15831,7 +15824,17 @@
 	name = "Genetics Exit Button";
 	normaldoorcontrol = 1;
 	pixel_x = -24;
-	pixel_y = -8
+	pixel_y = -12
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	pixel_x = -26;
+	pixel_y = 4
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -16732,15 +16735,6 @@
 	icon_state = "bot"
 	},
 /area/science/storage)
-"aGt" = (
-/obj/machinery/portable_atmospherics/scrubber/huge,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
-/area/science/storage)
 "aGu" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/structure/window/reinforced{
@@ -16751,13 +16745,14 @@
 	},
 /area/science/storage)
 "aGv" = (
-/obj/machinery/computer/operating,
+/obj/item/tool/surgicaldrill,
+/obj/item/tool/circular_saw,
+/obj/structure/table,
+/obj/item/tool/retractor,
 /turf/simulated/floor{
-	icon_state = "freezerfloor"
+	icon_state = "showroomfloor"
 	},
-/area/medical/surgery_ghetto{
-	name = "Overflow Surgery"
-	})
+/area/medical/surgery)
 "aGw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /mob/living/carbon/monkey,
@@ -16767,38 +16762,29 @@
 	},
 /area/medical/virology)
 "aGx" = (
-/obj/machinery/optable,
+/obj/machinery/computer/operating,
 /turf/simulated/floor{
-	icon_state = "freezerfloor"
+	icon_state = "showroomfloor"
 	},
-/area/medical/surgery_ghetto{
-	name = "Overflow Surgery"
-	})
+/area/medical/surgery)
 "aGy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/simulated/floor{
-	icon_state = "freezerfloor"
+	icon_state = "showroomfloor"
 	},
-/area/medical/surgery_ghetto{
-	name = "Overflow Surgery"
-	})
+/area/medical/surgery)
 "aGz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -16817,11 +16803,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -16829,7 +16810,7 @@
 "aGD" = (
 /obj/structure/table,
 /obj/item/tool/bonesetter{
-	pixel_y = 6
+	pixel_y = 14
 	},
 /obj/item/tool/FixOVein{
 	pixel_x = 8;
@@ -16837,7 +16818,7 @@
 	},
 /obj/item/stack/medical/advanced/bruise_pack{
 	pixel_x = -6;
-	pixel_y = 4
+	pixel_y = -2
 	},
 /obj/machinery/door_control{
 	id_tag = "medpriv";
@@ -16858,31 +16839,25 @@
 	name = "Firelock West"
 	},
 /obj/machinery/holosign/surgery,
+/obj/machinery/door/airlock/medical{
+	name = "Overflow Operating Room";
+	req_access_txt = "45"
+	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/medical{
-	name = "Overflow Operating Room";
-	req_access_txt = "45"
-	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/medical/surgery_ghetto{
-	name = "Overflow Surgery"
-	})
+/area/medical/surgery)
 "aGF" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 7
-	},
 /obj/structure/cable/yellow{
-	icon_state = "0-4";
-	tag = "icon-0-4"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/light/small{
@@ -17854,10 +17829,6 @@
 	dir = 8;
 	on = 1
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},
@@ -17878,22 +17849,17 @@
 	on = 1
 	},
 /turf/simulated/floor{
-	icon_state = "freezerfloor"
+	icon_state = "showroomfloor"
 	},
-/area/medical/surgery_ghetto{
-	name = "Overflow Surgery"
-	})
+/area/medical/surgery)
 "aIr" = (
 /obj/machinery/suit_storage_unit/medical,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "dark_navy";
+	tag = "icon-dark_navy (WEST)"
 	},
 /area/medical/eva)
-"aIs" = (
-/turf/simulated/wall/r_wall,
-/area/medical/surgery_ghetto{
-	name = "Overflow Surgery"
-	})
 "aIt" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -17909,22 +17875,24 @@
 	},
 /area/science/hallway)
 "aIu" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	name = "Firelock North"
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/door/airlock/glass_medical{
-	name = "Emergency Rescue Unit";
-	req_one_access_txt = "500;39"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/medical/eva)
+/turf/simulated/floor/wood,
+/area/bridge/meeting_room)
 "aIv" = (
 /obj/machinery/atmospherics/binary/volume_pump{
 	dir = 4;
@@ -17949,24 +17917,28 @@
 /area/medical/surgery)
 "aIx" = (
 /obj/structure/table,
-/obj/item/clothing/gloves/latex{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/item/clothing/mask/surgical,
-/obj/item/weapon/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
-	name = "Surgery Cleaner"
+/obj/item/clothing/mask/surgical{
+	pixel_x = 2
 	},
 /obj/machinery/light_switch{
 	dir = 4;
 	pixel_x = 24;
-	pixel_y = -8
+	pixel_y = -6
 	},
 /obj/machinery/holosign_switch{
 	id_tag = "surgery";
 	pixel_x = 24;
-	pixel_y = 2
+	pixel_y = 4
+	},
+/obj/item/clothing/gloves/latex{
+	pixel_x = -2;
+	pixel_y = 9
+	},
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
+	name = "Surgery Cleaner";
+	pixel_x = -7;
+	pixel_y = -1
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -17986,9 +17958,7 @@
 	name = "Firelock North"
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "dark_navy_corner";
-	tag = "icon-dark_navy_corner (NORTH)"
+	icon_state = "dark"
 	},
 /area/medical/medbay)
 "aIA" = (
@@ -18882,6 +18852,7 @@
 /obj/machinery/vending/wallmed2{
 	pixel_x = -28
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "dark floor stripe";
@@ -18909,9 +18880,6 @@
 /obj/machinery/camera{
 	name = "Medbay - Emergency Rescue Unit"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/item/weapon/storage/firstaid/o2{
 	pixel_y = 5;
 	pixel_x = 2
@@ -18924,27 +18892,29 @@
 	pixel_y = -5;
 	pixel_x = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
+/obj/structure/closet/hydrant{
+	pixel_y = 32
 	},
 /turf/simulated/floor{
-	dir = 4;
+	dir = 5;
 	icon_state = "dark_navy";
-	tag = "icon-dark_navy (EAST)"
+	tag = "icon-dark_navy (NORTHEAST)"
 	},
 /area/medical/eva)
 "aKj" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/iv_drip,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "dark_navy";
+	tag = "icon-dark_navy (NORTH)"
 	},
 /area/medical/eva)
 "aKk" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -18953,8 +18923,8 @@
 	},
 /area/medical/surgery)
 "aKl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -18975,22 +18945,20 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
 /area/medical/surgery)
 "aKn" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/wall,
 /area/medical/surgery)
 "aKo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -19000,11 +18968,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -19815,6 +19778,9 @@
 	dir = 8;
 	pixel_x = -11
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "dark floor stripe";
@@ -19836,10 +19802,20 @@
 /turf/simulated/floor/plating,
 /area/medical/genetics_cloning)
 "aLO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass_medical{
+	name = "Emergency Rescue Unit";
+	req_one_access_txt = "500;39"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
-	icon_state = "dark floor stripe";
-	tag = "icon-dark floor stripe"
+	icon_state = "dark"
 	},
 /area/medical/surgery)
 "aLP" = (
@@ -20918,10 +20894,9 @@
 /obj/item/weapon/tank/nitrogen,
 /obj/item/clothing/mask/breath/vox,
 /obj/item/clothing/mask/breath/vox,
-/obj/item/clothing/mask/breath/vox,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -21016,9 +20991,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/structure/closet/walllocker/defiblocker{
-	pixel_x = -32
-	},
+/obj/structure/closet/walllocker/defiblocker/west,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "dark_navy";
@@ -21028,10 +21001,6 @@
 "aNP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/bed/roller/deff,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -21125,6 +21094,9 @@
 	dir = 8
 	},
 /obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/medical/surgery)
 "aNW" = (
@@ -21143,6 +21115,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/sign/nosmoking_1{
+	pixel_y = -27
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -21784,7 +21759,10 @@
 /turf/simulated/floor/engine,
 /area/science/telescience)
 "aPf" = (
-/obj/structure/dispenser/oxygen,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark_navy";
@@ -21792,12 +21770,12 @@
 	},
 /area/medical/eva)
 "aPg" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/bed/chair{
 	dir = 1
+	},
+/obj/structure/sign/nosmoking_2{
+	pixel_x = -28
 	},
 /turf/simulated/floor{
 	dir = 9;
@@ -21814,8 +21792,11 @@
 	},
 /area/medical/genetics_cloning)
 "aPi" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -21843,15 +21824,17 @@
 	dir = 4;
 	pixel_y = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
 /obj/machinery/light_switch{
 	dir = 4;
 	pixel_x = -22;
-	pixel_y = -10
+	pixel_y = -15
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -32;
-	pixel_y = null
+	pixel_x = -27;
+	pixel_y = 2
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -22558,43 +22541,42 @@
 	},
 /area/medical/surgery)
 "aQH" = (
-/obj/structure/closet/walllocker/defiblocker{
-	pixel_x = -32
+/obj/machinery/suit_storage_unit/medical,
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/closet/hydrant{
-	pixel_y = 32
-	},
-/obj/structure/bed/roller/deff,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 9;
+	icon_state = "dark_navy";
+	tag = "icon-dark_navy (NORTHWEST)"
 	},
 /area/medical/eva)
 "aQI" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light{
+/obj/machinery/power/apc{
+	pixel_y = -25
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	pixel_y = -24
+	icon_state = "0-4";
+	tag = "icon-0-4"
 	},
 /turf/simulated/floor{
-	dir = 6;
+	dir = 4;
 	icon_state = "dark_navy";
-	tag = "icon-dark_navy (SOUTHEAST)"
+	tag = "icon-dark_navy (EAST)"
 	},
 /area/medical/eva)
 "aQJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	initialize_directions = 11
 	},
-/obj/structure/sign/nosmoking_2{
-	pixel_x = -28
+/obj/machinery/light,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -22617,6 +22599,11 @@
 "aQL" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	initialize_directions = 11
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -24583,18 +24570,13 @@
 /obj/item/device/gps/science,
 /obj/item/device/gps/science,
 /obj/item/device/gps/science,
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	pixel_x = 4
-	},
 /obj/machinery/light_switch{
-	pixel_y = 22;
-	pixel_x = -8
+	pixel_y = 24;
+	pixel_x = 3
 	},
 /turf/simulated/floor{
 	dir = 1;
-	icon_state = "dark_navy";
-	tag = "icon-dark_navy (NORTH)"
+	icon_state = "dark vault stripe"
 	},
 /area/science/telescience)
 "aUg" = (
@@ -26221,6 +26203,11 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "dark floor stripe";
@@ -26318,6 +26305,10 @@
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -23
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/simulated/floor{
 	dir = 10;
@@ -29393,16 +29384,6 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/effect/decal/warning_stripes{
-	dir = 1;
-	icon_state = "warning_corner";
-	tag = "icon-warning_corner (NORTH)"
-	},
-/obj/effect/decal/warning_stripes{
-	dir = 1;
-	icon_state = "warning_corner";
-	tag = "icon-warning_corner (NORTH)"
-	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whitepurplecorner"
@@ -29439,10 +29420,6 @@
 /area/science/hallway)
 "bdk" = (
 /obj/machinery/light,
-/obj/machinery/light_switch{
-	pixel_y = -23;
-	pixel_x = -8
-	},
 /turf/simulated/floor{
 	icon_state = "whitepurple"
 	},
@@ -31636,9 +31613,7 @@
 /obj/item/weapon/reagent_containers/glass/beaker/cryoxadone{
 	pixel_x = 12
 	},
-/obj/structure/closet/walllocker/defiblocker{
-	pixel_x = -32
-	},
+/obj/structure/closet/walllocker/defiblocker/west,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -31692,6 +31667,10 @@
 	name = "Firelock East"
 	},
 /obj/machinery/bodyscanner,
+/obj/structure/sign/nosmoking_1{
+	pixel_y = -26;
+	pixel_x = 2
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark_navy";
@@ -31718,8 +31697,10 @@
 "bgM" = (
 /obj/structure/bed/roller/deff,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/vending/wallmed1{
-	pixel_x = -30
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -25;
+	pixel_y = 3
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -31746,13 +31727,7 @@
 	},
 /area/medical/chemistry)
 "bgO" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 1;
-	on = 1
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -32579,24 +32554,13 @@
 	icon_state = "dark"
 	},
 /area/medical/medbay)
-"bit" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/medical/chemistry)
 "biu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/vending/wallmed1{
+	pixel_x = 25
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -35293,18 +35257,20 @@
 	},
 /area/medical/chemistry)
 "bnc" = (
-/obj/structure/table,
-/obj/item/tool/bonegel,
-/obj/item/tool/bonesetter,
-/obj/item/tool/cautery{
-	pixel_x = 4
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "bot"
+	},
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "freezerfloor"
+	icon_state = "floorgrime"
 	},
-/area/medical/surgery_ghetto{
-	name = "Overflow Surgery"
-	})
+/area/science/storage)
 "bnd" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -35933,14 +35899,14 @@
 	},
 /area/medical/medbay2)
 "bon" = (
-/obj/machinery/recharger/defibcharger/wallcharger{
-	pixel_x = -24
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
 	},
-/obj/structure/bed/roller/deff,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "dark floor stripe";
+	tag = "icon-dark floor stripe"
 	},
-/area/medical/eva)
+/area/medical/surgery)
 "boo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -36593,6 +36559,9 @@
 	phone_name = "Research And Development";
 	pixel_y = -28
 	},
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "whitepurple"
@@ -36639,14 +36608,6 @@
 	id_tag = "biohazard";
 	name = "Biohazard Blast Doors";
 	opacity = 0
-	},
-/obj/machinery/door_control{
-	desc = "A remote control switch for the science foyer.";
-	id_tag = "ScienceFoyer";
-	name = "Science Foyer Door Control";
-	normaldoorcontrol = 1;
-	pixel_x = -25;
-	pixel_y = 8
 	},
 /turf/simulated/floor/plating,
 /area/science/lab)
@@ -37223,13 +37184,18 @@
 /turf/simulated/floor/plating,
 /area/medical/paramedics)
 "bqH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -37841,7 +37807,7 @@
 /obj/structure/closet/firecloset/full,
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "whitebluecorner"
+	icon_state = "whiteblue"
 	},
 /area/science/hallway)
 "brQ" = (
@@ -37871,13 +37837,14 @@
 	},
 /obj/machinery/shower,
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whitepurple"
 	},
 /area/science/hallway)
 "brT" = (
 /turf/simulated/floor{
 	dir = 1;
-	icon_state = "whitepurplecorner"
+	icon_state = "whitepurple"
 	},
 /area/science/hallway)
 "brU" = (
@@ -39074,8 +39041,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "whitebluecorner"
+	dir = 8;
+	icon_state = "whiteblue"
 	},
 /area/science/hallway)
 "buh" = (
@@ -39112,16 +39079,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "white"
-	},
-/area/science/hallway)
-"bul" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "whitepurplecorner"
+	icon_state = "whitepurple"
 	},
 /area/science/hallway)
 "bum" = (
@@ -39132,8 +39090,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "whitepurplecorner"
+	dir = 6;
+	icon_state = "whitepurple"
 	},
 /area/science/hallway)
 "bun" = (
@@ -39145,7 +39103,7 @@
 	pixel_y = -27
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitepurple"
 	},
 /area/science/hallway)
 "buo" = (
@@ -73743,11 +73701,6 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "blue"
@@ -74610,11 +74563,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
 	dir = 4;
@@ -74628,11 +74576,6 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "blue"
@@ -74640,21 +74583,11 @@
 /area/bridge)
 "cMP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor,
 /area/bridge)
 "cMQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/bridge)
@@ -74681,11 +74614,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "blue"
@@ -74697,11 +74625,6 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /turf/simulated/floor{
 	desc = "\"This is a plaque in honour of our comrades whom bravely entered these tunnels and never returned..\" Engraved is an standard access door, grim as a tomb's door.";
@@ -75496,13 +75419,11 @@
 	},
 /area/bridge)
 "cOq" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/simulated/floor/carpet,
-/area/bridge)
+/turf/simulated/wall,
+/area/medical/surgery)
 "cOr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor,
@@ -75513,9 +75434,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/firstaid/regular,
-/obj/structure/closet/walllocker/defiblocker{
-	pixel_x = 32
-	},
+/obj/structure/closet/walllocker/defiblocker/east,
 /turf/simulated/floor,
 /area/bridge)
 "cOt" = (
@@ -78945,11 +78864,10 @@
 	},
 /area/bridge)
 "cTZ" = (
+/obj/machinery/computer/powermonitor,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/computer/powermonitor,
-/obj/structure/cable/yellow,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "darkred";
@@ -109044,15 +108962,11 @@
 	},
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "dark_navy_corner";
-	tag = "icon-dark_navy_corner (NORTH)"
+	icon_state = "dark_navy";
+	tag = "icon-dark_navy (WEST)"
 	},
 /area/medical/medbay)
 "ffV" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -109139,10 +109053,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
 	dir = 4
-	},
-/obj/structure/sign/nosmoking_1{
-	pixel_x = 26;
-	pixel_y = 4
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -109324,9 +109234,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "dark_navy";
-	tag = "icon-dark_navy (WEST)"
+	dir = 1;
+	icon_state = "dark_navy_corner";
+	tag = "icon-dark_navy_corner (NORTH)"
 	},
 /area/medical/medbay)
 "hdV" = (
@@ -109355,20 +109265,16 @@
 /turf/simulated/floor/shuttle,
 /area/shuttle/exploration)
 "hnY" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+/obj/structure/sign/nosmoking_1{
+	pixel_y = -26
 	},
 /turf/simulated/floor{
-	icon_state = "freezerfloor"
+	icon_state = "showroomfloor"
 	},
-/area/medical/surgery_ghetto{
-	name = "Overflow Surgery"
-	})
+/area/medical/surgery)
 "hpW" = (
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Engine Room";
@@ -109692,8 +109598,8 @@
 "iXO" = (
 /turf/simulated/floor{
 	dir = 5;
-	icon_state = "dark_navy";
-	tag = "icon-dark_navy (NORTHEAST)"
+	icon_state = "dark vault stripe";
+	tag = "icon-dark vault stripe (NORTHEAST)"
 	},
 /area/science/telescience)
 "iYB" = (
@@ -109702,28 +109608,7 @@
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/exploration)
-"iZS" = (
-/obj/effect/decal/warning_stripes{
-	dir = 4;
-	icon_state = "warning_corner";
-	tag = "icon-warning_corner (EAST)"
-	},
-/obj/effect/decal/warning_stripes{
-	dir = 4;
-	icon_state = "warning_corner";
-	tag = "icon-warning_corner (EAST)"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "whitepurplecorner"
-	},
-/area/science/hallway)
 "jlx" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -109781,15 +109666,15 @@
 	},
 /area/engineering/engine)
 "jML" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+/obj/structure/wc/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
 	},
 /turf/simulated/floor{
-	icon_state = "freezerfloor"
+	icon_state = "showroomfloor"
 	},
-/area/medical/surgery_ghetto{
-	name = "Overflow Surgery"
-	})
+/area/medical/surgery)
 "jTo" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -110086,6 +109971,15 @@
 /obj/effect/landmark/map_element/salvage_shuttle_spiders,
 /turf/space,
 /area)
+"mwS" = (
+/obj/structure/bed/roller/deff,
+/obj/structure/closet/walllocker/defiblocker/west,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "dark_navy";
+	tag = "icon-dark_navy (WEST)"
+	},
+/area/medical/eva)
 "mSS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -110148,6 +110042,20 @@
 	},
 /turf/simulated/floor/glass/plasma,
 /area/hallway/secondary/entry)
+"nil" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor{
+	icon_state = "dark floor stripe";
+	tag = "icon-dark floor stripe"
+	},
+/area/medical/surgery)
 "niJ" = (
 /obj/machinery/claw_machine,
 /turf/simulated/floor{
@@ -110165,7 +110073,11 @@
 	pixel_y = -26
 	},
 /obj/structure/sign/examroom{
-	pixel_x = -28
+	pixel_x = -29;
+	icon_state = "poster7";
+	name = "SMOKE!";
+	desc = "A poster reminding those with nothing left to lose that some vices exist for a reason.";
+	icon = 'icons/obj/posters.dmi'
 	},
 /obj/machinery/light/small{
 	dir = 8;
@@ -110371,14 +110283,11 @@
 	},
 /area/medical/medbay)
 "oJs" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
 /turf/simulated/floor{
-	icon_state = "dark_navy";
-	tag = "icon-dark_navy"
+	icon_state = "dark"
 	},
 /area/medical/eva)
 "oUX" = (
@@ -110386,8 +110295,9 @@
 	dir = 10
 	},
 /turf/simulated/floor{
-	icon_state = "dark purple corner";
-	tag = "icon-dark purple corner (WEST)"
+	dir = 4;
+	icon_state = "dark purple stripe";
+	tag = "icon-dark purple stripe (WEST)"
 	},
 /area/science/telescience)
 "pdq" = (
@@ -110637,6 +110547,16 @@
 /obj/item/toy/gasha/engi,
 /turf/space,
 /area)
+"qJG" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "dark_navy_corner";
+	tag = "icon-dark_navy_corner (NORTH)"
+	},
+/area/medical/medbay)
 "qLS" = (
 /obj/machinery/artifact_scanpad,
 /obj/machinery/light_switch{
@@ -110707,10 +110627,15 @@
 /turf/simulated/floor/shuttle,
 /area/shuttle/exploration)
 "rfC" = (
-/obj/machinery/suit_storage_unit/medical,
+/obj/machinery/recharger/defibcharger/wallcharger{
+	pixel_x = -24;
+	pixel_y = -2
+	},
+/obj/structure/bed/roller/deff,
 /turf/simulated/floor{
-	icon_state = "dark_navy_corner";
-	tag = "icon-dark_navy_corner"
+	dir = 8;
+	icon_state = "dark_navy";
+	tag = "icon-dark_navy (WEST)"
 	},
 /area/medical/eva)
 "rfJ" = (
@@ -110769,11 +110694,6 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	on = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -111043,10 +110963,11 @@
 	name = "Privacy Shutters";
 	opacity = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "dark_navy";
+	tag = "icon-dark_navy (NORTHEAST)"
 	},
-/turf/simulated/floor/plating,
 /area/medical/surgery)
 "tQR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -111407,6 +111328,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "dark floor stripe";
@@ -111689,12 +111613,9 @@
 /turf/space,
 /area/shuttle/exploration)
 "xGP" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4;
+	on = 1
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -212464,7 +212385,7 @@ aTV
 aYx
 bak
 bbG
-iZS
+bde
 beJ
 bgr
 bie
@@ -216465,8 +216386,8 @@ avT
 azs
 aBv
 aLH
-aEA
-aGt
+aEC
+aKg
 aIo
 aKg
 aKg
@@ -216965,11 +216886,11 @@ auG
 avW
 axP
 azv
-auI
-aIs
-aIs
-aIs
+awa
 aLH
+aEA
+aEA
+aBx
 aKg
 aLK
 aLK
@@ -217467,13 +217388,13 @@ aei
 avV
 axO
 azu
-auI
-bnc
-aEC
-aGv
+aGA
+aSz
+aSz
+aSz
 aLH
 aKg
-aLI
+bnc
 aLI
 aLH
 aaf
@@ -217969,7 +217890,7 @@ aei
 avY
 avX
 azw
-auI
+aGA
 aCS
 jML
 aGx
@@ -218471,15 +218392,15 @@ aei
 avX
 awa
 azw
-auI
+aGA
 aCR
 aED
 aEE
 kot
 aQH
-bon
 aIr
 aIr
+mwS
 rfC
 aNN
 aUf
@@ -218972,12 +218893,12 @@ aei
 aei
 awa
 awa
-azw
-aBx
-aEE
+apX
+aGA
+aGv
 aIq
 hnY
-aIu
+kot
 aKj
 xGP
 auM
@@ -219474,12 +219395,12 @@ atc
 auH
 avZ
 axQ
-azx
+aBv
 auI
 aCT
 aEF
 aGy
-aCU
+kot
 aKi
 aCW
 aNH
@@ -219978,15 +219899,15 @@ aCY
 aCY
 aCY
 aCY
-auI
-auI
+aGA
+cOq
 aGE
 aGA
 tAr
 aNV
 aGA
 aGA
-aGA
+aLO
 aSz
 aUk
 aVS
@@ -220987,8 +220908,8 @@ anM
 bqH
 lNr
 aKm
-aQG
-aNK
+nil
+aCU
 aXn
 aQL
 aSz
@@ -221010,7 +220931,7 @@ bpw
 bqz
 brT
 bdf
-bul
+buk
 bvz
 bwG
 byf
@@ -221476,7 +221397,7 @@ aei
 aEP
 apY
 atf
-apX
+arF
 arD
 aCY
 awc
@@ -221489,7 +221410,7 @@ aDa
 aGC
 aIw
 aKl
-aQG
+bon
 aNK
 bdp
 aQK
@@ -221985,7 +221906,7 @@ awf
 awb
 gSj
 azB
-aCX
+azx
 aGA
 hGM
 rCD
@@ -222012,7 +221933,7 @@ bmT
 boi
 bpx
 bqB
-bde
+brT
 bdf
 bun
 bvy
@@ -222492,8 +222413,8 @@ aGA
 azD
 aGD
 aIx
-aKn
-aLO
+aKo
+aQG
 aNM
 aPi
 aDb
@@ -222997,7 +222918,7 @@ aGA
 aUx
 aVW
 aGA
-aGA
+aKn
 aGA
 aGA
 aUo
@@ -223573,7 +223494,7 @@ aaa
 czI
 cBk
 cBh
-cDP
+aIu
 cFw
 cHc
 cIp
@@ -226002,7 +225923,7 @@ wxL
 onx
 azJ
 auN
-auN
+qJG
 eZh
 hdR
 aIz
@@ -226592,11 +226513,11 @@ cIz
 cJT
 cLt
 cMU
-cOq
-cOq
-cOq
-cOq
-cOq
+cJP
+cJP
+cJP
+cJP
+cJP
 cTZ
 cUL
 cVv
@@ -227527,7 +227448,7 @@ bgQ
 aCV
 awd
 bgN
-bit
+bgQ
 aBw
 bpH
 aLQ

--- a/maps/defficiency.dmm
+++ b/maps/defficiency.dmm
@@ -70625,7 +70625,7 @@
 	freerange = 1;
 	name = "Station Intercom (Captain)";
 	pixel_x = 27;
-	pixel_y = -7
+	pixel_y = -9
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
@@ -71348,10 +71348,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -24;
 	pixel_y = 6
-	},
-/obj/machinery/media/receiver/boombox/wallmount{
-	pixel_y = -4;
-	pixel_x = -28
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
@@ -72903,6 +72899,10 @@
 	dir = 6
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/media/receiver/boombox/wallmount{
+	pixel_y = -2;
+	pixel_x = -28
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "cJV" = (
@@ -72919,10 +72919,6 @@
 	},
 /area/bridge)
 "cJW" = (
-/obj/machinery/recharger/defibcharger/wallcharger{
-	pixel_x = 35;
-	pixel_y = -10
-	},
 /turf/simulated/floor{
 	icon_state = "bluecorner"
 	},
@@ -73835,6 +73831,10 @@
 /area/maintenance/maintcentral)
 "cLD" = (
 /obj/machinery/vending/cigarette,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "cLE" = (
@@ -74630,10 +74630,6 @@
 	dir = 1
 	},
 /obj/machinery/disposal,
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/structure/painting/random{
 	pixel_y = -32
 	},
@@ -74647,6 +74643,10 @@
 	},
 /area/bridge)
 "cMX" = (
+/obj/machinery/recharger/defibcharger/wallcharger{
+	pixel_x = 35;
+	pixel_y = -5
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "bluecorner"

--- a/maps/defficiency.dmm
+++ b/maps/defficiency.dmm
@@ -22529,10 +22529,6 @@
 	icon_state = "white"
 	},
 /area/science/mixing)
-"aQE" = (
-/obj/machinery/light/small,
-/turf/simulated/wall/r_wall,
-/area/science/mixing)
 "aQF" = (
 /obj/machinery/light{
 	dir = 1
@@ -33181,22 +33177,21 @@
 "bjx" = (
 /obj/structure/table,
 /obj/item/weapon/storage/box/donkpockets{
-	pixel_x = 4;
-	pixel_y = 3
+	pixel_x = -6;
+	pixel_y = 4
 	},
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/item/weapon/reagent_containers/food/snacks/customizable/cook/donkpocket{
-	pixel_x = -5;
-	pixel_y = 3
+	pixel_x = 6;
+	pixel_y = 4
 	},
 /obj/item/weapon/reagent_containers/food/snacks/customizable/cook/donkpocket{
-	pixel_x = -16
-	},
-/obj/item/weapon/reagent_containers/food/snacks/customizable/cook/donkpocket{
-	pixel_x = -10;
 	pixel_y = 9
+	},
+/obj/item/weapon/reagent_containers/food/snacks/customizable/cook/donkpocket{
+	pixel_x = -2
 	},
 /turf/simulated/floor{
 	icon_state = "darkpurple";
@@ -33222,11 +33217,11 @@
 	pixel_y = 5
 	},
 /obj/item/weapon/reagent_containers/food/drinks/flagmug/uruguaycup{
-	pixel_x = 5;
+	pixel_x = -3;
 	pixel_y = 1
 	},
 /obj/item/weapon/reagent_containers/food/drinks/flagmug/uruguaycup{
-	pixel_x = -3;
+	pixel_x = 5;
 	pixel_y = 1
 	},
 /turf/simulated/floor{
@@ -215882,7 +215877,7 @@ aKd
 aLG
 aLK
 aLH
-aQE
+aLD
 aSu
 aUb
 aVK

--- a/maps/defficiency.dmm
+++ b/maps/defficiency.dmm
@@ -70982,9 +70982,7 @@
 	name = "Security Medbay"
 	})
 "cGr" = (
-/obj/structure/closet/walllocker/defiblocker{
-	pixel_y = 32
-	},
+/obj/structure/closet/walllocker/defiblocker/north,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -110627,11 +110625,12 @@
 /turf/simulated/floor/shuttle,
 /area/shuttle/exploration)
 "rfC" = (
-/obj/machinery/recharger/defibcharger/wallcharger{
-	pixel_x = -24;
-	pixel_y = -2
-	},
 /obj/structure/bed/roller/deff,
+/obj/machinery/vending/wallmed1{
+	name = "Emergency NanoMed";
+	pixel_x = -27;
+	pixel_y = 2
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "dark_navy";

--- a/maps/defficiency.dmm
+++ b/maps/defficiency.dmm
@@ -7843,9 +7843,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/meatpizza{
-	pixel_y = 8
-	},
+/obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/meatpizza,
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
@@ -10834,9 +10832,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "dark";
-	tag = "icon-dark (NORTH)"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/medical/genetics)
 "awd" = (
@@ -10870,23 +10867,24 @@
 	name = "Medbay - Genetics Research"
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "dark";
-	tag = "icon-dark (NORTH)"
+	icon_state = "dark purple stripe";
+	tag = "icon-dark purple stripe (WEST)";
+	dir = 1
 	},
 /area/medical/genetics)
 "awf" = (
-/obj/machinery/dna_scannernew,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "dark";
-	tag = "icon-dark (NORTH)"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/area/medical/genetics)
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/captain)
 "awg" = (
 /obj/machinery/dna_scannernew,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "dark purple stripe";
+	tag = "icon-dark purple stripe (WEST)";
+	dir = 1
 	},
 /area/medical/genetics)
 "awh" = (
@@ -10903,9 +10901,9 @@
 	pixel_y = 2
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "dark";
-	tag = "icon-dark (NORTH)"
+	icon_state = "dark purple stripe";
+	tag = "icon-dark purple stripe (WEST)";
+	dir = 1
 	},
 /area/medical/genetics)
 "awi" = (
@@ -10920,7 +10918,9 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "dark purple stripe";
+	tag = "icon-dark purple stripe (SOUTHEAST)"
 	},
 /area/medical/genetics)
 "awj" = (
@@ -10929,7 +10929,9 @@
 	},
 /obj/machinery/computer/scan_consolenew,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "dark purple stripe";
+	tag = "icon-dark purple stripe (WEST)";
+	dir = 1
 	},
 /area/medical/genetics)
 "awk" = (
@@ -11811,9 +11813,8 @@
 "axR" = (
 /mob/living/carbon/monkey,
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "dark";
-	tag = "icon-dark (NORTH)"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/medical/genetics)
 "axT" = (
@@ -11868,9 +11869,8 @@
 	},
 /mob/living/carbon/monkey,
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "dark";
-	tag = "icon-dark (NORTH)"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/medical/genetics)
 "axZ" = (
@@ -11950,7 +11950,7 @@
 	},
 /obj/machinery/door/airlock/glass_research{
 	name = "Genetics Research";
-	req_access_txt = "5"
+	req_access_txt = "5;9"
 	},
 /turf/simulated/floor{
 	icon_state = "dark purple full";
@@ -12729,9 +12729,8 @@
 /mob/living/carbon/monkey,
 /obj/structure/window/reinforced,
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "dark";
-	tag = "icon-dark (NORTH)"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/medical/genetics)
 "azz" = (
@@ -12741,9 +12740,8 @@
 /mob/living/carbon/monkey,
 /obj/structure/window/reinforced,
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "dark";
-	tag = "icon-dark (NORTH)"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/medical/genetics)
 "azA" = (
@@ -12753,9 +12751,8 @@
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "dark";
-	tag = "icon-dark (NORTH)"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/medical/genetics)
 "azB" = (
@@ -14066,9 +14063,9 @@
 	pixel_x = -5
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "dark";
-	tag = "icon-dark (NORTH)"
+	dir = 8;
+	icon_state = "dark purple stripe";
+	tag = "icon-dark purple stripe (WEST)"
 	},
 /area/medical/genetics)
 "aBA" = (
@@ -14164,8 +14161,9 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	icon_state = "dark purple corner";
-	tag = "icon-dark purple corner (WEST)"
+	dir = 4;
+	icon_state = "dark purple stripe";
+	tag = "icon-dark purple stripe (WEST)"
 	},
 /area/medical/genetics)
 "aBK" = (
@@ -38021,8 +38019,9 @@
 	dir = 4
 	},
 /turf/simulated/floor{
+	dir = 10;
 	icon_state = "dark purple stripe";
-	tag = "icon-dark purple stripe (WEST)"
+	tag = "icon-dark purple stripe (SOUTHEAST)"
 	},
 /area/medical/genetics)
 "brZ" = (
@@ -66805,7 +66804,7 @@
 	},
 /obj/item/weapon/coin/silver{
 	pixel_x = 5;
-	pixel_y = -3
+	pixel_y = -15
 	},
 /obj/item/weapon/melee/chainofcommand{
 	pixel_y = 6;
@@ -72306,7 +72305,6 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "cIF" = (
-/obj/machinery/hologram/holopad,
 /obj/structure/table/woodentable,
 /obj/item/weapon/pinpointer,
 /obj/item/weapon/disk/nuclear,
@@ -110813,6 +110811,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
+"qEb" = (
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/medical/genetics)
 "qGK" = (
 /obj/effect/decal/warning_stripes{
 	dir = 4;
@@ -111152,9 +111156,8 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "dark";
-	tag = "icon-dark (NORTH)"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/medical/genetics)
 "sRx" = (
@@ -220704,7 +220707,7 @@ aoO
 apW
 arC
 aCY
-awb
+qEb
 axR
 azy
 aBy
@@ -222210,7 +222213,7 @@ aqa
 arF
 vuU
 aCY
-awf
+awg
 awb
 gSj
 azB
@@ -230834,7 +230837,7 @@ cEe
 cFN
 cyH
 cIF
-cJX
+awf
 cLB
 cMY
 cOu

--- a/maps/defficiency.dmm
+++ b/maps/defficiency.dmm
@@ -4485,9 +4485,6 @@
 /turf/simulated/wall,
 /area/medical/virology)
 "ajy" = (
-/obj/machinery/light_switch{
-	pixel_y = -24
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -6591,14 +6588,14 @@
 /area/maintenance/fpmaint)
 "anM" = (
 /obj/structure/closet/secure_closet/medical2,
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 25
-	},
 /obj/structure/cable/yellow{
 	d2 = 2;
 	icon_state = "0-2";
 	pixel_y = 1
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 25
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -7763,16 +7760,17 @@
 /area/medical/break_room)
 "apZ" = (
 /obj/structure/table/glass,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = 26
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "dark vault stripe"
 	},
 /area/medical/break_room)
 "aqa" = (
@@ -7788,7 +7786,8 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "dark vault stripe"
 	},
 /area/medical/break_room)
 "aqb" = (
@@ -7804,7 +7803,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "dark vault stripe"
 	},
 /area/medical/break_room)
 "aqc" = (
@@ -7820,7 +7820,8 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "dark vault stripe"
 	},
 /area/medical/break_room)
 "aqd" = (
@@ -7831,7 +7832,8 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "dark vault stripe"
 	},
 /area/medical/break_room)
 "aqe" = (
@@ -7844,8 +7846,12 @@
 /obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/meatpizza{
 	pixel_y = 8
 	},
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "dark vault stripe"
 	},
 /area/medical/break_room)
 "aqf" = (
@@ -8667,17 +8673,14 @@
 	pixel_x = -23
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 10;
+	icon_state = "dark vault stripe"
 	},
 /area/medical/break_room)
 "arE" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Break Room Maintenance";
 	req_access_txt = "5"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	name = "Firelock West"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9485,7 +9488,9 @@
 	},
 /obj/machinery/media/jukebox/bar,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 9;
+	icon_state = "dark vault stripe";
+	tag = "icon-dark vault stripe (NORTHWEST)"
 	},
 /area/medical/break_room)
 "atg" = (
@@ -9499,7 +9504,7 @@
 	dir = 5
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "dark vault stripe"
 	},
 /area/medical/break_room)
 "ath" = (
@@ -9531,7 +9536,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "dark vault stripe"
 	},
 /area/medical/break_room)
 "atj" = (
@@ -9540,7 +9545,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "dark vault stripe"
 	},
 /area/medical/break_room)
 "atk" = (
@@ -9549,7 +9554,7 @@
 	},
 /obj/structure/bookcase/manuals/medical,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "dark vault stripe"
 	},
 /area/medical/break_room)
 "atl" = (
@@ -9559,7 +9564,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "dark vault stripe"
 	},
 /area/medical/break_room)
 "atm" = (
@@ -11880,6 +11885,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/light_switch{
+	pixel_y = -24;
+	pixel_x = 2
+	},
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "dark purple stripe";
@@ -11944,7 +11953,8 @@
 	req_access_txt = "5"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "dark purple full";
+	tag = "icon-dark_navy_full"
 	},
 /area/medical/genetics)
 "ayd" = (
@@ -12708,7 +12718,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -25
 	},
 /turf/simulated/floor{
 	icon_state = "dark purple stripe";
@@ -12820,8 +12830,12 @@
 /obj/structure/window/reinforced,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "dark vault stripe"
 	},
 /area/medical/break_room)
 "azG" = (
@@ -12873,13 +12887,6 @@
 	name = "Medbay - Hallway";
 	pixel_y = 3
 	},
-/obj/machinery/requests_console{
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC";
-	phone_name = "Patient Rooms";
-	pixel_x = 32
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -12887,13 +12894,25 @@
 "azL" = (
 /obj/machinery/computer/crew,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "darkblue";
+	tag = "icon-darkblue (NORTH)"
 	},
 /area/medical/cmo)
 "azM" = (
 /obj/machinery/suit_storage_unit/medical,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Medical Officer's Desk";
+	departmentType = 5;
+	name = "Chief Medical Officer RC";
+	pixel_x = -28;
+	pixel_y = -5
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "darkblue";
+	tag = "icon-darkblue (NORTH)"
 	},
 /area/medical/cmo)
 "azN" = (
@@ -12902,18 +12921,20 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/trunk,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 22
-	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "darkblue"
 	},
 /area/medical/cmo)
 "azO" = (
 /obj/machinery/computer/med_data,
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "darkblue";
+	tag = "icon-darkblue (NORTH)"
 	},
 /area/medical/cmo)
 "azP" = (
@@ -14060,8 +14081,7 @@
 	},
 /turf/simulated/floor{
 	dir = 6;
-	icon_state = "dark purple stripe";
-	tag = "icon-dark purple stripe (SOUTHEAST)"
+	icon_state = "darkpurple"
 	},
 /area/science/telescience)
 "aBB" = (
@@ -14160,6 +14180,13 @@
 	dir = 1
 	},
 /obj/structure/window/full/reinforced,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "oncpriv";
+	name = "Privacy Shutters";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/medical/cmo)
 "aBL" = (
@@ -14177,12 +14204,20 @@
 	},
 /area/medical/cmo)
 "aBN" = (
-/obj/machinery/keycard_auth{
-	pixel_x = 24
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/keycard_auth{
+	pixel_x = 26;
+	pixel_y = 15
+	},
+/obj/machinery/door_control{
+	id_tag = "oncpriv";
+	name = "Privacy Shutters";
+	pixel_x = 25;
+	pixel_y = 4
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 4;
+	icon_state = "darkblue"
 	},
 /area/medical/cmo)
 "aBO" = (
@@ -14715,7 +14750,8 @@
 "aCQ" = (
 /obj/machinery/chem_master,
 /obj/item/device/radio/intercom/medbay{
-	pixel_x = 30
+	pixel_x = 30;
+	pixel_y = 1
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -14725,13 +14761,20 @@
 /area/medical/chemistry)
 "aCR" = (
 /obj/structure/table,
-/obj/item/tool/scalpel{
-	pixel_y = 2
-	},
-/obj/item/tool/hemostat,
-/obj/item/tool/FixOVein,
 /obj/machinery/camera{
 	name = "Medbay - Surgery Overflow"
+	},
+/obj/item/tool/scalpel{
+	pixel_y = -1;
+	pixel_x = 1
+	},
+/obj/item/tool/hemostat{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/tool/bonesetter{
+	pixel_x = 11;
+	pixel_y = 3
 	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
@@ -14739,13 +14782,17 @@
 /area/medical/surgery)
 "aCS" = (
 /obj/structure/table,
-/obj/item/tool/bonegel,
-/obj/item/tool/bonesetter,
-/obj/item/tool/cautery{
-	pixel_x = 4
+/obj/effect/decal/cleanable/cobweb,
+/obj/item/tool/circular_saw{
+	pixel_x = 5;
+	pixel_y = -1
 	},
-/obj/item/device/radio/intercom/medbay{
-	pixel_x = -30
+/obj/item/tool/FixOVein{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/tool/retractor{
+	pixel_x = 6
 	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
@@ -14884,10 +14931,10 @@
 	},
 /area/medical/medbay)
 "aDf" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/machinery/cloning/clonepod/full,
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "dark_navy";
@@ -14906,6 +14953,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "oncpriv";
+	name = "Privacy Shutters";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/medical/cmo)
 "aDh" = (
@@ -14923,8 +14977,8 @@
 	pixel_x = 5
 	},
 /obj/item/weapon/stamp/cmo{
-	pixel_x = -6;
-	pixel_y = 6
+	pixel_x = -7;
+	pixel_y = 9
 	},
 /obj/structure/table/glass,
 /obj/item/clothing/glasses/hud/health{
@@ -14933,7 +14987,7 @@
 	},
 /obj/item/weapon/pen/red{
 	pixel_x = -10;
-	pixel_y = 1
+	pixel_y = 4
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -14941,16 +14995,27 @@
 /area/medical/cmo)
 "aDj" = (
 /obj/structure/table/glass,
-/obj/item/weapon/paper_bin/white{
-	pixel_x = 5;
-	pixel_y = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/obj/item/weapon/pen{
-	pixel_x = 11;
-	pixel_y = 4
+/obj/item/weapon/cartridge/medical{
+	pixel_x = 10;
+	pixel_y = 1
+	},
+/obj/item/weapon/cartridge/medical{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/weapon/cartridge/chemistry{
+	pixel_y = 3;
+	pixel_x = 8
+	},
+/obj/item/weapon/cartridge/medical{
+	pixel_x = 3
+	},
+/obj/item/clothing/accessory/stethoscope{
+	pixel_y = 6;
+	pixel_x = -2
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -14964,19 +15029,24 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/item/device/radio/intercom/medbay{
-	pixel_x = 30
+	pixel_x = 28;
+	pixel_y = 2
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 4;
+	icon_state = "darkblue"
 	},
 /area/medical/cmo)
 "aDl" = (
-/obj/item/clothing/accessory/stethoscope{
-	pixel_y = 6;
-	pixel_x = -2
-	},
 /obj/structure/table/glass,
-/mob/living/simple_animal/cat/Runtime,
+/obj/item/weapon/paper_bin/white{
+	pixel_x = -6;
+	pixel_y = 13
+	},
+/obj/item/weapon/pen{
+	pixel_x = -4;
+	pixel_y = 7
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -15695,27 +15765,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	pixel_x = 27;
-	pixel_y = 3
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 1
-	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/medical/surgery)
 "aEG" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
+/obj/machinery/light_switch{
+	pixel_x = 22;
+	pixel_y = -14
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -15786,7 +15843,7 @@
 	pixel_y = -4
 	},
 /obj/machinery/newscaster{
-	pixel_x = -32
+	pixel_x = -27
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -15820,7 +15877,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	pixel_x = -26;
-	pixel_y = 4
+	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -15916,6 +15973,13 @@
 	dir = 8
 	},
 /obj/structure/window/full/reinforced,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "oncpriv";
+	name = "Privacy Shutters";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/medical/cmo)
 "aEW" = (
@@ -15944,21 +16008,16 @@
 /area/medical/cmo)
 "aEZ" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Medical Officer's Desk";
-	departmentType = 5;
-	name = "Chief Medical Officer RC";
-	pixel_x = 32
-	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 4;
+	icon_state = "darkblue"
 	},
 /area/medical/cmo)
 "aFa" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	on = 1
 	},
+/mob/living/simple_animal/cat/Runtime,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -16736,10 +16795,17 @@
 	},
 /area/science/storage)
 "aGv" = (
-/obj/item/tool/surgicaldrill,
-/obj/item/tool/circular_saw,
+/obj/item/tool/surgicaldrill{
+	pixel_y = 5
+	},
 /obj/structure/table,
-/obj/item/tool/retractor,
+/obj/item/tool/bonegel{
+	pixel_x = -2;
+	pixel_y = 1
+	},
+/obj/item/tool/cautery{
+	pixel_x = 4
+	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -16762,11 +16828,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -16776,11 +16837,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "dark floor stripe";
@@ -16833,11 +16889,6 @@
 /obj/machinery/door/airlock/medical{
 	name = "Overflow Operating Room";
 	req_access_txt = "45"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -17028,10 +17079,6 @@
 	},
 /area/medical/cmo)
 "aGQ" = (
-/obj/machinery/light_switch{
-	pixel_x = -5;
-	pixel_y = -26
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -17053,7 +17100,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 4;
+	icon_state = "darkblue"
 	},
 /area/medical/cmo)
 "aGS" = (
@@ -18071,44 +18119,39 @@
 /obj/structure/cable/yellow,
 /obj/machinery/photocopier,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "darkblue"
 	},
 /area/medical/cmo)
 "aIH" = (
-/obj/item/weapon/cartridge/medical{
-	pixel_x = -2;
-	pixel_y = 6
-	},
-/obj/item/weapon/cartridge/medical{
-	pixel_x = 6;
-	pixel_y = 3
-	},
-/obj/item/weapon/cartridge/medical,
-/obj/item/weapon/cartridge/chemistry{
-	pixel_y = 2
-	},
-/obj/structure/table/glass,
+/obj/structure/table,
 /obj/machinery/light,
 /obj/machinery/light_switch{
-	pixel_x = -22;
+	pixel_x = -23;
 	pixel_y = 5
 	},
+/obj/machinery/faxmachine{
+	department = "CMO's Office";
+	pixel_y = 4;
+	pixel_x = -2
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "darkblue"
 	},
 /area/medical/cmo)
 "aII" = (
 /obj/structure/closet/secure_closet/CMO,
-/obj/item/clothing/suit/storage/draculacoat,
+/obj/item/weapon/cartridge/cmo,
 /obj/item/weapon/beartrap,
+/obj/item/clothing/suit/storage/draculacoat,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 6;
+	icon_state = "darkblue"
 	},
 /area/medical/cmo)
 "aIJ" = (
 /obj/structure/filingcabinet/medical,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "darkblue"
 	},
 /area/medical/cmo)
 "aIK" = (
@@ -18862,8 +18905,7 @@
 	},
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "dark purple stripe";
-	tag = "icon-dark purple stripe (WEST)"
+	icon_state = "darkpurple"
 	},
 /area/science/telescience)
 "aKi" = (
@@ -18883,13 +18925,10 @@
 	pixel_y = -5;
 	pixel_x = 1
 	},
-/obj/structure/closet/hydrant{
-	pixel_y = 32
-	},
 /turf/simulated/floor{
-	dir = 5;
+	dir = 4;
 	icon_state = "dark_navy";
-	tag = "icon-dark_navy (NORTHEAST)"
+	tag = "icon-dark_navy (EAST)"
 	},
 /area/medical/eva)
 "aKj" = (
@@ -19006,7 +19045,7 @@
 "aKt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/newscaster{
-	pixel_x = 32
+	pixel_x = 24
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -19804,6 +19843,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8;
+	name = "Firelock West"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -22534,7 +22577,7 @@
 "aQH" = (
 /obj/machinery/suit_storage_unit/medical,
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 26
 	},
 /turf/simulated/floor{
 	dir = 9;
@@ -22576,17 +22619,16 @@
 	},
 /area/medical/surgery)
 "aQK" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/medical/surgery)
+/area/medical/chemistry)
 "aQL" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	initialize_directions = 11
@@ -23590,10 +23632,6 @@
 	},
 /area/medical/sleeper)
 "aSE" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	name = "Firelock East"
-	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -23701,10 +23739,6 @@
 	dir = 8
 	},
 /obj/machinery/disposal,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "darkyellow";
@@ -24556,11 +24590,26 @@
 /area/science/mixing)
 "aUf" = (
 /obj/structure/table/reinforced,
-/obj/item/device/gps/science,
-/obj/item/device/gps/science,
-/obj/item/device/gps/science,
-/obj/item/device/gps/science,
-/obj/item/device/gps/science,
+/obj/item/device/gps/science{
+	pixel_y = 2;
+	pixel_x = -2
+	},
+/obj/item/device/gps/science{
+	pixel_y = 2;
+	pixel_x = -2
+	},
+/obj/item/device/gps/science{
+	pixel_y = 2;
+	pixel_x = -2
+	},
+/obj/item/device/gps/science{
+	pixel_x = 1;
+	pixel_y = 3
+	},
+/obj/item/device/gps/science{
+	pixel_x = -2;
+	pixel_y = 3
+	},
 /obj/machinery/light_switch{
 	pixel_y = 24;
 	pixel_x = 3
@@ -26184,7 +26233,9 @@
 	pixel_x = 10;
 	pixel_y = 10
 	},
-/obj/item/weapon/storage/firstaid/regular,
+/obj/item/weapon/storage/firstaid/regular{
+	pixel_y = 1
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -26233,17 +26284,12 @@
 	},
 /area/medical/medbay)
 "aXq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/firedoor/border_only{
+	dir = 1;
+	name = "Firelock North"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "whitepurplecorner"
-	},
-/area/science/hallway)
+/turf/simulated/floor,
+/area/hallway/primary/fore)
 "aXr" = (
 /turf/simulated/wall,
 /area/medical/medbay2)
@@ -26303,8 +26349,7 @@
 	},
 /turf/simulated/floor{
 	dir = 10;
-	icon_state = "dark purple stripe";
-	tag = "icon-dark purple stripe (SOUTHWEST)"
+	icon_state = "darkpurple"
 	},
 /area/science/telescience)
 "aXw" = (
@@ -26319,8 +26364,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
-	icon_state = "dark purple stripe";
-	tag = "icon-dark purple stripe (WEST)"
+	icon_state = "darkpurple"
 	},
 /area/science/telescience)
 "aXz" = (
@@ -26949,11 +26993,17 @@
 	},
 /area/hallway/primary/central)
 "aYT" = (
-/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor,
-/area/hallway/primary/fore)
+/area/hallway/primary/port)
 "aYU" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
@@ -26967,7 +27017,6 @@
 /turf/simulated/wall,
 /area/crew_quarters/bar)
 "aYW" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
 	dir = 4
@@ -27836,7 +27885,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor{
-	dir = 1;
+	dir = 4;
 	icon_state = "whitepurplecorner"
 	},
 /area/science/hallway)
@@ -28012,6 +28061,10 @@
 /area/medical/medbay2)
 "baF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1;
+	name = "Firelock North"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "blue"
@@ -28602,8 +28655,7 @@
 	},
 /obj/machinery/vending/discount,
 /turf/simulated/floor{
-	icon_state = "dark purple stripe";
-	tag = "icon-dark purple stripe (WEST)"
+	icon_state = "darkpurple"
 	},
 /area/science/hallway)
 "bbH" = (
@@ -28613,8 +28665,7 @@
 /obj/machinery/vending/coffee,
 /turf/simulated/floor{
 	dir = 10;
-	icon_state = "dark purple stripe";
-	tag = "icon-dark purple stripe (SOUTHWEST)"
+	icon_state = "darkpurple"
 	},
 /area/science/hallway)
 "bbI" = (
@@ -28627,8 +28678,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/suit_storage_unit,
 /turf/simulated/floor{
-	icon_state = "dark purple stripe";
-	tag = "icon-dark purple stripe (WEST)"
+	icon_state = "darkpurple"
 	},
 /area/science/hallway)
 "bbJ" = (
@@ -28639,22 +28689,19 @@
 	tag = "icon-warning (NORTH)"
 	},
 /turf/simulated/floor{
-	icon_state = "dark purple stripe";
-	tag = "icon-dark purple stripe (WEST)"
+	icon_state = "darkpurple"
 	},
 /area/science/hallway)
 "bbK" = (
 /obj/structure/closet/secure_closet/scientist,
 /turf/simulated/floor{
-	icon_state = "dark purple stripe";
-	tag = "icon-dark purple stripe (WEST)"
+	icon_state = "darkpurple"
 	},
 /area/science/hallway)
 "bbL" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor{
-	icon_state = "dark purple stripe";
-	tag = "icon-dark purple stripe (WEST)"
+	icon_state = "darkpurple"
 	},
 /area/science/hallway)
 "bbM" = (
@@ -28710,15 +28757,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "whitepurple"
+	dir = 4;
+	icon_state = "whitepurplecorner"
 	},
 /area/science/hallway)
 "bbT" = (
@@ -30392,14 +30437,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -30453,18 +30496,15 @@
 	},
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "dark purple stripe";
-	tag = "icon-dark purple stripe (WEST)"
+	icon_state = "darkpurple"
 	},
 /area/science/telescience)
 "beV" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "whitepurple"
+	dir = 1;
+	icon_state = "whitepurplecorner"
 	},
 /area/science/hallway)
 "beW" = (
@@ -30474,8 +30514,7 @@
 "beX" = (
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "dark purple stripe";
-	tag = "icon-dark purple stripe (WEST)"
+	icon_state = "darkpurple"
 	},
 /area/science/telescience)
 "beY" = (
@@ -30571,6 +30610,10 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
 	on = 1
+	},
+/obj/structure/sign/poster{
+	icon_state = "poster9";
+	pixel_x = -32
 	},
 /turf/simulated/floor,
 /area/hallway/primary/fore)
@@ -31473,7 +31516,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "whitepurplecorner"
+	icon_state = "white"
 	},
 /area/science/hallway)
 "bgw" = (
@@ -31504,7 +31547,7 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "whitepurplecorner"
+	icon_state = "whitepurple"
 	},
 /area/science/hallway)
 "bgy" = (
@@ -31601,10 +31644,11 @@
 	pixel_x = -2;
 	pixel_y = 4
 	},
-/obj/item/weapon/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 12
-	},
 /obj/structure/closet/walllocker/defiblocker/west,
+/obj/item/weapon/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 10;
+	pixel_y = 1
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -31737,6 +31781,9 @@
 	pixel_x = 15;
 	pixel_y = -3
 	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "whitepurple"
@@ -31752,6 +31799,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -32495,7 +32547,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor{
-	dir = 8;
+	dir = 1;
 	icon_state = "whitepurplecorner"
 	},
 /area/science/hallway)
@@ -32509,8 +32561,14 @@
 	dir = 1;
 	name = "Firelock North"
 	},
+/obj/machinery/camera{
+	dir = 4;
+	name = "Research Division East";
+	network = list("SS13","RD")
+	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "whitepurplecorner"
 	},
 /area/science/hallway)
 "biq" = (
@@ -32551,7 +32609,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/vending/wallmed1{
-	pixel_x = 25
+	pixel_x = 26
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -33098,22 +33156,55 @@
 /area/science/rd)
 "bjx" = (
 /obj/structure/table,
-/obj/item/weapon/storage/box/donkpockets,
-/obj/structure/sign/chemtable{
-	pixel_y = 32
+/obj/item/weapon/storage/box/donkpockets{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/weapon/reagent_containers/food/snacks/customizable/cook/donkpocket{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/weapon/reagent_containers/food/snacks/customizable/cook/donkpocket{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/weapon/reagent_containers/food/snacks/customizable/cook/donkpocket{
+	pixel_x = -9;
+	pixel_y = 9
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "darkpurple";
+	dir = 1
 	},
 /area/science/hallway)
 "bjy" = (
 /obj/machinery/chem_dispenser/brewer{
-	pixel_y = 24
+	pixel_y = 23;
+	pixel_x = 1
 	},
 /obj/structure/table,
-/obj/item/weapon/reagent_containers/glass/kettle/purple,
+/obj/machinery/camera{
+	dir = 4;
+	name = "Research Division Break Room"
+	},
+/obj/item/weapon/reagent_containers/food/drinks/flagmug/uruguaycup{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/item/weapon/reagent_containers/food/drinks/flagmug/uruguaycup{
+	pixel_x = -3;
+	pixel_y = 1
+	},
+/obj/item/weapon/reagent_containers/food/drinks/flagmug/uruguaycup{
+	pixel_x = 5;
+	pixel_y = 1
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 9;
+	icon_state = "darkpurple"
 	},
 /area/science/hallway)
 "bjz" = (
@@ -33132,31 +33223,48 @@
 /area/science/hallway)
 "bjA" = (
 /obj/structure/table,
-/obj/machinery/microwave,
+/obj/machinery/microwave{
+	pixel_y = 6;
+	pixel_x = -3
+	},
+/obj/structure/sign/chemtable{
+	pixel_y = 32
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "darkpurple"
 	},
 /area/science/hallway)
 "bjB" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/tinted{
-	dir = 1
-	},
-/obj/structure/window/reinforced/tinted,
-/obj/structure/window/reinforced/tinted{
-	dir = 4
-	},
-/obj/structure/window/reinforced/tinted{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/science/lab)
 "bjC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	icon_state = "whitepurplecorner"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/science/hallway)
 "bjD" = (
 /obj/effect/decal/warning_stripes{
@@ -33291,6 +33399,11 @@
 /obj/item/weapon/stool{
 	pixel_y = 8
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -33363,8 +33476,12 @@
 	pixel_x = 3;
 	pixel_y = -7
 	},
-/obj/machinery/light_switch{
-	pixel_x = 22
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	pixel_x = 26
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -34028,11 +34145,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -34058,15 +34177,12 @@
 	},
 /area/science/server)
 "blg" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 1;
-	on = 1
-	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -34078,6 +34194,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -34086,9 +34205,6 @@
 "bli" = (
 /obj/structure/bed/chair/office/light{
 	dir = 8
-	},
-/obj/effect/landmark/start{
-	name = "Research Director"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -34146,14 +34262,23 @@
 	},
 /area/science/rd)
 "bll" = (
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4;
+	on = 1
 	},
+/turf/simulated/floor/mineral/plasma,
 /area/science/hallway)
 "blm" = (
 /obj/machinery/door/airlock/glass_science{
 	name = "Break Room";
 	req_access_txt = "47"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	name = "Firelock East"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -34186,13 +34311,15 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whitepurplecorner"
 	},
 /area/science/hallway)
 "blp" = (
 /obj/machinery/door/airlock/research{
 	name = "Research and Development Lab";
-	req_access_txt = "7"
+	req_access_txt = "7";
+	icon = 'icons/obj/doors/doorresearchglass.dmi'
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -34229,7 +34356,7 @@
 	},
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "whitepurple"
+	icon_state = "whitepurplecorner"
 	},
 /area/science/hallway)
 "blr" = (
@@ -34383,8 +34510,7 @@
 /obj/machinery/space_heater/air_conditioner,
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "dark purple stripe";
-	tag = "icon-dark purple stripe (WEST)"
+	icon_state = "darkpurple"
 	},
 /area/science/telescience)
 "blE" = (
@@ -34996,9 +35122,6 @@
 	},
 /area/science/server)
 "bmJ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/machinery/power/apc{
 	dir = 8;
 	pixel_x = -24
@@ -35008,6 +35131,7 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -35022,6 +35146,9 @@
 	},
 /obj/machinery/light_switch{
 	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -35040,6 +35167,10 @@
 	icon_state = "warning";
 	tag = "icon-warning (NORTH)"
 	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8;
+	on = 1
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -35049,6 +35180,9 @@
 	dir = 9;
 	icon_state = "warning";
 	tag = "icon-warning (NORTHWEST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -35072,31 +35206,30 @@
 	},
 /area/science/rd)
 "bmP" = (
-/obj/structure/bed/chair/comfy/beige{
-	dir = 4
-	},
+/obj/structure/bed/chair/comfy/beige,
 /obj/machinery/newscaster{
-	pixel_x = -28
+	pixel_x = -25
 	},
 /obj/effect/landmark/start{
 	name = "Scientist"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "darkpurple"
 	},
 /area/science/hallway)
 "bmQ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/tinted{
-	dir = 1
-	},
-/obj/structure/window/reinforced/tinted,
-/obj/structure/window/reinforced/tinted{
-	dir = 4
-	},
-/obj/structure/window/reinforced/tinted{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -35104,8 +35237,8 @@
 /area/science/lab)
 "bmR" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	initialize_directions = 11
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -35302,6 +35435,10 @@
 	pixel_y = -1
 	},
 /obj/structure/table,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "darkyellow";
@@ -35667,6 +35804,7 @@
 	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
+/obj/item/stack/sheet/mineral/plasma,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -35787,20 +35925,35 @@
 	},
 /area/science/rd)
 "boc" = (
-/obj/structure/bed/chair/comfy/beige{
-	dir = 4
+/obj/structure/table/glass,
+/obj/item/weapon/kitchen/utensil/spork{
+	pixel_x = 11;
+	pixel_y = 3
 	},
-/obj/machinery/light{
-	dir = 8
+/obj/item/trash/plate{
+	pixel_y = 12;
+	pixel_x = 1
+	},
+/obj/item/weapon/kitchen/utensil/spork{
+	pixel_x = -10;
+	pixel_y = 7
+	},
+/obj/item/trash/plate{
+	pixel_x = -1
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = -31
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "darkpurple"
 	},
 /area/science/hallway)
 "bod" = (
 /obj/structure/flora/pottedplant/random,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "darkpurple"
 	},
 /area/science/hallway)
 "boe" = (
@@ -35826,7 +35979,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "whitepurplecorner"
 	},
 /area/science/hallway)
 "boh" = (
@@ -36407,6 +36561,9 @@
 /obj/structure/wc/toilet{
 	dir = 4
 	},
+/obj/effect/landmark/start{
+	name = "Research Director"
+	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -36465,14 +36622,13 @@
 	},
 /area/science/rd)
 "bps" = (
-/obj/structure/bed/chair/comfy/beige{
-	dir = 4
-	},
+/obj/structure/bed/chair/comfy/beige,
 /obj/effect/landmark/start{
 	name = "Scientist"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 10;
+	icon_state = "darkpurple"
 	},
 /area/science/hallway)
 "bpt" = (
@@ -36484,7 +36640,8 @@
 	pixel_x = 11
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 6;
+	icon_state = "darkpurple"
 	},
 /area/science/hallway)
 "bpu" = (
@@ -36498,7 +36655,7 @@
 	icon_state = "pipe-j2s"
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitepurple"
 	},
 /area/science/hallway)
 "bpv" = (
@@ -36508,8 +36665,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "whitepurplecorner"
+	dir = 10;
+	icon_state = "whitepurple"
 	},
 /area/science/hallway)
 "bpw" = (
@@ -36518,8 +36675,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "whitepurplecorner"
+	dir = 6;
+	icon_state = "whitepurple"
 	},
 /area/science/hallway)
 "bpx" = (
@@ -37058,14 +37215,15 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access";
-	req_access_txt = "47"
+	req_access_txt = "47";
+	icon = 'icons/obj/doors/doorresearchglass.dmi'
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1;
 	name = "Firelock North"
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitepurplefull"
 	},
 /area/science/hallway)
 "bqy" = (
@@ -37098,14 +37256,17 @@
 /turf/simulated/floor/plating,
 /area/science/hallway)
 "bqA" = (
-/obj/machinery/door/airlock/research{
-	name = "Research and Development Lab";
-	req_access_txt = "7"
-	},
 /obj/machinery/door/firedoor/border_only{
 	name = "Firelock South"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/door/airlock/research{
+	name = "Research and Development Lab";
+	req_access_txt = "7";
+	icon = 'icons/obj/doors/doorresearchglass.dmi'
+	},
+/turf/simulated/floor{
+	icon_state = "whitepurplefull"
+	},
 /area/science/lab)
 "bqB" = (
 /obj/structure/grille,
@@ -37182,11 +37343,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -37754,6 +37910,11 @@
 	name = "Private AI Channel";
 	pixel_y = 22
 	},
+/obj/machinery/camera/flawless{
+	dir = 4;
+	name = "AI Upload Access";
+	network = list("SS13","RD")
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -37784,10 +37945,6 @@
 	},
 /area/turret_protected/ai_upload_foyer)
 "brP" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4;
-	on = 1
-	},
 /obj/structure/sign/biohazard{
 	pixel_y = 32
 	},
@@ -37814,9 +37971,7 @@
 	},
 /area/science/hallway)
 "brR" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whitepurplecorner"
@@ -38564,14 +38719,16 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8;
+	on = 1
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
 /area/science/hallway)
 "btl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -38997,11 +39154,8 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/machinery/light/small,
-/obj/machinery/camera/flawless{
-	dir = 1;
-	name = "AI Upload Access";
-	network = list("SS13","RD")
+/obj/structure/sign/ninjaglove{
+	pixel_y = -32
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -39015,6 +39169,7 @@
 /obj/effect/landmark/start{
 	name = "Cyborg"
 	},
+/obj/machinery/light,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -39074,9 +39229,6 @@
 	},
 /area/science/hallway)
 "bum" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -39086,9 +39238,6 @@
 	},
 /area/science/hallway)
 "bun" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -27
@@ -39775,7 +39924,8 @@
 "bvw" = (
 /obj/machinery/door/airlock/research{
 	name = "Robotics Lab";
-	req_access_txt = "29"
+	req_access_txt = "29";
+	icon = 'icons/obj/doors/doorresearchglass.dmi'
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -45899,6 +46049,7 @@
 /obj/machinery/optable{
 	name = "Robotics Operating Table"
 	},
+/obj/machinery/light/small,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -46421,7 +46572,8 @@
 	},
 /obj/machinery/door/airlock/research{
 	name = "Mech Bay";
-	req_access_txt = "29"
+	req_access_txt = "29";
+	icon = 'icons/obj/doors/doorresearchglass.dmi'
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -54685,9 +54837,6 @@
 /turf/simulated/floor,
 /area/crew_quarters/theatre)
 "bZA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -54697,10 +54846,6 @@
 	},
 /area/hallway/primary/port)
 "bZB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
@@ -55098,9 +55243,13 @@
 	},
 /area/crew_quarters/theatre)
 "car" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
-/area/hallway/primary/port)
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet,
+/area/bridge)
 "cas" = (
 /obj/structure/bed/chair,
 /obj/machinery/firealarm{
@@ -55839,7 +55988,6 @@
 /obj/effect/landmark{
 	name = "lightsout"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/hallway/primary/port)
 "cbL" = (
@@ -56328,10 +56476,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
 "ccU" = (
@@ -56359,10 +56503,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/sortjunction/Theatre/mirrored{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutral"
@@ -56831,8 +56973,8 @@
 /turf/simulated/floor,
 /area/hallway/primary/port)
 "ceg" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutral"
@@ -57210,6 +57352,9 @@
 /obj/machinery/light_switch{
 	pixel_y = -28
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},
@@ -57238,22 +57383,34 @@
 /obj/item/weapon/stool/piano{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/theatre)
 "cfh" = (
 /obj/structure/piano/random{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/theatre)
 "cfi" = (
 /obj/machinery/light,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/theatre)
 "cfj" = (
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/theatre)
@@ -57263,11 +57420,17 @@
 	dir = 1;
 	pixel_y = -25
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/theatre)
 "cfl" = (
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -57289,6 +57452,9 @@
 /obj/item/weapon/reagent_containers/food/snacks/pie,
 /obj/item/weapon/reagent_containers/food/snacks/pie,
 /obj/item/weapon/reagent_containers/food/snacks/pie,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/theatre)
 "cfo" = (
@@ -57314,8 +57480,10 @@
 /turf/simulated/floor/plating,
 /area/lawoffice)
 "cfq" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/sortjunction/Theatre/mirrored{
+	dir = 1
+	},
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
@@ -73686,6 +73854,11 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "blue"
@@ -74553,6 +74726,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "bluecorner"
@@ -74565,6 +74743,11 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "blue"
@@ -74572,11 +74755,21 @@
 /area/bridge)
 "cMP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor,
 /area/bridge)
 "cMQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/bridge)
@@ -74603,6 +74796,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "blue"
@@ -74614,6 +74812,11 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor{
 	desc = "\"This is a plaque in honour of our comrades whom bravely entered these tunnels and never returned..\" Engraved is an standard access door, grim as a tomb's door.";
@@ -78857,6 +79060,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/structure/cable/yellow,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "darkred";
@@ -95179,8 +95383,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "dark purple stripe";
-	tag = "icon-dark purple stripe (WEST)"
+	icon_state = "darkpurple"
 	},
 /area/science/telescience)
 "dUt" = (
@@ -95189,9 +95392,9 @@
 /area)
 "dXb" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -108903,6 +109106,18 @@
 	icon_state = "dark vault stripe"
 	},
 /area/engineering/engine)
+"eHl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "whitepurplecorner"
+	},
+/area/science/hallway)
 "ePc" = (
 /obj/structure/closet/emcloset/vox,
 /obj/machinery/alarm/vox{
@@ -109016,11 +109231,9 @@
 	},
 /area/hallway/primary/fore)
 "ftF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/light,
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "darkpurple"
 	},
 /area/science/hallway)
 "fuB" = (
@@ -109114,7 +109327,8 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whitepurplecorner"
 	},
 /area/science/hallway)
 "gyv" = (
@@ -109264,6 +109478,15 @@
 	icon_state = "showroomfloor"
 	},
 /area/medical/surgery)
+"hob" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "darkpurple"
+	},
+/area/science/hallway)
 "hpW" = (
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Engine Room";
@@ -109350,6 +109573,12 @@
 "hLz" = (
 /turf/simulated/floor/plating,
 /area/derelictparts/fsderelict)
+"hMI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/simulated/floor/mineral/plasma,
+/area/science/hallway)
 "hND" = (
 /obj/structure/grille/window_spawner/reinforced/full,
 /obj/machinery/door/poddoor{
@@ -109493,6 +109722,15 @@
 /obj/machinery/computer/shuttle_control/mining,
 /turf/simulated/floor,
 /area/hallway/primary/central)
+"ioj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "darkpurple"
+	},
+/area/science/hallway)
 "ipM" = (
 /obj/machinery/computer/crew{
 	req_access_txt = "500"
@@ -109664,6 +109902,15 @@
 	icon_state = "showroomfloor"
 	},
 /area/medical/surgery)
+"jPq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "dark vault stripe"
+	},
+/area/medical/break_room)
 "jTo" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -109677,6 +109924,17 @@
 /obj/abstract/map/spawner/floorpill/guaranteed,
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
+"jWq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/science/hallway)
 "jXi" = (
 /obj/structure/closet/medical_wall,
 /turf/simulated/wall/shuttle/black,
@@ -109900,6 +110158,14 @@
 /obj/machinery/firealarm,
 /turf/simulated/wall/shuttle/black,
 /area/shuttle/exploration)
+"lLf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/simulated/floor{
+	icon_state = "whitepurple"
+	},
+/area/science/hallway)
 "lNr" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -109969,6 +110235,12 @@
 	tag = "icon-dark_navy (WEST)"
 	},
 /area/medical/eva)
+"mGT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/theatre)
 "mSS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -109997,6 +110269,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/supermatter_room)
+"mUh" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "darkpurple"
+	},
+/area/science/hallway)
 "mWe" = (
 /obj/structure/shuttle/diag_wall/smooth{
 	dir = 8
@@ -110258,6 +110540,12 @@
 	},
 /turf/simulated/floor,
 /area/engineering/engine)
+"oEs" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/crew_quarters/theatre)
 "oIA" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -110285,8 +110573,7 @@
 	},
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "dark purple stripe";
-	tag = "icon-dark purple stripe (WEST)"
+	icon_state = "darkpurple"
 	},
 /area/science/telescience)
 "pdq" = (
@@ -110322,10 +110609,8 @@
 "pko" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/camera{
-	dir = 4;
-	name = "Research Division East";
-	network = list("SS13","RD")
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -110447,6 +110732,14 @@
 	},
 /turf/simulated/floor,
 /area/hallway/primary/central)
+"pUl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1;
+	name = "Firelock North"
+	},
+/turf/simulated/floor,
+/area/hallway/primary/fore)
 "pWI" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor{
@@ -110912,6 +111205,12 @@
 	},
 /turf/simulated/floor,
 /area/hallway/primary/central)
+"taF" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/science/hallway)
 "tpu" = (
 /obj/structure/rack,
 /turf/simulated/floor/shuttle,
@@ -110959,6 +111258,19 @@
 	tag = "icon-dark_navy (NORTHEAST)"
 	},
 /area/medical/surgery)
+"tOo" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/science/hallway)
 "tQR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door_control{
@@ -110997,8 +111309,7 @@
 /obj/structure/closet/secure_closet/scientist,
 /turf/simulated/floor{
 	dir = 6;
-	icon_state = "dark purple stripe";
-	tag = "icon-dark purple stripe (SOUTHEAST)"
+	icon_state = "darkpurple"
 	},
 /area/science/hallway)
 "tZJ" = (
@@ -111234,6 +111545,12 @@
 	tag = "icon-darkred (NORTH)"
 	},
 /area/security/brig)
+"vqe" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/plasma,
+/area/science/hallway)
 "vtG" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -111248,7 +111565,7 @@
 "vuU" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "dark vault stripe"
 	},
 /area/medical/break_room)
 "vwF" = (
@@ -111312,14 +111629,15 @@
 /area/engineering/engine)
 "vHG" = (
 /obj/structure/closet/crate/freezer/surgery,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
+	},
+/obj/machinery/firealarm{
+	pixel_y = 25;
+	pixel_x = 1
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -215891,7 +216209,7 @@ aaf
 aYL
 bdi
 beJ
-bgz
+eHl
 bik
 bjv
 blj
@@ -216393,7 +216711,7 @@ aaf
 bbM
 bdi
 beJ
-bgz
+jWq
 bij
 bju
 bli
@@ -217395,7 +217713,7 @@ aLD
 aLD
 bbO
 bbO
-ftF
+bdi
 beK
 bgA
 bil
@@ -217897,8 +218215,8 @@ blD
 beU
 aXv
 bbO
-aXq
-beL
+bdi
+beK
 bgz
 bim
 bjy
@@ -218405,9 +218723,9 @@ aET
 bim
 bjx
 bll
-bll
-bll
-bll
+hMI
+vqe
+ftF
 bqw
 brN
 btg
@@ -218906,9 +219224,9 @@ rfJ
 iaj
 bim
 bjA
-bll
-bll
-bll
+ioj
+hob
+mUh
 bpt
 bqw
 bqw
@@ -219403,13 +219721,13 @@ bbV
 bfd
 baq
 bbO
-ftF
+bdi
 beK
 boo
 bim
 bjz
 blm
-bjz
+bjC
 bim
 bim
 bim
@@ -220413,7 +220731,7 @@ aXk
 aIt
 bgB
 bln
-bgB
+tOo
 boe
 bpu
 bqx
@@ -220913,7 +221231,7 @@ bdm
 beS
 bgD
 bip
-bjC
+bgD
 blq
 bmR
 bog
@@ -221387,7 +221705,7 @@ aei
 aEP
 apY
 atf
-arF
+jPq
 arD
 aCY
 awc
@@ -221403,7 +221721,7 @@ aKl
 bon
 aNK
 bdp
-aQK
+aQM
 aSz
 oom
 oom
@@ -221422,8 +221740,8 @@ bof
 bof
 bof
 brS
-bdf
-buk
+taF
+lLf
 bvy
 bwF
 byd
@@ -221957,7 +222275,7 @@ bUp
 bUp
 bUp
 ceb
-bUp
+oEs
 bUp
 cho
 cdV
@@ -224969,7 +225287,7 @@ cao
 cao
 ccP
 ced
-cea
+mGT
 bUp
 chp
 ciq
@@ -226475,7 +226793,7 @@ bUp
 bUp
 bUp
 bUp
-bUp
+oEs
 bUp
 chu
 ciq
@@ -226503,11 +226821,11 @@ cIz
 cJT
 cLt
 cMU
-cJP
-cJP
-cJP
-cJP
-cJP
+car
+car
+car
+car
+car
 cTZ
 cUL
 cVv
@@ -227475,11 +227793,11 @@ bVR
 bXf
 bYi
 bZB
-car
+bKI
 cbK
 ccT
 cef
-cfm
+aYT
 cfm
 cht
 cfm
@@ -229446,7 +229764,7 @@ beZ
 bdt
 dXb
 bgR
-bne
+aQK
 bjQ
 blF
 bnd
@@ -231448,8 +231766,8 @@ aSN
 aIS
 aIS
 aIS
-aYT
 aIS
+aXq
 aIS
 aIS
 aIS
@@ -231951,7 +232269,7 @@ aUB
 aWi
 aXA
 aYW
-aXA
+pUl
 aXA
 aXA
 aXA

--- a/maps/defficiency.dmm
+++ b/maps/defficiency.dmm
@@ -28626,7 +28626,6 @@
 	pixel_y = 9
 	},
 /obj/item/weapon/pen,
-/obj/item/weapon/folder/white,
 /obj/effect/decal/warning_stripes{
 	icon_state = "warning";
 	tag = "icon-warning"
@@ -33214,10 +33213,6 @@
 	dir = 4;
 	name = "Research Division Break Room"
 	},
-/obj/item/weapon/reagent_containers/food/drinks/flagmug/uruguaycup{
-	pixel_x = 5;
-	pixel_y = 1
-	},
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -23
@@ -33225,6 +33220,10 @@
 /obj/item/weapon/reagent_containers/food/drinks/flagmug/uruguaycup{
 	pixel_x = 1;
 	pixel_y = 5
+	},
+/obj/item/weapon/reagent_containers/food/drinks/flagmug/uruguaycup{
+	pixel_x = 5;
+	pixel_y = 1
 	},
 /obj/item/weapon/reagent_containers/food/drinks/flagmug/uruguaycup{
 	pixel_x = -3;
@@ -36714,10 +36713,6 @@
 /area/science/hallway)
 "bpt" = (
 /obj/structure/flora/pottedplant/random,
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 3
-	},
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "darkpurple"
@@ -36784,10 +36779,6 @@
 	},
 /area/science/lab)
 "bpy" = (
-/obj/structure/wc/sink{
-	dir = 4;
-	pixel_x = 11
-	},
 /obj/machinery/light_switch{
 	pixel_x = -1;
 	pixel_y = -25

--- a/maps/defficiency.dmm
+++ b/maps/defficiency.dmm
@@ -4739,7 +4739,7 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/machinery/washing_machine,
+/obj/structure/flora/pottedplant/random,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -5697,12 +5697,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /obj/effect/decal/warning_stripes{
 	dir = 1;
 	icon_state = "warning"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -5711,14 +5711,6 @@
 	},
 /area/medical/virology)
 "alX" = (
-/obj/structure/wc/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/machinery/access_button{
 	command = "cycle_interior";
 	master_tag = "virology_airlock_control";
@@ -5732,6 +5724,9 @@
 	icon_state = "warning";
 	tag = "icon-warning (NORTHWEST)"
 	},
+/obj/machinery/shower{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "dark green stripe";
@@ -5739,7 +5734,6 @@
 	},
 /area/medical/virology)
 "alY" = (
-/obj/structure/closet/emcloset,
 /obj/machinery/camera{
 	name = "Virology Airlock"
 	},
@@ -5751,6 +5745,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
+/obj/structure/closet/l3closet/virology,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "dark green stripe";
@@ -6139,9 +6134,6 @@
 	},
 /area/medical/virology)
 "amR" = (
-/obj/machinery/shower{
-	dir = 4
-	},
 /obj/structure/sign/securearea{
 	pixel_x = -32
 	},
@@ -6150,6 +6142,9 @@
 	icon_state = "warning";
 	tag = "icon-warning (WEST)"
 	},
+/obj/machinery/shower{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "dark green stripe";
@@ -6157,20 +6152,16 @@
 	},
 /area/medical/virology)
 "amS" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/closet/l3closet/virology,
 /obj/effect/decal/warning_stripes{
 	dir = 4;
 	icon_state = "warning";
 	tag = "icon-warning (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/closet/l3closet/virology,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark green stripe";
@@ -6619,9 +6610,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/decal/warning_stripes{
 	dir = 8;
 	icon_state = "warning_corner";
@@ -6631,26 +6619,25 @@
 	icon_state = "warning_corner";
 	tag = "icon-warning_corner"
 	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	canSpawnMice = 0;
+	dir = 4;
+	on = 1
+	},
 /turf/simulated/floor{
 	icon_state = "dark green stripe";
 	tag = "icon-dark green stripe (NORTH)"
 	},
 /area/medical/virology)
 "anO" = (
-/obj/structure/wc/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	canSpawnMice = 0;
-	dir = 4;
-	on = 1
-	},
 /obj/effect/decal/warning_stripes{
 	dir = 10;
 	icon_state = "warning";
 	tag = "icon-warning (SOUTHWEST)"
+	},
+/obj/structure/wc/sink{
+	dir = 8;
+	pixel_x = -11
 	},
 /turf/simulated/floor{
 	dir = 10;
@@ -6668,7 +6655,6 @@
 	},
 /area/medical/virology)
 "anQ" = (
-/obj/structure/closet/l3closet/virology,
 /obj/effect/decal/warning_stripes{
 	dir = 6;
 	icon_state = "warning";
@@ -6677,6 +6663,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/washing_machine,
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "dark green stripe";

--- a/maps/defficiency.dmm
+++ b/maps/defficiency.dmm
@@ -230837,7 +230837,7 @@ cEe
 cFN
 cyH
 cIF
-awf
+cJX
 cLB
 cMY
 cOu
@@ -231339,7 +231339,7 @@ cEb
 cFK
 cHk
 cID
-cJX
+awf
 cLy
 cLy
 cOt


### PR DESCRIPTION
[deff] (closes #38749)

## What this does
fixes a couple small errors i never got around to fixing but more importantly reroutes medbay's EVA through surgery observation

<img width="544" height="448" alt="StrongDMM-2026-06-16 17 46 24" src="https://github.com/user-attachments/assets/7395368a-b33e-4e92-978c-57eac5c82d26" />

## Why it's good
ive noticed that going through surgery overflow discouraged doctors from going to telescience. the trip is much shorter now, so hopefully the lazy doctors will take advantage of their telepad access

## How it was tested
self-hosted

## Changelog
:cl:
 * rscadd: Deff: you now have to walk through surgery observation to reach medbay's EVA and telescience. very convenient!
 * tweak: Deff: slightly tweaked research, CMO's office, and medbay
 * tweak: Deff: small changes made to robotics
 * bugfix: Deff: VIROLOGY FINALLY GETS A WASHING MACHINE!
 * bugfix: Deff: fixed out of place painted tiles in medbay and bad object placement outside genetics
 * bugfix: Deff: the theatre disposal bin is now connected to the disposal pipe network