### PR TITLE
some tweaks to radiation

### DIFF
--- a/code/game/objects/items/devices/PDA/cart/engineering.dm
+++ b/code/game/objects/items/devices/PDA/cart/engineering.dm
@@ -186,17 +186,17 @@
     icon = "pda_reagent"
 
 /datum/pda_app/cart/scanner/engineer/attack(mob/living/carbon/C, mob/living/user as mob)
-    if(istype(C))
-        for (var/mob/O in viewers(C, null))
+	if(istype(C))
+		for (var/mob/O in viewers(C, null))
 			if(O==user) //no need to show this to ourselves
 				continue
-            O.show_message("<span class='warning'>[user] has analyzed [C]'s radiation levels!</span>", 1)
+			O.show_message("<span class='warning'>[user] has analyzed [C]'s radiation levels!</span>", 1)
 
-        user.show_message("<span class='notice'>Analyzing Results for [C]:</span>")
-        if(C.radiation)
-            user.show_message("<span class='good'>Radiation Level: </span>[C.radiation]")
-        else
-            user.show_message("<span class='notice'>No radiation detected.</span>")
+		user.show_message("<span class='notice'>Analyzing Results for [C]:</span>")
+		if(C.radiation)
+			user.show_message("<span class='good'>Radiation Level: </span>[C.radiation]")
+		else
+			user.show_message("<span class='notice'>No radiation detected.</span>")
 
 /obj/item/weapon/cartridge/atmos
     name = "\improper BreatheDeep Cartridge"

--- a/code/game/objects/items/devices/PDA/cart/engineering.dm
+++ b/code/game/objects/items/devices/PDA/cart/engineering.dm
@@ -188,6 +188,8 @@
 /datum/pda_app/cart/scanner/engineer/attack(mob/living/carbon/C, mob/living/user as mob)
     if(istype(C))
         for (var/mob/O in viewers(C, null))
+			if(O==user) //no need to show this to ourselves
+				continue
             O.show_message("<span class='warning'>[user] has analyzed [C]'s radiation levels!</span>", 1)
 
         user.show_message("<span class='notice'>Analyzing Results for [C]:</span>")

--- a/code/game/objects/items/devices/modkit.dm
+++ b/code/game/objects/items/devices/modkit.dm
@@ -246,4 +246,8 @@
 	C.slowdown+=0.4
 	C.armor["rad"]+=25
 	C.armor_absorb["rad"]+=4.0
+	if(istype(C,/obj/item/clothing/suit/space/rig))
+		var/obj/item/clothing/suit/space/rig/R=C
+		if(R.H && R.H.rig==R && !R.H.canremove) //if the suit has a helmet built in, we should apply it to that, too
+			R.H.armor["rad"]+=25
 	

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -177,6 +177,7 @@
 		/obj/item/clothing/suit/radiation = 2,
 		/obj/item/clothing/head/radiation = 2,
 		/obj/item/device/geiger_counter,
