### PR TITLE
Making fire suppression a little more usable

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -21,7 +21,7 @@ var/area/space_area
 	var/obj/effect/area_alert_holder/alert_holder = null
 	var/obj/effect/narration/narrator = null
 	var/holomap_draw_override = HOLOMAP_DRAW_NORMAL
-
+	var/total_floors = 0 //Total simulated floors in an area.
 	flags = CAVES_ALLOWED
 
 /// Used for shuttle overrides so we can expose planet or space turfs depending on the shuttle's location.

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -565,14 +565,12 @@ var/global/list/air_alarms = list()
 				if(get_area(fire) == this_area)
 					fire_amount++
 					if(fire_amount >= fires_needed)
+						preset_key = "Fire Suppression"
+						mode = AALARM_MODE_FIRE
+						apply_preset(1)
+						auto_suppress = FALSE
+						config.suppression_mode = FALSE
 						break
-
-			if((fire_amount / this_area.total_floors) >= fires_needed)
-				preset_key = "Fire Suppression"
-				mode = AALARM_MODE_FIRE
-				apply_preset(1)
-				auto_suppress = FALSE
-				config.suppression_mode = FALSE
 
 	if(preset_key == "Fire Suppression")
 		var/datum/airalarm_threshold/current_pressure_threshold_suppress = config.pressure_threshold
@@ -584,7 +582,7 @@ var/global/list/air_alarms = list()
 			if(get_area(Fire) == this_area)
 				has_fire = TRUE
 				break
-		if(!has_fire && abs(environment.return_temperature() - target_temp) <= 2 && environment.return_pressure() <= target_pressure_suppress * 1.05)
+		if(!has_fire && abs(environment.return_temperature() - target_temp) <= 2 && environment.return_pressure() <= target_pressure_suppress * 1.05) // <=2 to match the 2 degrees over/under on alarm thermostats.
 			preset_key = "Human"
 			mode = AALARM_MODE_SCRUBBING
 			apply_preset(1)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -7,7 +7,9 @@
 #define AALARM_MODE_PANIC		3 //constantly sucks all air
 #define AALARM_MODE_CYCLE		4 //sucks off all air, then refill and switches to scrubbing
 #define AALARM_MODE_FILL		5 //emergency fill
-#define AALARM_MODE_OFF			6 //Shuts it all down.
+#define AALARM_MODE_FIRE		6 //Turns vent and scrubber checks off to remove oxygen and pump nitrogen as fast as possible.
+#define AALARM_MODE_OFF			7 //Shuts it all down.
+
 
 #define AALARM_SCREEN_MAIN		1
 #define AALARM_SCREEN_VENT		2
@@ -286,10 +288,10 @@
 							GAS_SLEEPING = new /datum/airalarm_threshold(-1, -1, -1, -1),
 							GAS_CRYOTHEUM = new /datum/airalarm_threshold(-1, -1, -1, -1) )
 	other_gas_threshold = new /datum/airalarm_threshold(-1, -1, 0.5, 1)
