### PR TITLE
Improves Reagent Explosion Logging

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -79,7 +79,7 @@
 
 /datum/chemical_reaction/explosion_potassium/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/datum/effect/system/reagents_explosion/e = new()
-	e.set_up(min(round (created_volume/10, 1), 15), holder.my_atom, 0, 0)
+	e.set_up(min(round (created_volume/10, 1), 15), holder.my_atom, 0, 0, whodunnit = usr)
 	e.holder_damage(holder.my_atom)
 	if(isliving(holder.my_atom))
 		e.amount *= 0.5
@@ -609,7 +609,7 @@
 
 /datum/chemical_reaction/nitroglycerin/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/datum/effect/system/reagents_explosion/e = new()
-	e.set_up(round (created_volume/2, 1), holder.my_atom, 0, 0)
+	e.set_up(round (created_volume/2, 1), holder.my_atom, 0, 0, whodunnit = usr)
 	e.holder_damage(holder.my_atom)
 	if(isliving(holder.my_atom))
 		e.amount *= 0.5
@@ -663,6 +663,7 @@
 			var/mob/living/L = holder.my_atom
 			if(L.stat!=DEAD)
 				e.amount *= 0.5
+		e.user = usr
 		e.start()
 		holder.clear_reagents()
 


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
This PR attempts to link a whodunnit to reagent explosions. This is not a reliable source since it relies on the use of usr instead of being properly passed a user via some outside means. Those means, however, are complex, and probably involve finding every source of reagent reactions in the game and adding a user link to them. This is considerably simpler and can help improve finding out who blew up 12 supermatter shards in a round via the logs.

## Why it's good
12 explosions by user (caused by fueltank explosion) vs 12 explosions (caused by fueltank explosion)

## How it was tested
Blew up funny fuel tank.
<img width="784" height="676" alt="image" src="https://github.com/user-attachments/assets/9689852a-b22b-47e2-92d4-7f614fadcc90" />
<img width="994" height="99" alt="image" src="https://github.com/user-attachments/assets/0284f709-c15a-434c-8e90-3ebd18c2f742" />


## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Reagent explosions now have improved whodunnit logging.