### PR TITLE
Fix Plasmaman selection in emagged cloning

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -996,6 +996,7 @@ var/list/RESTRICTED_CAMERA_NETWORKS = list( //Those networks can only be accesse
 #define SPECIES_NO_MOUTH 	(1<<13)
 //#define REQUIRE_DARK 		(1<<14)
 #define RAD_IMMUNE 			(1<<15)
+#define EMAG_CLONEABLE 		(1<<16)	//Can be selected as a species by an emagged cloning console.
 
 //Species anatomical flags.
 #define HAS_SKIN_TONE 		(1)

--- a/code/modules/medical/computer/cloning.dm
+++ b/code/modules/medical/computer/cloning.dm
@@ -20,7 +20,7 @@
 	var/list/records = list()
 	var/datum/dna2/record/active_record = null
 	var/obj/item/weapon/disk/data/diskette = null //Mostly so the geneticist can steal everything.
-	var/list/available_species // Species available to emagged consoles.
+	var/list/available_species // Species available to emagged consoles. Per-instance copy to allow adminbus.
 	var/loading = 0 // Nice loading text
 
 	light_color = LIGHT_COLOR_BLUE
@@ -34,11 +34,6 @@
 
 /obj/machinery/computer/cloning/New()
 	..()
-	available_species = list()
-	for(var/species_name in all_species)
-		var/datum/species/S = all_species[species_name]
-		if(S.emag_cloneable)
-			available_species += S.name
 	spawn(5)
 		updatemodules()
 		return
@@ -65,6 +60,7 @@
 	..()
 
 /obj/machinery/computer/cloning/initialize()
+	available_species = emag_cloneable_species.Copy()
 	updatemodules()
 
 /obj/machinery/computer/cloning/multitool_menu(var/mob/user, var/obj/item/device/multitool/P)

--- a/code/modules/medical/computer/cloning.dm
+++ b/code/modules/medical/computer/cloning.dm
@@ -20,8 +20,8 @@
 	var/list/records = list()
 	var/datum/dna2/record/active_record = null
 	var/obj/item/weapon/disk/data/diskette = null //Mostly so the geneticist can steal everything.
+	var/list/available_species // Species available to emagged consoles.
 	var/loading = 0 // Nice loading text
-	var/available_species = list("Human","Tajaran","Skrell","Unathi","Grey","Plasmamen","Vox", "Insectoid")
 
 	light_color = LIGHT_COLOR_BLUE
 
@@ -34,6 +34,11 @@
 
 /obj/machinery/computer/cloning/New()
 	..()
+	available_species = list()
+	for(var/species_name in all_species)
+		var/datum/species/S = all_species[species_name]
+		if(S.emag_cloneable)
+			available_species += S.name
 	spawn(5)
 		updatemodules()
 		return

--- a/code/modules/mob/living/carbon/human/species/plasmaman.dm
+++ b/code/modules/mob/living/carbon/human/species/plasmaman.dm
@@ -1,12 +1,11 @@
 /datum/species/plasmaman // /vg/
 	name = "Plasmaman"
-	emag_cloneable = TRUE
 	icobase = 'icons/mob/human_races/r_plasmaman_sb.dmi'
 	deform = 'icons/mob/human_races/r_plasmaman_pb.dmi'  // TODO: Need deform.
 	known_languages = list(LANGUAGE_HUMAN)
 	attack_verb = "punches"
 
-	flags = WHITELISTED | PLAYABLE | PLASMA_IMMUNE
+	flags = WHITELISTED | PLAYABLE | PLASMA_IMMUNE | EMAG_CLONEABLE
 	anatomy_flags = NO_BLOOD
 	blood_color = "#743474"
 	flesh_color = "#898476"

--- a/code/modules/mob/living/carbon/human/species/plasmaman.dm
+++ b/code/modules/mob/living/carbon/human/species/plasmaman.dm
@@ -1,5 +1,6 @@
 /datum/species/plasmaman // /vg/
 	name = "Plasmaman"
+	emag_cloneable = TRUE
 	icobase = 'icons/mob/human_races/r_plasmaman_sb.dmi'
 	deform = 'icons/mob/human_races/r_plasmaman_pb.dmi'  // TODO: Need deform.
 	known_languages = list(LANGUAGE_HUMAN)

--- a/code/modules/mob/living/carbon/human/species/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/vox.dm
@@ -1,5 +1,6 @@
 /datum/species/vox
 	name = "Vox"
+	emag_cloneable = TRUE
 	icobase = 'icons/mob/human_races/vox/r_vox.dmi'
 	deform = 'icons/mob/human_races/vox/r_def_vox.dmi'
 	known_languages = list(LANGUAGE_VOX)

--- a/code/modules/mob/living/carbon/human/species/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/vox.dm
@@ -1,6 +1,5 @@
 /datum/species/vox
 	name = "Vox"
-	emag_cloneable = TRUE
 	icobase = 'icons/mob/human_races/vox/r_vox.dmi'
 	deform = 'icons/mob/human_races/vox/r_def_vox.dmi'
 	known_languages = list(LANGUAGE_VOX)
@@ -20,7 +19,7 @@
 	breath_type = GAS_NITROGEN
 
 	default_mutations = list(M_BEAK, M_TALONS)
-	flags = PLAYABLE | WHITELISTED
+	flags = PLAYABLE | WHITELISTED | EMAG_CLONEABLE
 	blood_color = VOX_BLOOD
 	flesh_color = "#808D11"
 	max_skin_tone = 6

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -10,6 +10,7 @@ var/global/list/all_languages[0]
 var/global/list/all_species = list()
 var/global/list/whitelisted_species = list("Human")
 var/global/list/playable_species = list("Human")
+var/global/list/emag_cloneable_species = list()
 
 /proc/buildSpeciesLists()
 	var/datum/language/L
@@ -29,13 +30,14 @@ var/global/list/playable_species = list("Human")
 			whitelisted_species += S.name
 			if(S.flags & PLAYABLE || S.conditional_playable())
 				playable_species += S.name
+		if(S.flags & EMAG_CLONEABLE)
+			emag_cloneable_species += S.name
 	return
 
 ////////////////////////////////////////////////////////////////
 
 /datum/species
 	var/name                     // Species name.
-	var/emag_cloneable = FALSE  // Can be selected as a species by an emagged cloning console.
 
 	var/icobase = 'icons/mob/human_races/r_human.dmi'		// Normal icon set.
 	var/deform = 'icons/mob/human_races/r_def_human.dmi'	// Mutated icon set.
@@ -346,7 +348,7 @@ var/global/list/playable_species = list("Human")
 
 /datum/species/human
 	name = "Human"
-	emag_cloneable = TRUE
+	flags = EMAG_CLONEABLE
 	known_languages = list(LANGUAGE_HUMAN)
 	primitive = /mob/living/carbon/monkey
 
@@ -405,7 +407,6 @@ var/global/list/playable_species = list("Human")
 
 /datum/species/unathi
 	name = "Unathi"
-	emag_cloneable = TRUE
 	icobase = 'icons/mob/human_races/r_lizard.dmi'
 	deform = 'icons/mob/human_races/r_def_lizard.dmi'
 	known_languages = list(LANGUAGE_UNATHI)
@@ -423,7 +424,7 @@ var/global/list/playable_species = list("Human")
 	heat_level_2 = 480 //Default 400
 	heat_level_3 = 1100 //Default 1000
 
-	flags = WHITELISTED
+	flags = WHITELISTED | EMAG_CLONEABLE
 	anatomy_flags = HAS_LIPS | HAS_UNDERWEAR | HAS_TAIL
 
 	default_mutations=list(M_CLAWS)
@@ -497,7 +498,6 @@ var/global/list/playable_species = list("Human")
 
 /datum/species/tajaran
 	name = "Tajaran"
-	emag_cloneable = TRUE
 	icobase = 'icons/mob/human_races/r_tajaran.dmi'
 	deform = 'icons/mob/human_races/r_def_tajaran.dmi'
 	known_languages = list(LANGUAGE_CATBEAST, LANGUAGE_MOUSE)
@@ -516,7 +516,7 @@ var/global/list/playable_species = list("Human")
 
 	primitive = /mob/living/carbon/monkey/tajara
 
-	flags = WHITELISTED
+	flags = WHITELISTED | EMAG_CLONEABLE
 	anatomy_flags = HAS_LIPS | HAS_UNDERWEAR | HAS_TAIL | HAS_SWEAT_GLANDS | HAS_ICON_SKIN_TONE
 
 	default_mutations=list(M_CLAWS)
@@ -576,7 +576,6 @@ var/global/list/playable_species = list("Human")
 
 /datum/species/grey // /vg/
 	name = "Grey"
-	emag_cloneable = TRUE
 	icobase = 'icons/mob/human_races/grey/r_grey.dmi'
 	deform = 'icons/mob/human_races/grey/r_def_grey.dmi'
 	known_languages = list(LANGUAGE_GREY)
@@ -593,7 +592,7 @@ var/global/list/playable_species = list("Human")
 
 	primitive = /mob/living/carbon/monkey/grey
 
-	flags = PLAYABLE | WHITELISTED
+	flags = PLAYABLE | WHITELISTED | EMAG_CLONEABLE
 	anatomy_flags = HAS_LIPS | HAS_SWEAT_GLANDS | ACID4WATER | HAS_ICON_SKIN_TONE
 
 	spells = list(/spell/targeted/telepathy)
@@ -706,13 +705,12 @@ var/global/list/playable_species = list("Human")
 
 /datum/species/skrell
 	name = "Skrell"
-	emag_cloneable = TRUE
 	icobase = 'icons/mob/human_races/r_skrell.dmi'
 	deform = 'icons/mob/human_races/r_def_skrell.dmi'
 	known_languages = list(LANGUAGE_SKRELLIAN)
 	primitive = /mob/living/carbon/monkey/skrell
 
-	flags = WHITELISTED
+	flags = WHITELISTED | EMAG_CLONEABLE
 	anatomy_flags = HAS_LIPS | HAS_UNDERWEAR | HAS_SWEAT_GLANDS
 
 	flesh_color = "#8CD7A3"
@@ -1103,7 +1101,6 @@ var/list/has_died_as_golem = list()
 
 /datum/species/insectoid
 	name = "Insectoid"
-	emag_cloneable = TRUE
 	icobase = 'icons/mob/human_races/r_insectoid.dmi'
 	deform = 'icons/mob/human_races/r_def_insectoid.dmi'
 	eyes = "insectoid_eyes_m"
@@ -1111,7 +1108,7 @@ var/list/has_died_as_golem = list()
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/insectoid
 	primitive = /mob/living/carbon/monkey/roach
 
-	flags = WHITELISTED | PLAYABLE
+	flags = WHITELISTED | PLAYABLE | EMAG_CLONEABLE
 	anatomy_flags = HAS_LIPS | HAS_SWEAT_GLANDS | NO_BALD | RGBSKINTONE
 
 	burn_mod = 1.1

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -35,6 +35,7 @@ var/global/list/playable_species = list("Human")
 
 /datum/species
 	var/name                     // Species name.
+	var/emag_cloneable = FALSE  // Can be selected as a species by an emagged cloning console.
 
 	var/icobase = 'icons/mob/human_races/r_human.dmi'		// Normal icon set.
 	var/deform = 'icons/mob/human_races/r_def_human.dmi'	// Mutated icon set.
@@ -345,6 +346,7 @@ var/global/list/playable_species = list("Human")
 
 /datum/species/human
 	name = "Human"
+	emag_cloneable = TRUE
 	known_languages = list(LANGUAGE_HUMAN)
 	primitive = /mob/living/carbon/monkey
 
@@ -403,6 +405,7 @@ var/global/list/playable_species = list("Human")
 
 /datum/species/unathi
 	name = "Unathi"
+	emag_cloneable = TRUE
 	icobase = 'icons/mob/human_races/r_lizard.dmi'
 	deform = 'icons/mob/human_races/r_def_lizard.dmi'
 	known_languages = list(LANGUAGE_UNATHI)
@@ -494,6 +497,7 @@ var/global/list/playable_species = list("Human")
 
 /datum/species/tajaran
 	name = "Tajaran"
+	emag_cloneable = TRUE
 	icobase = 'icons/mob/human_races/r_tajaran.dmi'
 	deform = 'icons/mob/human_races/r_def_tajaran.dmi'
 	known_languages = list(LANGUAGE_CATBEAST, LANGUAGE_MOUSE)
@@ -572,6 +576,7 @@ var/global/list/playable_species = list("Human")
 
 /datum/species/grey // /vg/
 	name = "Grey"
+	emag_cloneable = TRUE
 	icobase = 'icons/mob/human_races/grey/r_grey.dmi'
 	deform = 'icons/mob/human_races/grey/r_def_grey.dmi'
 	known_languages = list(LANGUAGE_GREY)
@@ -701,6 +706,7 @@ var/global/list/playable_species = list("Human")
 
 /datum/species/skrell
 	name = "Skrell"
+	emag_cloneable = TRUE
 	icobase = 'icons/mob/human_races/r_skrell.dmi'
 	deform = 'icons/mob/human_races/r_def_skrell.dmi'
 	known_languages = list(LANGUAGE_SKRELLIAN)
@@ -1097,6 +1103,7 @@ var/list/has_died_as_golem = list()
 
 /datum/species/insectoid
 	name = "Insectoid"
+	emag_cloneable = TRUE
 	icobase = 'icons/mob/human_races/r_insectoid.dmi'
 	deform = 'icons/mob/human_races/r_def_insectoid.dmi'
 	eyes = "insectoid_eyes_m"


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
Adds an explicit species opt-in for emagged cloning and builds the console’s species list from canonical species names.

This removes the invalid "Plasmamen" entry ("Plasmam**a**n" is the correct one), preventing malformed clones.

Closes #39550.
## Why it's good
self-evident

## How it was tested
~~Not tested. :^)~~ Kill&Clone'd a second client, both the plasmaman and random options produced correct humans

## Changelog
:cl:
 * bugfix: Fixed a bug that caused emagged cloners to create malformed clones when Plasmaman was the selected species.