-	pressure_threshold = new /datum/airalarm_threshold(-1, -1, -1, -1)
-	temperature_threshold = new /datum/airalarm_threshold(T0C-50, T0C-25, T0C+25, T0C+50)
-	target_temperature = T0C
-	scrubbed_gases = list( GAS_OXYGEN, GAS_PLASMA )
+	pressure_threshold = new /datum/airalarm_threshold(ONE_ATMOSPHERE*0.80, ONE_ATMOSPHERE*0.90, ONE_ATMOSPHERE*1.10, ONE_ATMOSPHERE*1.20)
+	temperature_threshold = new /datum/airalarm_threshold(T0C-30, T0C, T0C+40, T0C+70)
+	target_temperature = T0C+20
+	scrubbed_gases = list( GAS_OXYGEN, GAS_PLASMA, )
 
 //these are used for the UIs and new ones can be added and existing ones edited at the CAC
 var/global/list/airalarm_presets = list(
@@ -532,8 +534,14 @@ var/global/list/air_alarms = list()
 		mode=AALARM_MODE_FILL
 		apply_mode()
 
+	if (mode==AALARM_MODE_FILL)
+		var/datum/airalarm_threshold/current_pressure_threshold_fill = config.pressure_threshold
+		var/target_pressure_fill = (current_pressure_threshold_fill.min_1() + current_pressure_threshold_fill.max_1())/2
+		if(environment.return_pressure()>=target_pressure_fill*0.95)
+			mode = AALARM_MODE_SCRUBBING
+			apply_mode()
 
-	//atmos computer remote controll stuff
+	//atmos computer remote control stuff
 	switch(rcon_setting)
 		if(RCON_NO)
 			remote_control = 0
@@ -546,14 +554,42 @@ var/global/list/air_alarms = list()
 		*/
 		if(RCON_YES)
 			remote_control = 1
+
 	if(auto_suppress)
 		var/area/this_area = get_area(src)
-		if(this_area.fire)
-			preset_key = "Fire Suppression"
+		var/fires_needed = ceil(this_area.total_floors * 0.25) //25% coverage of fire needed.
+		var/fire_amount = 0
+
+		if(this_area.total_floors)
+			for(var/obj/effect/fire/fire in SSair.processing_parts[SSAIR_HOTSPOT])
+				if(get_area(fire) == this_area)
+					fire_amount++
+					if(fire_amount >= fires_needed)
+						break
+
+			if((fire_amount / this_area.total_floors) >= fires_needed)
+				preset_key = "Fire Suppression"
+				mode = AALARM_MODE_FIRE
+				apply_preset(1)
+				auto_suppress = FALSE
+				config.suppression_mode = FALSE
+
+	if(preset_key == "Fire Suppression")
+		var/datum/airalarm_threshold/current_pressure_threshold_suppress = config.pressure_threshold
+		var/target_pressure_suppress = (current_pressure_threshold_suppress.min_1() + current_pressure_threshold_suppress.max_1()) / 2
+		var/target_temp = config.target_temperature
+		var/area/this_area = get_area(src)
+		var/has_fire = FALSE
+		for(var/obj/effect/fire/Fire in SSair.processing_parts[SSAIR_HOTSPOT])
+			if(get_area(Fire) == this_area)
+				has_fire = TRUE
+				break
+		if(!has_fire && abs(environment.return_temperature() - target_temp) <= 2 && environment.return_pressure() <= target_pressure_suppress * 1.05)
+			preset_key = "Human"
+			mode = AALARM_MODE_SCRUBBING
 			apply_preset(1)
-			auto_suppress = FALSE
-			config.suppression_mode = FALSE
-	return
+			auto_suppress = TRUE
+			config.suppression_mode = TRUE
 
 /obj/machinery/alarm/proc/calculate_local_danger_level(const/datum/gas_mixture/environment)
 	if (wires.IsIndexCut(AALARM_WIRE_AALARM))
@@ -755,7 +791,7 @@ var/global/list/air_alarms = list()
 				if(!presetdata)
 					presetdata = new /datum/airalarm_configuration/preset/human()
 
-				var/list/signal_data = list("power"= 1, "scrubbing"= 1, "panic_siphon"= 0)
+				var/list/signal_data = list("power"= 1, "checks"= 1, "scrubbing"= 1, "panic_siphon"= 0)
 				for(var/gas_id in XGM.gases)
 					signal_data[gas_id + "_scrub"] = (gas_id in presetdata.scrubbed_gases)
 				send_signal(device_id,  signal_data)
@@ -778,13 +814,26 @@ var/global/list/air_alarms = list()
 			for(var/device_id in this_area.air_scrub_names)
 				send_signal(device_id, list("power"= 0) )
 			for(var/device_id in this_area.air_vent_names)
-				send_signal(device_id, list("power"= 1, "checks"= 1, "set_external_pressure"= target_pressure) )
+				send_signal(device_id, list("power"= 1, "checks"= 0, "set_external_pressure"= target_pressure) )
 
 		if(AALARM_MODE_OFF)
 			for(var/device_id in this_area.air_scrub_names)
 				send_signal(device_id, list("power"= 0) )
 			for(var/device_id in this_area.air_vent_names)
 				send_signal(device_id, list("power"= 0) )
+
+		if(AALARM_MODE_FIRE)
+			for(var/device_id in this_area.air_scrub_names)
+				var/datum/airalarm_configuration/preset/presetdata = airalarm_presets[preset_key]
+				if(!presetdata)
+					presetdata = new /datum/airalarm_configuration/preset/human()
+
+				var/list/signal_data = list("power"= 1, "checks"= 0, "scrubbing"= 1, "panic_siphon"= 0)
+				for(var/gas_id in XGM.gases)
+					signal_data[gas_id + "_scrub"] = (gas_id in presetdata.scrubbed_gases)
+				send_signal(device_id,  signal_data)
+			for(var/device_id in this_area.air_vent_names)
+				send_signal(device_id, list("power"= 1, "checks"= 1))
 
 // This sets our danger level, and, if it's changed, forces a new election of danger levels.
 /obj/machinery/alarm/proc/setDangerLevel(var/new_danger_level)
@@ -911,6 +960,7 @@ var/global/list/air_alarms = list()
 		/*AALARM_MODE_PANIC*/ list("name"="Panic",       "desc"="Siphons air out of the room"),\
 		/*AALARM_MODE_CYCLE*/ list("name"="Cycle",       "desc"="Siphons air before replacing"),\
 		/*AALARM_MODE_FILL*/ list("name"="Fill",        "desc"="Shuts off scrubbers and opens vents"),\
+		/*AALARM_MODE_FIRE*/ list("name"="Fire",        "desc"="Removes checks on vents and scrubbers"),\
 		/*AALARM_MODE_OFF*/ list("name"="Off",         "desc"="Shuts off vents and scrubbers"))
 	data["mode"]=mode
 

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -63,6 +63,10 @@ var/global/list/turf/phazontiles = list()
 		icon_regular_floor = "floor"
 	else
 		icon_regular_floor = icon_state
