### PR TITLE
Removes the delay blocker from the rest verb.

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1222,8 +1222,8 @@ Thanks.
 	set name = "Rest"
 	set category = "IC"
 
-	if(client.move_delayer.blocked())
-		return
+//	if(client.move_delayer.blocked())
+//		return
 	if(resting) /* If you're somehow already standing up while inside a crate (shouldn't happen), you can still rest. */
 		if(istype(loc, /obj/structure/closet/crate))
 			to_chat(src, "<span class='warning'>There isn't enough room to get up. Open the [loc.name] first!</span>")


### PR DESCRIPTION
## What this does
You can now rest while moving. You'll stop to a dead halt when resting (naturally), but the rest verb will no longer be ignored when moving.
Could even extend into a full on dodge roll verb, much like tackling.
## Why it's good
Lets you do some cool ass dodge rolling and maybe hopefully adds some extra kino to our combat system.
## How it was tested
Commented it out.
Moved a bunch while pressing the rest button.
Worked as intended.
:cl:
 * tweak: Moving no longer stops you from resting.