### PR TITLE
GDR cargo crates now come in genuine mothership closets

### DIFF
--- a/code/datums/supply_packs/clothing.dm
+++ b/code/datums/supply_packs/clothing.dm
@@ -332,7 +332,7 @@
 					/obj/item/weapon/tank/emergency_oxygen/engi,
 					/obj/item/weapon/tank/emergency_oxygen/engi)
 	cost = 40
-	containertype = /obj/structure/closet/crate/ayy3/metal
+	containertype = /obj/structure/closet/crate/ayy3
 	containername = "GDR half-mask crate"
 	contraband = 1
 	group = "Clothing"

--- a/code/datums/supply_packs/clothing.dm
+++ b/code/datums/supply_packs/clothing.dm
@@ -295,7 +295,7 @@
 					/obj/item/weapon/tank/oxygen/red,
 					/obj/item/clothing/mask/gas/mothership)
 	cost = 175
-	containertype = /obj/structure/closet/crate/ayy/metal
+	containertype = /obj/structure/closet/crate/ayy
 	containername = "grey Space-Ex crate"
 	group = "Clothing"
 	containsdesc = "Contains a space-worthy softsuit that is perfectly fitted for a grey. Includes a fancy red oxygen tank!"
@@ -313,7 +313,7 @@
 					/obj/item/clothing/shoes/jackboots/mothership,
 					/obj/item/clothing/shoes/jackboots/mothership)
 	cost = 50
-	containertype = /obj/structure/closet/ayy/metal
+	containertype = /obj/structure/closet/ayy
 	containername = "mothership uniform locker"
 	containsicon = "grey_uniform"
 	containsdesc = "A batch of clothing from the grey mothership. Comes with either two outfits for workers, or two outfits for researchers. Whatever they had extra."

--- a/code/datums/supply_packs/security.dm
+++ b/code/datums/supply_packs/security.dm
@@ -141,7 +141,7 @@
 					/obj/item/clothing/head/helmet/mothership,
 					/obj/item/clothing/head/helmet/mothership)
 	cost = 60
-	containertype = /obj/structure/closet/secure_closet/ayy2/metal
+	containertype = /obj/structure/closet/secure_closet/ayy2
 	containername = "MDF standard armor locker"
 	one_access = list(access_security, access_mothership_military)
 	group = "Security"

--- a/code/datums/supply_packs/security.dm
+++ b/code/datums/supply_packs/security.dm
@@ -170,7 +170,7 @@
 					/obj/item/clothing/head/helmet/mothership_explorer,
 					/obj/item/clothing/head/helmet/mothership_explorer)
 	cost = 60
-	containertype = /obj/structure/closet/secure_closet/ayy/metal
+	containertype = /obj/structure/closet/secure_closet/ayy
 	containername = "GDR explorer armor locker"
 	one_access = list(access_security, access_mothership_military)
 	group = "Security"

--- a/maps/randomvaults/mothership_lab.dm
+++ b/maps/randomvaults/mothership_lab.dm
@@ -400,9 +400,6 @@
 	icon_closed = "ayycrate1"
 	starting_materials = list(MAT_RETICULITE = 2*CC_PER_SHEET_RETICULITE)
 
-/obj/structure/closet/crate/ayy/metal
-	starting_materials = list(MAT_IRON = 2*CC_PER_SHEET_METAL)
-
 /obj/structure/closet/crate/ayy2
 	name = "MDF crate"
 	desc = "A rugged storage crate, for transporting mothership military supplies."
@@ -422,9 +419,6 @@
 	icon_opened = "ayycrate3open"
 	icon_closed = "ayycrate3"
 	starting_materials = list(MAT_RETICULITE = 2*CC_PER_SHEET_RETICULITE)
-
-/obj/structure/closet/crate/ayy3/metal
-	starting_materials = list(MAT_IRON = 2*CC_PER_SHEET_METAL)
 
 /obj/structure/closet/crate/secure/ayy_general
 	name = "GDR secure crate"
@@ -454,9 +448,6 @@
 	icon_opened = "ayy1_open"
 	starting_materials = list(MAT_RETICULITE = 2*CC_PER_SHEET_RETICULITE)
 
-/obj/structure/closet/ayy/metal
-	starting_materials = list(MAT_IRON = 2*CC_PER_SHEET_METAL)
-
 /obj/structure/closet/ayy2
 	name = "MDF locker"
 	desc = "A rugged storage unit, for transporting mothership military supplies."
@@ -484,9 +475,6 @@
 	icon_off = "ayysecureoff"
 	starting_materials = list(MAT_RETICULITE = 2*CC_PER_SHEET_RETICULITE)
 
-/obj/structure/closet/secure_closet/ayy/metal
-	starting_materials = list(MAT_IRON = 2*CC_PER_SHEET_METAL)
-
 /obj/structure/closet/secure_closet/ayy2
 	name = "MDF secure locker"
 	desc = "A rugged card-locked storage unit, for transporting mothership military supplies."
@@ -497,9 +485,6 @@
 	icon_broken = "ayymdfsecurebroken"
 	icon_off = "ayymdfsecureoff"
 	starting_materials = list(MAT_RETICULITE = 2*CC_PER_SHEET_RETICULITE)
-
-/obj/structure/closet/secure_closet/ayy2/metal
-	starting_materials = list(MAT_IRON = 2*CC_PER_SHEET_METAL)
 
 /obj/structure/closet/secure_closet/ayy_leader
 	name = "Administrator's secure locker"


### PR DESCRIPTION
## What this does
GDR cargo crates now come in reticulite-based closets, instead of the faux metal ones.
:cl:
 * tweak: GDR cargo crates now come in genuine mothership closets!