### PR TITLE
Potential fix for slow roundstart

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -189,6 +189,12 @@ var/datum/controller/gameticker/ticker
 	var/list/new_players_ready = list() //unique list of people who have readied up, so we can delete mob/new_player later (ready is lost on mind transfer)
 	var/list/roundstart_occupied_area_paths = list() //List of typepaths of areas in departments that are occupied at roundstart, used to handle the lights being on or off.
 
+	var/list/ready_player_ckeys = list()
+	for(var/mob/new_player/ready_np in player_list)
+		if(ready_np.ready && ready_np.mind && ready_np.mind.assigned_role && ready_np.client)
+			ready_player_ckeys |= ready_np.ckey
+	var/list/custom_items_by_ckey = GetCustomItemsByCkey(ready_player_ckeys)
+
 	for(var/mob/M in player_list)
 		if(!istype(M, /mob/new_player/))
 			var/mob/living/L = M
@@ -217,7 +223,7 @@ var/datum/controller/gameticker/ticker
 			else
 				var/mob/living/carbon/human/H = np.create_human(prefs)
 				H.store_position()
-				EquipCustomItems(H)
+				EquipCustomItemsPrefetched(H, key, custom_items_by_ckey)
 				H.update_icons()
 				new_characters[key] = H
 				roundstart_occupied_area_paths |= get_department_area_typepaths(H)

--- a/code/modules/customitems/item_spawning.dm
+++ b/code/modules/customitems/item_spawning.dm
@@ -1,6 +1,5 @@
 
 /proc/EquipCustomItems(mob/living/carbon/human/M)
-//	testing("\[CustomItem\] Checking for custom items for [M.ckey] ([M.real_name])...")
 	if(!SSdbcore.Connect())
 		return
 
@@ -31,64 +30,97 @@
 		return
 
 	while(query.NextRow())
-		var/path = text2path(query.item[1])
-		var/propadjust = query.item[2]
-		var/jobmask = query.item[3]
-//		testing("\[CustomItem\] Setting up [path] for [M.ckey] ([M.real_name]).  jobmask=[jobmask];propadjust=[propadjust]")
-		var/ok=0
-		if(jobmask!="*")
-			var/allowed_jobs = splittext(jobmask,",")
-			var/alt_blocked=0
-			if(M.mind.role_alt_title)
-				if(!(M.mind.role_alt_title in allowed_jobs))
-					alt_blocked=1
-			if(!(M.mind.assigned_role in allowed_jobs) || alt_blocked)
-//				testing("Failed to apply custom item for [M.ckey]: Role(s) [M.mind.assigned_role][M.mind.role_alt_title ? " (nor "+M.mind.role_alt_title+")" : ""] are not in allowed_jobs ([english_list(allowed_jobs)])")
-				continue
-
-
-		var/obj/item/Item = new path()
-//		testing("Adding new custom item [query.item[1]] to [key_name_admin(M)]...")
-		if(istype(Item,/obj/item/weapon/card/id))
-			var/obj/item/weapon/card/id/I = Item
-			for(var/obj/item/weapon/card/id/C in M)
-				//default settings
-				I.name = "[M.real_name]'s ID Card ([M.mind.role_alt_title ? M.mind.role_alt_title : M.mind.assigned_role])"
-				I.registered_name = M.real_name
-				I.access = C.access
-				I.assignment = C.assignment
-				I.blood_type = C.blood_type
-				I.dna_hash = C.dna_hash
-				I.fingerprint_hash = C.fingerprint_hash
-				//I.pin = C.pin
-				//replace old ID
-				QDEL_NULL(C)
-				ok = M.equip_if_possible(I, slot_wear_id, 0)	//if 1, last argument deletes on fail
-				break
-//			testing("Replaced ID!")
-		else if(istype(M.back, /obj/item/weapon/storage)) // Try to place it in something on the mob's back
-			var/obj/item/weapon/storage/backpack = M.back
-			if(backpack.contents.len < backpack.storage_slots)
-				Item.forceMove(M.back)
-				ok = 1
-	//			testing("Added to [M.back.name]!")
-				to_chat(M, "<span class='notice'>Your [Item.name] has been added to your [M.back.name].</span>")
-		else
-			for(var/obj/item/weapon/storage/S in M.contents) // Try to place it in any item that can store stuff, on the mob.
-				if (S.contents.len < S.storage_slots)
-					Item.forceMove(S)
-					ok = 1
-//					testing("Added to [S]!")
-					to_chat(M, "<span class='notice'>Your [Item.name] has been added to your [S.name].</span>")
-					break
-
-		//skip:
-		if (ok == 0) // Finally, since everything else failed, place it on the ground
-//			testing("Plopped onto the ground!")
-			Item.forceMove(get_turf(M.loc))
-
-		HackProperties(Item,propadjust)
+		ApplyCustomItem(M, query.item[1], query.item[2], query.item[3])
 	qdel(query)
