### PR TITLE
robot woodcutting

### DIFF
--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -600,6 +600,17 @@ var/global/list/gene_tag_masks = list()   // Gene obfuscation for delicious tria
 			if(!success)
 				to_chat(M, "<span class='warning'>The stems on this plant are too tough to cut by hand, you'll need something sharp in one of your hands to harvest it.</span>")
 
+		if(istype(user, /mob/living/silicon/robot))
+			var/mob/living/silicon/robot/M = user
+			if(M.module_active)
+				var/obj/item/I = M.module_active
+				if(I.sharpness_flags & (SHARP_BLADE|SERRATED_BLADE))
+					success = 1
+
+			if(!success)
+				to_chat(M, "<span class='warning'>The stems on this plant are too tough to cut with your claws, you'll need a sharper tool to harvest it.</span>")
+
+
 	return success
 
 // Create a seed packet directly from the plant.


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

[bugfix]

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

<img width="722" height="317" alt="image" src="https://github.com/user-attachments/assets/3f5e2066-7af8-4195-8919-94ec22efa4e4" />
<img width="335" height="251" alt="image" src="https://github.com/user-attachments/assets/b829bc29-9d01-4b28-88fe-4bf6f3938397" />


## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
simple lazy copy paste in the part of the code that forces you to use sharp items to cut down trees. it only checked for carbons (and silicons don't make use of `held_items` anyway), so this lets robots also chop wood. namely MoMMIs.
because it just checks for sharpness flags in the active tool, this actually also works for e.g. medborgs using circular saws. we don't have botany borgs, but if someone ever adds one (for some reason?), it should work for them too. neither is intentional, but it's not really an issue as I see it.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
in 1997, steve was chopping wood.
now, almost 30 years later, silicons will have equal opportunity.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
tested with a MoMMI, a medborg, and a human test dummy, and all 3 had the expected behaviour. for the borg, I tested it with a scalpel (takes a seed sample), circular saw (cuts wood), and revival prod (does nothing). for the MoMMI and human, I tested with wirecutters (takes a seed sample), hatchet (cuts wood), and rolling pin (does nothing).
also, I set the `maturation = 2` on the seed so it was faster to test, but that doesn't really matter.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed silicons not being able to cut tower caps into logs of wood.