+
+	var/area/A = loc
+	A.total_floors++
+
 	footstep_sound = sounds_floor
 	footstep_sound_barefoot = sounds_floor_barefoot
 	footstep_sound_claw = sounds_floor_claw

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -521,18 +521,23 @@ var/highest_player_entry = 0
 
 //Creates a new turf
 /turf/proc/ChangeTurf(var/turf/N, var/tell_universe=1, var/force_lighting_update = 0, var/allow = 1,var/defer_edges = FALSE)
-	var/area/original_area=loc
+	var/area/original_area = loc
 	if(loc)
 		var/area/A = loc
 		A.area_turfs -= src
 		if(istype(A, /area/shuttle))
 			turf_flags |= SHUTTLE_TURF
+
 	var/preserved_shuttle_flag = turf_flags & SHUTTLE_TURF
+
 	if (!N || !allow)
 		return
-	remove_particles()
-	var/datum/gas_mixture/env
 
+	if(istype(src, /turf/simulated/floor))
+		original_area.total_floors--
+	remove_particles()
+
+	var/datum/gas_mixture/env
 	var/old_opacity = opacity
 	var/old_dynamic_lighting = dynamic_lighting
 	var/old_affecting_lights = affecting_lights
@@ -542,7 +547,6 @@ var/highest_player_entry = 0
 	var/old_holomap_draw_override = holomap_draw_override
 	var/old_registered_events = registered_events
 	var/datum/virtual_z/old_v = v
-
 	var/old_holomap = holomap_data
 
 	if(light)
@@ -963,17 +967,21 @@ var/highest_player_entry = 0
 	if(ispath(A))
 		var/path = A
 		A = locate(path)
-
 		if(!A)
 			A = new path
 	else if(!isarea(A))
 		return FALSE
 
 	var/area/old_area = loc
