### PR TITLE
Disables Jungle Station

### DIFF
--- a/code/datums/next_map.dm
+++ b/code/datums/next_map.dm
@@ -182,6 +182,7 @@
 /datum/next_map/junglestation
 	name = "Jungle Station" //NT Colony Gamma-8 - the trve name.
 	path = "junglestation"
+	is_enabled = FALSE
 
 /datum/next_map/odyssey
 	name = "NTEV Odyssey"


### PR DESCRIPTION
[controversial] [vote]
## Why do this?

we currently have 3 unfinished maps in rotation: theseus, odyssey, and jungle. jungle is the oldest of the three so removing it makes the most sense

## How is jungle unfinished?

ive looked into what it'd take to engooden jungle and the amount of work this map requires is staggering.

1. the map lacks unique content. a planetary map will not have space/ZAS mechanics by default and jungle doesnt really replace those with anything else. despite being called **jungle** station it doesnt even have rain even though rain is already in the code
2. compared to other maps, jungle doesnt really have a good layout. ive tried fixing this but people still have issues with it
3. take a look at the minimap on the website. the endless flood of randomly placed trees is just lazy, especially when compared to snaxi's various outdoor areas

## Jungle's popularity

people support jungle on github but i dont think emojiocracy is a good way of gauging the server's opinion on the matter. the plasmeme PR was neck and neck on github but it was overwhelmingly rejected when the polls were made. given the amount of seething ive seen in OOC, im fairly confident that jungle would lose a server poll, but i welcome any outcome

## Changelog
:cl: 
 * rscdel: disabled jungle