### PR TITLE
Catbeasts cannot roll on odyssey anymore

### DIFF
--- a/maps/odyssey.dm
+++ b/maps/odyssey.dm
@@ -93,6 +93,8 @@
 		return FALSE
 	else if(ispath(DR.role_category,/datum/role/wizard))
 		return FALSE
+	else if(ispath(DR.role_category,/datum/role/catbeast))
+		return FALSE
 	return ..()
 
 /datum/map/active/proc/get_ship_state()


### PR DESCRIPTION
## What this does
Catbeasts are no longer a thing in Odyssey. Why would a random escapee somehow get into the actively traveling research ship?
## Why it's good
Good point raised by #39460, they either get killed in 10 seconds cause the entire crew has guns, so they're meaningless, or they speedrun RnD, print 2 bags and bagulo in medbay, ending the round instantly, both are extremely unfun for everyone involved.
:cl:
 * rscdel: Catbeasts no longer appear in Odyssey, as they either instantly speedrun or get speedran by an armed crew.