### PR TITLE
Plasmemes can now work in command roles (Cap, HoP, HoS)

### DIFF
--- a/code/modules/jobs/job/captain.dm
+++ b/code/modules/jobs/job/captain.dm
@@ -10,7 +10,7 @@
 	access = list() 			//See get_access()
 	minimal_access = list() 	//See get_access()
 	minimal_player_age = 30
-	species_whitelist = list("Human")
+	species_whitelist = list("Human","Plasmaman")
 
 	outfit_datum = /datum/outfit/captain
 
@@ -34,7 +34,7 @@
 	req_admin_notify = 1
 	minimal_player_age = 20
 
-	species_whitelist = list("Human")
+	species_whitelist = list("Human", "Plasmaman")
 
 	access = list(access_security, access_sec_doors, access_brig, access_court, access_weapons, access_forensics_lockers,
 			            access_medical, access_engine_major, access_change_ids, access_ai_upload, access_eva, access_heads,

--- a/code/modules/jobs/job/security.dm
+++ b/code/modules/jobs/job/security.dm
@@ -17,7 +17,7 @@
 			            access_heads, access_hos, access_RC_announce, access_keycard_auth, access_gateway)
 	minimal_player_age = 30
 
-	species_whitelist = list("Human")
+	species_whitelist = list("Human","Plasmaman")
 
 	outfit_datum = /datum/outfit/hos
 


### PR DESCRIPTION
## What this does
Plasmamen, being formerly human, are still considered human enough for NT's hiring protocols, and have been allowed to sign up as Captains, Heads of Personnel and Heads of Security.
I don't have a horse in this race, I PR'd this on behalf of Tigersfang.
## Why it's good
Any argument aside from this one would be dishonest since that'd not be my real opinion.
You get the rare chance to see the never seen Captain/Hop/HoS plasmeme softsuit and I think that's pretty neat.
## How it was tested
It was not, but it follows the schema so it should work.
:cl:
 * rscadd: Plasmamen can now sign up as Captains, Heads of Personnel and Heads of Security.