+		/obj/item/clothing/accessory/rad_patch = 2,
 	)
 
 /*

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -387,15 +387,22 @@
 	new /obj/item/clothing/suit/radiation(src)
 	new /obj/item/clothing/head/radiation(src)
 	new /obj/item/device/geiger_counter(src)
+	new /obj/item/clothing/accessory/rad_patch(src)
+	
 	new /obj/item/clothing/suit/radiation(src)
 	new /obj/item/clothing/head/radiation(src)
 	new /obj/item/device/geiger_counter(src)
+	new /obj/item/clothing/accessory/rad_patch(src)
+	
 	new /obj/item/clothing/suit/radiation(src)
 	new /obj/item/clothing/head/radiation(src)
 	new /obj/item/device/geiger_counter(src)
+	new /obj/item/clothing/accessory/rad_patch(src)
+	
 	new /obj/item/clothing/suit/radiation(src)
 	new /obj/item/clothing/head/radiation(src)
 	new /obj/item/device/geiger_counter(src)
+	new /obj/item/clothing/accessory/rad_patch(src)
 
 /obj/structure/closet/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(air_group || (height==0 || wall_mounted))

--- a/code/modules/clothing/accessories/accessory.dm
+++ b/code/modules/clothing/accessories/accessory.dm
@@ -125,6 +125,9 @@
 	if(accessories.len)
 		return " It has [counted_english_list(accessories)]."
 
+/obj/item/clothing/accessory/proc/examine_attached(var/mob/user,var/obj/item/clothing/worn)
+	to_chat(user, "<span class='info'>\A [src] is clipped to it.</span>")
+
 /obj/item/clothing/accessory/pinksquare
 	name = "pink square"
 	desc = "It's a pink square."
@@ -517,33 +520,38 @@
 	..()
 
 /obj/item/clothing/accessory/rad_patch
-	name = "radiation detection patch"
-	desc = "A paper patch that you can attach to your clothing. Changes color to black when it absorbs over a certain amount of radiation."
-	icon_state = "patch_0"
+	name = "\improper dosimeter"
+	desc = "A small device that you can attach to your clothing. Records cumulative received radiation."
+	icon_state = "patch_1"
 	var/rad_absorbed = 0
-	var/rad_threshold = 45
-	var/triggered = FALSE
+	var/rad_warn_increment = 10
+	var/rad_last_warn=0
 	var/event_key
 
 	w_class = W_CLASS_TINY
-	w_type = RECYK_WOOD
-	flammable = TRUE
+	w_type = RECYK_METAL
+
+/obj/item/clothing/accessory/rad_patch/attack_self(var/mob/user)
+	to_chat(user, "<span class = 'notice'>You reset \the [src]'s dose counter.</span>")
+	rad_absorbed=0
+	rad_last_warn=0
+
+/obj/item/clothing/accessory/rad_patch/examine_attached(var/mob/user,var/obj/item/clothing/worn)
+	to_chat(user, "<span class='info'>\A [src] is clipped to it. </span> <span class='warning'> It reports [rad_absorbed] rads.</span>")
 
 /obj/item/clothing/accessory/rad_patch/proc/check_rads(mob/living/carbon/human/user, rads)
-	if(triggered)
-		return
-	rad_absorbed += rads
-
-	if(rad_absorbed > rad_threshold)
-		triggered = TRUE
-		update_icon()
-		to_chat(user, "<span class = 'warning'>You hear \the [src] tick!</span>")
-
-		user.unregister_event(/event/irradiate, src, nameof(src::check_rads()))
+	
+	rads-=user.getarmorabsorb(null,"rad")
+	rads*=(100-user.getarmor(null, "rad"))/100
+	rad_absorbed += max(rads,0)
+	
+	if (rad_absorbed>rad_last_warn+rad_warn_increment)
+		to_chat(user, "<span class = 'warning'>\the [src] beeps \"cumulative dose: [floor(rad_absorbed/rad_warn_increment)*rad_warn_increment] rads\"</span>")
+		rad_last_warn=floor(rad_absorbed/rad_warn_increment)*rad_warn_increment
 
 /obj/item/clothing/accessory/rad_patch/on_attached(obj/item/clothing/C)
 	..()
-	if(ismob(C.loc) && !triggered)
+	if(ismob(C.loc))
 		var/mob/user = C.loc
 		user.register_event(/event/irradiate, src, nameof(src::check_rads()))
 
@@ -553,14 +561,10 @@
 
 /obj/item/clothing/accessory/rad_patch/examine(mob/user)
 	..(user)
-	if(triggered)
-		to_chat(user, "<span class = 'warning'>It is a deep dark color!</span>")
+	to_chat(user, "<span class = 'warning'>It reports a cumulative dose of [rad_absorbed] rads.</span>")
 
 /obj/item/clothing/accessory/rad_patch/update_icon()
-	if(triggered)
-		icon_state = "patch_1"
-	else
-		icon_state = "patch_0"
+	icon_state = "patch_1"
 	..()
 
 /obj/item/clothing/accessory/rabbit_foot

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -187,7 +187,7 @@
 /obj/item/clothing/examine(mob/user)
 	..()
 	for(var/obj/item/clothing/accessory/A in accessories)
-		to_chat(user, "<span class='info'>\A [A] is clipped to it.</span>")
+		A.examine_attached(user,src)
 
 /obj/item/clothing/emp_act(severity)
 	for(var/obj/item/clothing/accessory/accessory in accessories)

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -450,6 +450,7 @@
 	icon_state = "vox-civ-engineer"
 	item_state = "vox-pressure-engineer"
 	armor = list(melee = 5, bullet = 5, laser = 5, energy = 5, bomb = 0, bio = 100, rad = 50)
+	armor_absorb = list(melee = 0,bullet = 0,laser = 0,energy = 0,bomb = 0, bio = 0, rad = 8)
 	allowed = list(/obj/item/device/flashlight, /obj/item/weapon/tank, /obj/item/device/t_scanner, /obj/item/device/rcd, /obj/item/tool/wrench/socket)
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	pressure_resistance = 200 * ONE_ATMOSPHERE
@@ -460,6 +461,7 @@
 	item_state = "vox-pressure-engineer"
 	desc = "A very alien-looking helmet for vox crewmembers. This one comes with more radiation protection."
 	armor = list(melee = 5, bullet = 5, laser = 5, energy = 5, bomb = 0, bio = 100, rad = 50)
+	armor_absorb = list(melee = 0,bullet = 0,laser = 0,energy = 0,bomb = 0, bio = 0, rad = 2)
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	pressure_resistance = 200 * ONE_ATMOSPHERE
 	eyeprot = 3

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -487,6 +487,7 @@
 	desc = "A cheap and oddly-shaped pressure suit made for vox crewmembers. Has some heat protection."
 	icon_state = "vox-civ-atmos"
 	armor = list(melee = 5, bullet = 5, laser = 5, energy = 5, bomb = 0, bio = 100, rad = 10)
+	armor_absorb = list(melee = 0,bullet = 0,laser = 0,energy = 0,bomb = 0, bio = 0, rad = 0)
 	clothing_flags = PLASMAGUARD
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	pressure_resistance = 400 * ONE_ATMOSPHERE
@@ -496,6 +497,7 @@
 	icon_state = "vox-civ0_atmos"
 	desc = "A very alien-looking helmet for vox crewmembers. Has some heat protection."
 	armor = list(melee = 5, bullet = 5, laser = 5, energy = 5, bomb = 0, bio = 100, rad = 10)
+	armor_absorb = list(melee = 0,bullet = 0,laser = 0,energy = 0,bomb = 0, bio = 0, rad = 0)
 	clothing_flags = PLASMAGUARD
 	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
 	pressure_resistance = 400 * ONE_ATMOSPHERE

--- a/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
+++ b/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
@@ -226,7 +226,7 @@
 	var/event_key
 	var/initial_suit = 0
 	var/initial_helmet = 0
-	var/max_capacity = 500 //Just barely over 2 "item touch" worth of rads when standing right next to the shard with a suit with only 10 rad resist. About 5-6 items at 50. Based on in-game tests on Aug. 2020.
+	var/max_capacity = 250 //Just barely over 2 "item touch" worth of rads when standing right next to the shard with a suit with only 10 rad resist. About 5-6 items at 50. Based on in-game tests on Aug. 2020.
 	var/current_capacity = 0
 	//Warning thresholds, will announce to the user when these thresholds have been surpassed. The compiler shits itself if I put numbers in the variable names and calculations in the variable values, so it's done this way instead.
 	var/first_threshold //50% capacity
@@ -286,10 +286,13 @@
 	if(rig?.wearer != user) //Well lad.
 		user.unregister_event(/event/irradiate, src, nameof(src::absorb_rads()))
 		return
-
+	
+	rads =  max(0,rads-rig.armor_absorb["rad"])
 	if(rig.H)
-		current_capacity += min(max_capacity, (rads * ((100 - initial_helmet) / 100)))
-	current_capacity += min(max_capacity, (rads * ((100 - initial_suit) / 100)))
+		rads = max(0,rads-rig.H.armor_absorb["rad"])
+		current_capacity += rads * ((100 - (initial_suit*0.5+initial_helmet*0.5) ) / 100)
+	else
+		current_capacity += rads * ((100 - initial_suit) / 100)
 
 	if(current_capacity >= third_threshold && threshold_announced < third_threshold)
 		say_to_wearer("\The [src] is at 90% capacity. Take precaution.")
@@ -317,7 +320,7 @@
 /obj/item/rig_module/rad_shield/adv
 	name = "high capacity radiation absorption device"
 	desc = "Its acronym, R.A.D., and full name both convey the application of this module. By using similar technology as radiation collectors, it protects the suit wearer from incoming radiation until its collectors are full. This model features a higher capacity than the basic version. It can be reset by using a suit storage unit's cleaning operation."
-	max_capacity = 1600 //About 7-8 "item touches" worth based on the same conditions as the above testing.
+	max_capacity = 800 //About 7-8 "item touches" worth based on the same conditions as the above testing.
 
 /obj/item/rig_module/rad_shield/adv/can_install(var/obj/item/clothing/suit/space/rig/target)
    var/parent_check=..()

--- a/code/modules/clothing/spacesuits/rig_subtypes/rig_subtypes.dm
+++ b/code/modules/clothing/spacesuits/rig_subtypes/rig_subtypes.dm
@@ -5,6 +5,7 @@
 	icon_state = "rig0-engineering"
 	item_state = "eng_helm"
 	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 50)
+	armor_absorb = list(melee = 0,bullet = 0,laser = 0,energy = 0,bomb = 0, bio = 0, rad = 1)
 	_color = "engineering"
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	pressure_resistance = 200 * ONE_ATMOSPHERE
@@ -18,6 +19,7 @@
 	icon_state = "rig-engineering"
 	item_state = "eng_hardsuit"
 	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 50)
+	armor_absorb = list(melee = 0,bullet = 0,laser = 0,energy = 0,bomb = 0, bio = 0, rad = 4)
 	allowed = list(/obj/item/device/flashlight, /obj/item/weapon/tank, /obj/item/weapon/storage/bag/ore, /obj/item/device/t_scanner, /obj/item/weapon/pickaxe, /obj/item/device/rcd, /obj/item/tool/wrench/socket)
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	pressure_resistance = 200 * ONE_ATMOSPHERE

--- a/code/modules/clothing/spacesuits/rig_subtypes/rig_subtypes.dm
+++ b/code/modules/clothing/spacesuits/rig_subtypes/rig_subtypes.dm
@@ -5,7 +5,6 @@
 	icon_state = "rig0-engineering"
 	item_state = "eng_helm"
 	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 50)
-	armor_absorb = list(melee = 0,bullet = 0,laser = 0,energy = 0,bomb = 0, bio = 0, rad = 1)
 	_color = "engineering"
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	pressure_resistance = 200 * ONE_ATMOSPHERE
@@ -19,7 +18,6 @@
 	icon_state = "rig-engineering"
 	item_state = "eng_hardsuit"
 	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 50)
-	armor_absorb = list(melee = 0,bullet = 0,laser = 0,energy = 0,bomb = 0, bio = 0, rad = 4)
 	allowed = list(/obj/item/device/flashlight, /obj/item/weapon/tank, /obj/item/weapon/storage/bag/ore, /obj/item/device/t_scanner, /obj/item/weapon/pickaxe, /obj/item/device/rcd, /obj/item/tool/wrench/socket)
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	pressure_resistance = 200 * ONE_ATMOSPHERE

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -86,6 +86,7 @@
 			altered = effect
 			halloss += altered // Useful for objects that cause "subdual" damage. PAIN!
 		if(IRRADIATE)
+			altered = max(0,altered-getarmorabsorb(null,"rad"))
 			altered = max(0, (effect/100)*(100-getarmor(null, "rad"))) //Get overall radiation protection, rather than point-exposure
 			radiation += altered
 		if(STUTTER)


### PR DESCRIPTION
[balance] [powercreep] [oldcoders] [bugfix] [tweak]

## What this does
makes it so that armor_absorb is factored into radiation damage, as it was previously unused (and as a whole, that variable is inconsistently applied). this is done by first subtracting that value from the received radiation, then applying armor as usual afterwards.
also applies this now functioning armor to the vox engineering pressure suits, to account for the lack of radiation absorbers (since vox suits cannot take any modules).

fixes a bug in the radiation absorption device module that makes it take radiation twice, and halved the capacity to compensate.

changes the radiation patch into a dosimeter, which now shows a received cumulative radiation dose, accounting for armor. operates similarly as before. you can use it in hand to clear the value.
<img width="443" height="144" alt="Capture2" src="https://github.com/user-attachments/assets/476dcf1b-25de-4dac-b79e-7d92a6c9598b" />


## Why it's good
radiation damage is often a "all or nothing" kind of thing, where because armor is multiplicative only, not having 100% resistance isn't terribly useful. This change opens up more nuanced armor balancing, and allows radiation shielding to be useful without full immunity, as subtractive armor will filter out low levels but still leave the user prone to high bursts.

fixing the bug is probably good, even if it didn't really ever come to play.

having a dosimeter is cool fluff for muh immulsions.

## How it was tested
went in game and messed around with radiation a bit, such as calling a radstorm or using the apply_radiation proc, suited up and not. verified the values were what they should roughly be.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed radiation absorption modules double counting radiation when a helmet is equiped
 * tweak: changed radiation armor to be able to use a subtractive factor that was previously unused, currently only applied to vox engineering pressure suits
 * tweak: the radiation patch has been reworked into a dosimeter, and can now be found in radiation lockers and crates