+
+// batch custom item db lookup rather than calling one by one at roundstart for redaied players
+/proc/GetCustomItemsByCkey(list/ckeys)
+	if(!ckeys || !ckeys.len)
+		return list()
+	if(!SSdbcore.Connect())
+		return null
+
+	var/list/in_placeholders = list()
+	var/list/arguments = list()
+	for(var/i = 1, i <= ckeys.len, i++)
+		in_placeholders += ":ckey_[i]"
+		arguments["ckey_[i]"] = "[ckeys[i]]"
+
+	var/datum/DBQuery/query = SSdbcore.NewQuery("SELECT cuiCKey, cuiRealName, cuiPath, cuiPropAdjust, cuiJobMask FROM customitems WHERE cuiCKey IN ([in_placeholders.Join(", ")])", arguments)
+	if(!query.Execute())
+		log_sql("DB Error: [query.ErrorMsg()]")
+		qdel(query)
+		return null
+
+	var/list/by_ckey = list()
+	while(query.NextRow())
+		var/row_ckey = ckey("[query.item[1]]")
+		var/list/rows = by_ckey[row_ckey]
+		if(!rows)
+			rows = list()
+			by_ckey[row_ckey] = rows
+		rows += list(list(query.item[2], query.item[3], query.item[4], query.item[5]))
+	qdel(query)
+	return by_ckey
+
+// pass key separately because still not assigned to M at this stage
+/proc/EquipCustomItemsPrefetched(mob/living/carbon/human/M, player_key, list/by_ckey)
+	if(!player_key || !islist(by_ckey))
+		return
+	var/list/rows = by_ckey[ckey(player_key)]
+	if(!rows)
+		return
+	for(var/list/row in rows)
+		if(row[1] != "*" && lowertext(row[1]) != lowertext(M.real_name))
+			continue
+		ApplyCustomItem(M, row[2], row[3], row[4])
+
+/proc/ApplyCustomItem(mob/living/carbon/human/M, path_text, propadjust, jobmask)
+	var/path = text2path(path_text)
+	var/ok=0
+	if(jobmask!="*")
+		var/allowed_jobs = splittext(jobmask,",")
+		var/alt_blocked=0
+		if(M.mind.role_alt_title)
+			if(!(M.mind.role_alt_title in allowed_jobs))
+				alt_blocked=1
+		if(!(M.mind.assigned_role in allowed_jobs) || alt_blocked)
+			return
+
+	var/obj/item/Item = new path()
+	if(istype(Item,/obj/item/weapon/card/id))
+		var/obj/item/weapon/card/id/I = Item
+		for(var/obj/item/weapon/card/id/C in M)
+			//default settings
+			I.name = "[M.real_name]'s ID Card ([M.mind.role_alt_title ? M.mind.role_alt_title : M.mind.assigned_role])"
+			I.registered_name = M.real_name
+			I.access = C.access
+			I.assignment = C.assignment
+			I.blood_type = C.blood_type
+			I.dna_hash = C.dna_hash
+			I.fingerprint_hash = C.fingerprint_hash
+			//replace old ID
+			QDEL_NULL(C)
+			ok = M.equip_if_possible(I, slot_wear_id, 0)	//if 1, last argument deletes on fail
+			break
+	else if(istype(M.back, /obj/item/weapon/storage)) // Try to place it in something on the mob's back
+		var/obj/item/weapon/storage/backpack = M.back
+		if(backpack.contents.len < backpack.storage_slots)
+			Item.forceMove(M.back)
+			ok = 1
+			to_chat(M, "<span class='notice'>Your [Item.name] has been added to your [M.back.name].</span>")
+	else
+		for(var/obj/item/weapon/storage/S in M.contents) // Try to place it in any item that can store stuff, on the mob.
+			if (S.contents.len < S.storage_slots)
+				Item.forceMove(S)
+				ok = 1
+				to_chat(M, "<span class='notice'>Your [Item.name] has been added to your [S.name].</span>")
+				break
+
+	if (ok == 0) // Finally, since everything else failed, place it on the ground
+		Item.forceMove(get_turf(M.loc))
+
+	HackProperties(Item,propadjust)
 
 	// This is hacky, but since it's difficult as fuck to make a proper parser in BYOND without killing the server, here it is. - N3X
 /proc/HackProperties(var/mob/living/carbon/human/M,var/obj/item/I,var/script)


### PR DESCRIPTION
## What this does

Batches the DB queries at roundstart

Recently there have been issues where the roundstart timer runs down to 0 but then the game doesn't actually start for another couple of minutes. Looking at logs found that all of the time is spent in the character creation loop, which involves one DB query per player. IF the situation is that the lookup round-trip time is slow (e.g. 5 seconds) and doing this once each for 24 players (= 120 sec) then this PR will reduce the lookups to 1 and the total time on a single round-trip (5 seconds) rather than the O(N) stuff we have now. This change only affects the lookups for readied players at round start and has no effect on latejoins

(apparently its generally good practice to batch these types of queries anyway)

If the problem is not the round-trip time but instead the DB itself is slow, for some other reason, this won't have much of an effect at all beyond just allegedly better practices in SQL lookup

In any case I believe this to be an environment issue more than anything

## Why it's good
slow round start bad, the Gamers become Upset

## How it was tested

it isn't yet. I need to set up this local DB shit to test it properly and its a pain in the ass

## Changelog
:cl:
 * bugfix: Possibly fixed slow round start