### PR TITLE
Roswell mech prober can now use both tiny and small items.

### DIFF
--- a/code/modules/mecha/equipment/tools/tools.dm
+++ b/code/modules/mecha/equipment/tools/tools.dm
@@ -1873,7 +1873,7 @@
 		to_chat(user, "<span class='warning'>Access Denied.</span>")
 		chassis.log_append_to_last("Permission denied.")
 		return
-	if(W.w_class > 1)
+	if(W.w_class > 2)
 		to_chat(user,"<span class='warning'>This item is too big for the prober.</span>")
 		return
 	if(user.drop_item(W,src))


### PR DESCRIPTION
## What this does
Tweaked on request.
The Roswell mech prober can now use both tiny and small items for its probing (previously only tiny). Gives a good niche to the Roswell, whilst still keeping balanced (if you want to murderbone it's faster to build a gygax or a phazon).
## Why it's good
You can already implant stuff small stuff surgically, why not the dedicated prober? Also lets you implant funny stuff into people's groins and I find that funny.
:cl:
 * tweak: Advancements in Ayy technology now lets Roswell probers use both Tiny and Small items, previously just Tiny.