### PR TITLE
telecomms traceroute runtime fix

### DIFF
--- a/code/game/machinery/telecomms/telemonitor.dm
+++ b/code/game/machinery/telecomms/telemonitor.dm
@@ -197,6 +197,7 @@
 	trace_signal.transmission_method = 2
 	screen = 2
 	tracert_report = "Beginning tracert on [freq] at [worldtime2text()].<BR>EXPECTED NEXT: Receiver<BR>"
+	last_machine = null
 	for(var/obj/machinery/telecomms/receiver/R in telecomms_list)
 		R.receive_signal(trace_signal)
 	spawn(1 SECONDS)

--- a/code/game/machinery/telecomms/telemonitor.dm
+++ b/code/game/machinery/telecomms/telemonitor.dm
@@ -201,7 +201,9 @@
 		R.receive_signal(trace_signal)
 	spawn(1 SECONDS)
 		if(!trace_signal.data["done"])
-			tracert_report += "The operation timed out.<BR><font color = #D70B00>Last Known Machine:</font color> <a href='?src=\ref[src];viewmachine=[last_machine.id]'>\ref[last_machine] [last_machine.id]</a>"
+			tracert_report += "The operation timed out."
+			if(last_machine)
+				tracert_report += "<BR><font color = #D70B00>Last Known Machine:</font color> <a href='?src=\ref[src];viewmachine=[last_machine.id]'>\ref[last_machine] [last_machine.id]</a>"
 		QDEL_NULL(trace_signal)
 		updateUsrDialog()
 


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
if you traceroute a frequency that doesn't have a receiver pick it up, the thing will runtime and the traceroute will stay in the machine forever, making new traceroutes impossible until you rebuild the computer

## Why it's good
one step closer to fixing the defficiency radio(but not headset and intercom) outage

## How it was tested
wasn't
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Telecomms traceroute should no longer break if an invalid route was requested
