### PR TITLE
Secure Crates Harder to Open

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -222,6 +222,8 @@
 	has_lockless_type = /obj/structure/closet/crate/large
 
 /obj/structure/closet/crate/secure/large/close()
+	if(!..())
+		return 0
 	//we can hold up to one large item
 	var/found = 0
 	for(var/obj/structure/S in src.loc)
@@ -236,7 +238,7 @@
 			if(!M.anchored)
 				M.forceMove(src)
 				break
-	..()
+	return 1
 
 //fluff variant
 /obj/structure/closet/crate/secure/large/reinforced
@@ -288,6 +290,8 @@
 	has_lock_type = /obj/structure/closet/crate/secure/large
 
 /obj/structure/closet/crate/large/close()
+	if(!..())
+		return 0
 	//we can hold up to one large item
 	var/found = 0
 	for(var/obj/structure/S in src.loc)
@@ -302,7 +306,7 @@
 			if(!M.anchored)
 				M.forceMove(src)
 				break
-	..()
+	return 1
 
 /obj/structure/closet/crate/hydroponics
 	name = "Hydroponics crate"
@@ -545,6 +549,13 @@
 	else
 		..()
 
+/obj/structure/closet/crate/secure/can_open()
+	if(!..())
+		return 0
+	if(src.locked)
+		return 0
+	return 1
+
 /obj/structure/closet/crate/MouseDrop(atom/drop_atom, src_location, over_location)
 	. = ..()
 	var/mob/living/user = usr
@@ -606,6 +617,16 @@
 		src.locked = 0
 		src.broken = 1
 		to_chat(user, "<span class='notice'>You unlock \the [src].</span>")
+
+/obj/structure/closet/crate/secure/proc/break_open()
+	if(locked && !broken)
+		overlays.len = 0
+		overlays += emag
+		overlays += sparks
+		spawn(6) overlays -= sparks //Tried lots of stuff but nothing works right. so i have to use this *sadface*
+		playsound(src, "sparks", 60, 1)
+		src.locked = 0
+		src.broken = 1
 
 /obj/structure/closet/crate/secure/verb/verb_togglelock()
 	set src in oview(1) // One square distance

--- a/code/game/objects/structures/crateshelf.dm
+++ b/code/game/objects/structures/crateshelf.dm
@@ -120,6 +120,9 @@
 		step(stored, pick(cardinal)) // Shuffle the contents around as though they've fallen down.
 		if(prob(5)) // Open the crate!
 			var/obj/structure/closet/crate/crate = stored
+			if(istype(crate, /obj/structure/closet/crate/secure))
+				var/obj/structure/closet/crate/secure/S = crate
+				S.break_open()
 			if(istype(crate) && crate.open())
 				crate.visible_message("<span class='warning'>[crate]'s lid falls open!</span>")
 	if(trapping)
@@ -349,6 +352,9 @@
 		step(stored, pick(cardinal))
 		if(prob(50))
 			var/obj/structure/closet/crate/crate = stored
+			if(istype(crate, /obj/structure/closet/crate/secure))
+				var/obj/structure/closet/crate/secure/S = crate
+				S.break_open()
 			if(istype(crate) && crate.open())
 				crate.visible_message("<span class='warning'>[crate]'s lid falls open!</span>")
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1042,6 +1042,10 @@ Thanks.
 				var/obj/structure/closet/secure_closet/SC = L.loc
 				if(!SC.locked && !SC.welded)
 					return //It's a secure closet, but isn't locked. Easily escapable from, no need to 'resist'
+			else if(istype(C, /obj/structure/closet/crate/secure))
+				var/obj/structure/closet/crate/secure/SC = L.loc
+				if(!SC.locked && !SC.welded)
+					return
 			else
 				if(!C.welded)
 					return //closed but not welded...
@@ -1060,6 +1064,10 @@ Thanks.
 						var/obj/structure/closet/secure_closet/SC = L.loc
 						if(!SC.locked && !SC.welded)
 							return
+					else if(istype(L.loc, /obj/structure/closet/crate/secure))
+						var/obj/structure/closet/crate/secure/SC = L.loc
+						if(!SC.locked && !SC.welded)
+							return
 					else
 						if(!C.welded)
 							return
@@ -1075,6 +1083,9 @@ Thanks.
 					sleep(10)
 					SC.broken = SC.locked // If it's only welded just break the welding, dont break the lock.
 					SC.locked = 0
+				if(istype(usr.loc, /obj/structure/closet/crate/secure))
+					var/obj/structure/closet/crate/secure/SC = L.loc
+					SC.break_open()
 				C.welded = 0
 				if(C.arcanetampered)
 					C.bless() // so it doesn't just close again, fairness on the user


### PR DESCRIPTION


## What this does
This PR fixes two specific means of opening crates, and due to backend code changes helps to futureproof unintended means to open crates. This is done by adding a locked check to can_open() for secure crates, similar to the one that secure closets have. It also fixes a logic error in large crate loading where it would always attempt to load a large object if close() was called upon it, even if the crate was already closed.
1. Recycling machines will no longer open locked crates, unless they are unlocked.
2. Cargo carts will no longer randomly open large crates (via sucking in the cargo cart and then the cargo cart getting pulled out, which forces the crate to open).

## Why it's good
Locked crates mean something, you gotta make an effort to open them. Stealing the recycling machine isn't good enough. And two rounds of Jungle have been ruined by a shard crate opening from the cargo cart glitch, which is funny because it happened twice.

## How it was tested
<img width="268" height="257" alt="image" src="https://github.com/user-attachments/assets/855c0be2-6e33-4adf-8a54-3699b92c1acf" />

Tested throwing myself into a locked crate and resisting out, throwing various locked crates through the recycling machine, messing with large crates.

<!-- Document what procedures you used to test this PR here, including any images if helpful. -->

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Recycling machines no longer open locked crates.
 * bugfix: Cargo carts no longer randomly open large locked crates.
