### PR TITLE
Fixes candle boxes describing donuts

### DIFF
--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -137,6 +137,7 @@
 	icon = 'icons/obj/candle.dmi'
 	icon_state = "candlebox"
 	item_state = "candlebox"
+	icon_type = "candle"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/candles.dmi', "right_hand" = 'icons/mob/in-hand/right/candles.dmi')
 	foldable = /obj/item/stack/sheet/cardboard
 	starting_materials = list(MAT_CARDBOARD = 3750)


### PR DESCRIPTION
[grammar]

## What this does
Closes #39504.

## How it was tested
Spawning one, examining it, taking out all the candles and examining it again, with one left and none.

## Changelog
:cl:
 * spellcheck: Candle boxes now properly describe having candles inside instead of donuts.