### PR TITLE
Device analyzers show loaded designs.

### DIFF
--- a/code/modules/research/mechanic/device_analyser.dm
+++ b/code/modules/research/mechanic/device_analyser.dm
@@ -24,6 +24,8 @@
 
 /obj/item/device/device_analyser/examine(mob/user)
 	..()
+	if(!Adjacent(user))
+		return
 	if(!loaded_designs.len)
 		to_chat(user, "No designs currently loaded.")
 		return

--- a/code/modules/research/mechanic/device_analyser.dm
+++ b/code/modules/research/mechanic/device_analyser.dm
@@ -22,6 +22,15 @@
 
 	mech_flags = MECH_SCAN_FAIL
 
+/obj/item/device/device_analyser/examine(mob/user)
+	..()
+	if(!loaded_designs.len)
+		return
+	var/list/out = list("<span class='notice'>Current designs loaded </span>")
+	for (var/design in loaded_designs)
+		out += design
+	to_chat(user, jointext(out, "<br/>"))
+
 /obj/item/device/device_analyser/attack_self()
 	..()
 	loadone = !loadone
@@ -80,7 +89,7 @@
 	// Objects that cannot be scanned
 	if((O.mech_flags & MECH_SCAN_FAIL)==MECH_SCAN_FAIL)
 		return 0
-	
+
 	if((O.mech_flags & MECH_SCAN_GOONECODE)==MECH_SCAN_GOONECODE)
 		to_chat(user, "<span class='notice'>Your device blinks red and a message appears: <span class='warning'>\"ERROR: CLOSED SOURCE SOFTWARE; INCOMPATIBLE WITH GPLv3.\"</span></span>")
 		return 0

--- a/code/modules/research/mechanic/device_analyser.dm
+++ b/code/modules/research/mechanic/device_analyser.dm
@@ -25,10 +25,12 @@
 /obj/item/device/device_analyser/examine(mob/user)
 	..()
 	if(!loaded_designs.len)
+		to_chat(user, "No designs currently loaded.")
 		return
-	var/list/out = list("<span class='notice'>Current designs loaded </span>")
-	for (var/design in loaded_designs)
-		out += design
+	var/list/out = list("Designs currently loaded: <span class='info'>")
+	for(var/datum/design/current in loaded_designs)
+		out += current.name
+	out += "</span>"
 	to_chat(user, jointext(out, "<br/>"))
 
 /obj/item/device/device_analyser/attack_self()


### PR DESCRIPTION
[tweak][qol]
<img width="789" height="138" alt="image" src="https://github.com/user-attachments/assets/8d019199-0b7c-49a8-a9f7-5f744bc78d16" />


## What this does
Closes #39032 
Makes a list of all current loaded designs show when examining the device analyzer.

## Why it's good
In case you forget if you've scanned something after getting distracted you can double check without having to run all over the station I suppose.

## How it was tested
Loaded up packed scanned a few things examined the analyzer, transfered the designs examined it again to make sure they no longer showed.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Device analyzers show loaded designs when examined.

