### PR TITLE
Fixes reticulite being unscannable with the mat synth

### DIFF
--- a/code/game/objects/items/devices/mat_synth.dm
+++ b/code/game/objects/items/devices/mat_synth.dm
@@ -17,6 +17,7 @@ var/static/list/mat2type = list(
 	MAT_MYTHRIL = /obj/item/stack/sheet/mineral/mythril,
 	MAT_CLOWN = /obj/item/stack/sheet/mineral/clown,
 	MAT_PHAZON = /obj/item/stack/sheet/mineral/phazon,
+	MAT_RETICULITE = /obj/item/stack/sheet/mineral/reticulite,
 )
 
 /obj/item/device/material_synth


### PR DESCRIPTION
## What this does
Fixes a mat synth oversight, a new material (reticulite) was added, but its mat 2 type define was not included on the mat synth's defines.
## Why it's good
Lets you produce some reticulite, provided you somehow get a sample.
:cl:
 * bugfix: Mat synths can now properly scan reticulite.