### PR TITLE
Fixes broken teleport scatter

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -106,6 +106,10 @@
 /datum/teleport/proc/isValidTurf(turf/T)
 	if(istype(T, /turf/unsimulated/wall/supermatter))
 		return FALSE //Don't teleport into supermatter turfs
+	if(T.turf_flags & NOJAUNT)
+		return FALSE //Don't teleport into vlevel border tiles and other no-teleport turfs
+	if(T.get_virtual_z() != destination.get_virtual_z())
+		return FALSE //Don't let teleport scatter land outside the destination's vlevel
 
 	return TRUE
 
@@ -116,12 +120,13 @@
 	var/area/destarea = get_area(destination)
 	if(precision)
 		var/list/posturfs = circlerangeturfs(destination,precision)
-		if(!posturfs || !posturfs.len)
-			return FALSE
-
-		do
-			destturf = pick_n_take(posturfs)
-		while(!isValidTurf(destturf) && posturfs.len)
+		while(posturfs?.len)
+			var/turf/potential_turf = pick_n_take(posturfs)
+			if(isValidTurf(potential_turf))
+				destturf = potential_turf
+				break
+		if(!destturf)
+			destturf = get_turf(destination) //no valid turf in scatter range, land on target
 	else
 		destturf = get_turf(destination)
 


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Sanity checks the scatter turfs players can end up on after teleporting with items that reduce teleportation precision (such as bags of holding), which will prevent vLevel border turfs or turfs in adjacent vLevels from being selected.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Stops people from teleporting across vLevel barriers (or into them) and closes #39490.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
0%

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed imprecise teleportation sending players to adjacent vLevels or into vLevel border turfs.