+
 	old_area.contents.Remove(src)
 	old_area.area_turfs.Remove(src)
 	A.contents.Add(src)
 	A.area_turfs.Add(src)
+
+	if(istype(src, /turf/simulated/floor))
+		old_area.total_floors--
+		A.total_floors++
 	if(old_area)
 		change_area(old_area, A)
 		for(var/atom/AM in contents)

--- a/code/modules/ZAS/Fire.dm
+++ b/code/modules/ZAS/Fire.dm
@@ -220,7 +220,8 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 		//Change in internal energy = change in energy due to heat transfer due to isochoric reaction
 		delta_t = heat_out/(delta_m * material.heating_value)
 		T.hotspot_expose(temperature + delta_t, FULL_FLAME, 1)
-		new /obj/effect/fire(T)
+		if(!locate(/obj/effect/fire) in T)
+			new /obj/effect/fire(T)
 
 	//Ash the object if all of its mass has been consumed.
 	if(thermal_mass <= 0.05)
@@ -281,7 +282,8 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 	//Start a fire on the tile if a burning object is present without an underlying fire effect.
 	if(!in_fire)
 		T.hotspot_expose(max_temperature, FULL_FLAME, 1)
-		new /obj/effect/fire(T)
+		if(!locate(/obj/effect/fire) in T)
+			new /obj/effect/fire(T)
 
 	return list("heat_out"=heat_out,"oxy_used"=oxy_used,"co2_prod"=co2_prod,"max_temperature"=max_temperature)
 
@@ -303,7 +305,7 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 
 /atom/proc/extinguish(var/duration = 30 SECONDS)
 	if(on_fire)
-		on_fire=0
+		on_fire = 0
 	fire_protection = world.time + duration
 	if(fire_overlay)
 		overlays -= fire_overlay
@@ -324,7 +326,7 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 		if(!has_liquid_fuel())
 			return 0
 
-	on_fire=1
+	on_fire = 1
 
 	if(fire_dmi && fire_sprite && !fire_overlay)
 		fire_overlay = mutable_appearance(fire_dmi,fire_sprite)
@@ -453,7 +455,7 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 					O.ignite()
 					igniting = 1
 					break
-		if(igniting)
+		if(igniting && !locate(/obj/effect/fire) in src)
 			new /obj/effect/fire(src)
 	return igniting
 
@@ -483,7 +485,7 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 		return FALSE
 
 	var/in_fire = FALSE
-	on_fire=1
+	on_fire = 1
 
 	if(locate(/obj/effect/fire) in src)
 		in_fire = TRUE
@@ -523,7 +525,7 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 	. = ..()
 	dir = pick(cardinal)
 	var/turf/T = get_turf(loc)
-	var/datum/gas_mixture/air_contents=T.return_air()
+	var/datum/gas_mixture/air_contents = T.return_air()
 	if(air_contents)
 		setfirelight(air_contents.calculate_firelevel(get_turf(src)), air_contents.temperature)
 	SSair.add_hotspot(src)


### PR DESCRIPTION
[tweak]

## What this does
Closes #39231 hopefully

Features: Makes it so a couple of the air alarm modes and presets switch themselves a bit more actively. Mainly just making it so fire suppression as a preset is only used for either auto suppressing or in rooms that have already been on fire. Made fill work more efficiently by turning it self off once its done, which is an extension from cycling if you ever accidentally leave on autocycle. 

Also fixed a fairly significant TOCTOU bug with fire which was causing multiple fires to be created at once in the same tile bypassing the safety check. 

## Why it's good
Opens up a few more options for engineers to get ahead of problems by having suppress work allows you to actually use a couple of the modes without needing to babysit them too so you don't have to swing back to any room you touch just to reenable its scrubbers when its done filling which feels more intuitive.


## How it was tested
Alarms were tested by using the presets in different configurations. (setting to fill, setting to cycle, auto suppress and setting the room on fire, manually setting fire suppress)

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Added a bunch of fire alarms to all maps.
 * tweak: Made some air alarm presets more practical.