### PR TITLE
Fix startup stall

### DIFF
--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -110,10 +110,11 @@
 		C = M.client
 	if(!C)
 		return
-	user << browse(get_content(), "window=[window_id];[window_options]")
+	var/dpi = C.dpiScale || 1
+	var/window_size = ""
 	if (width && height)
-		var/dpi = text2num(winget(C, window_id, "dpi")) || 1
-		winset(C, window_id, "size=[width*dpi]x[height*dpi]")
+		window_size = "size=[width*dpi]x[height*dpi];"
+	user << browse(get_content(), "window=[window_id];[window_size][window_options]")
 	if (use_onclose)
 		onclose(user, window_id, ref)
 

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -199,7 +199,8 @@ var/datum/controller/gameticker/ticker
 		var/mob/new_player/np = M
 		if(!(np.ready && np.mind && np.mind.assigned_role))
 			//If they aren't ready, update new player panels so they say join instead of ready up.
-			np.new_player_panel()
+			spawn()
+				np.new_player_panel()
 			continue
 		var/datum/preferences/prefs = M.client.prefs
 		var/key = M.key

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -65,6 +65,11 @@
 	// See /goon/code/datums/browserOutput.dm
 	var/datum/chatOutput/chatOutput
 
+	// Post-Byond 516 DPI scaling settings affects opened windows.
+	// Rather than e.g. 100x100 you get (window size / scale), so for 125% scaling you get 80x80.
+	// This messes up a lot of interfaces so this value is cached and applied to opening windows to correct for scaling.
+	/client/var/dpiScale = 1
+
 		////////////
 		//PARALLAX+OTHER PLANEMASTERS//
 		////////////

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -68,7 +68,7 @@
 	// Post-Byond 516 DPI scaling settings affects opened windows.
 	// Rather than e.g. 100x100 you get (window size / scale), so for 125% scaling you get 80x80.
 	// This messes up a lot of interfaces so this value is cached and applied to opening windows to correct for scaling.
-	/client/var/dpiScale = 1
+	var/dpiScale = 1
 
 		////////////
 		//PARALLAX+OTHER PLANEMASTERS//

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -276,6 +276,10 @@ var/updated_stats = 0
 
 
 	send_resources()
+	spawn()//dont let winget stall login on a dead client
+		var/dpi = text2num(winget(src, null, "dpi"))
+		if (dpi && (src in clients))
+			dpiScale = dpi
 
 	var/datum/DBQuery/query = SSdbcore.NewQuery("SELECT id, ckey, ip, computerid, a_ckey, reason, expiration_time, duration, bantime, bantype, unbanned, unbanned_ckey, unbanned_datetime FROM erro_ban WHERE (ckey = :ckey [address ? "OR ip = :address" : ""]  [computer_id ? "OR computerid = :computer_id" : ""]) AND unbanned_notification = 0;",
 		list(

--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -12,11 +12,6 @@ nanoui is used to open and update nano browser uis
 #define STATUS_DISABLED 0 // RED Visability
 #define STATUS_CLOSE -1 // Close the window
 
-// Post-Byond 516 DPI scaling settings affect the opened window.
-// Rather than e.g. 100x100 you get (window size / scale), so for 125% scaling you get 80x80.
-// This messes up a lot of interfaces so this value is cached and applied to opening windows to correct for scaling.
-/client/var/dpiScale = 1
-
 /datum/nanoui
 	// the user who opened this ui
 	var/mob/user
@@ -535,7 +530,7 @@ nanoui is used to open and update nano browser uis
   * @return nothing
   */
 /datum/nanoui/Topic(href, href_list)
-	if (href_list["nanoui_dpr"])
+	if (href_list["nanoui_dpr"]) //viewport self-reports from layout_default.tmpl, cache dpi on client
 		var/scale = text2num(href_list["nanoui_dpr"])
 		if (!scale && href_list["nanoui_inner_w"] && width)
 			var/inner_width = text2num(href_list["nanoui_inner_w"])


### PR DESCRIPTION
tfw this PR was GONE it was DISAPPEAREDED from github for two weeks and no one noticed lol

## What this does

Fix a startup stall that can prevent the round from starting.
I had a whole thing written up on the last PR but that PR has vanished under mysterious circumstances.
weird huh

Anyway roughly what happens is:

- Game is in lobby counting down
- A client disconnects for some reason but isn't fully dead, Byond is helpfully still holding part of it
- When the timer hits 0 it tries to update the new player setup window from the pre-start variant (i.e. the one with `Declare Ready` on it and stuff) to the post-start variant (with the join button on it)
- Doing this involves a winset to deal with DPI scaling, but Byond will just wait on this winset if the client isn't answering, which is exactly what was happening with the above mentioned dead client
- When the client is finally dropped the round proceeds

The fix involves caching dpi on the client (pre-existing) and using the cached dpi rather than using a synchronous `winset` in that critical path. The price of this is that DPI is likely wrong on the New Player Setup window


This PR *might* also fix failures to connect where the game just dies instead of connecting. Hard to verify though

## Why it's good

people lose their fuckin minds when the game is supposed to start but doesn't

## How it was tested

- Launched a client and connected to server
- In Process Explorer, suspend DreamSeeker as the timer approaches 0 (this simulates a dead client not responding to the server)
- Before fix observe the roundstart just stall
- After fix observe roundstart proceed normally

## Changelog
:cl:
 * bugfix: Fixed a bug that could stall round start